### PR TITLE
Add queue and db cli flags

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,6 +68,21 @@ func main() {
 				return err
 			}
 
+			// override config with cli flags
+			redisCliDsn, err := cmd.Flags().GetString("queue")
+			if err != nil {
+				return err
+			}
+			cfg.Queue.Redis.DSN = redisCliDsn
+
+			mongoCliDsn, err := cmd.Flags().GetString("db")
+			if err != nil {
+				return err
+			}
+			cfg.Database.Dsn = mongoCliDsn
+
+			// init connections
+
 			db, err = datastore.New(cfg)
 			if err != nil {
 				return err
@@ -147,8 +162,12 @@ func main() {
 	}
 
 	var configFile string
+	var redisDsn string
+	var mongoDsn string
 
 	cmd.PersistentFlags().StringVar(&configFile, "config", "./convoy.json", "Configuration file for convoy")
+	cmd.PersistentFlags().StringVar(&redisDsn, "queue", "redis://localhost:6379", "Redis DSN")
+	cmd.PersistentFlags().StringVar(&mongoDsn, "db", "mongodb://localhost:27017", "MongoDB DSN")
 
 	cmd.AddCommand(addVersionCommand())
 	cmd.AddCommand(addCreateCommand(app))

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,7 +58,22 @@ func main() {
 				return err
 			}
 
-			err = config.LoadConfig(cfgPath)
+			override := new(config.Configuration)
+
+			// override config with cli flags
+			redisCliDsn, err := cmd.Flags().GetString("queue")
+			if err != nil {
+				return err
+			}
+			override.Queue.Redis.DSN = redisCliDsn
+
+			mongoCliDsn, err := cmd.Flags().GetString("db")
+			if err != nil {
+				return err
+			}
+			override.Database.Dsn = mongoCliDsn
+
+			err = config.LoadConfig(cfgPath, override)
 			if err != nil {
 				return err
 			}
@@ -67,21 +82,6 @@ func main() {
 			if err != nil {
 				return err
 			}
-
-			// override config with cli flags
-			redisCliDsn, err := cmd.Flags().GetString("queue")
-			if err != nil {
-				return err
-			}
-			cfg.Queue.Redis.DSN = redisCliDsn
-
-			mongoCliDsn, err := cmd.Flags().GetString("db")
-			if err != nil {
-				return err
-			}
-			cfg.Database.Dsn = mongoCliDsn
-
-			// init connections
 
 			db, err = datastore.New(cfg)
 			if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -140,7 +140,7 @@ func Get() (Configuration, error) {
 
 // LoadConfig is used to load the configuration from either the json config file
 // or the environment variables.
-func LoadConfig(p string) error {
+func LoadConfig(p string, override *Configuration) error {
 	f, err := os.Open(p)
 	if err != nil {
 		return err
@@ -196,6 +196,14 @@ func LoadConfig(p string) error {
 	err = ensureAuthConfig(c.Auth)
 	if err != nil {
 		return err
+	}
+
+	if len(override.Queue.Redis.DSN) > 0 {
+		c.Queue.Redis.DSN = override.Database.Dsn
+	}
+
+	if len(override.Database.Dsn) > 0 {
+		c.Database.Dsn = override.Database.Dsn
 	}
 
 	cfgSingleton.Store(c)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -41,7 +41,7 @@ func Test_EnvironmentTakesPrecedence(t *testing.T) {
 
 			// Assert.
 			configFile := "./testdata/Test_ConfigurationFromEnvironment/convoy.json"
-			err := LoadConfig(configFile)
+			err := LoadConfig(configFile, new(Configuration))
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}
@@ -301,7 +301,7 @@ func TestLoadConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := LoadConfig(tt.args.path)
+			err := LoadConfig(tt.args.path, new(Configuration))
 			if tt.wantErr {
 				require.NotNil(t, err)
 				require.Equal(t, tt.wantErrMsg, err.Error())

--- a/server/application_test.go
+++ b/server/application_test.go
@@ -100,6 +100,10 @@ func stripTimestamp(t *testing.T, obj string, b *bytes.Buffer) *bytes.Buffer {
 	return nil
 }
 
+func provideFakeOverride() *config.Configuration {
+	return new(config.Configuration)
+}
+
 func TestApplicationHandler_GetApp(t *testing.T) {
 
 	var app *applicationHandler
@@ -189,7 +193,7 @@ func TestApplicationHandler_GetApp(t *testing.T) {
 				tc.dbFn(app)
 			}
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, new(config.Configuration))
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}
@@ -283,7 +287,7 @@ func TestApplicationHandler_GetApps(t *testing.T) {
 				tc.dbFn(app)
 			}
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, new(config.Configuration))
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}
@@ -395,7 +399,7 @@ func TestApplicationHandler_CreateApp(t *testing.T) {
 				tc.dbFn(app)
 			}
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, new(config.Configuration))
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}
@@ -614,7 +618,7 @@ func TestApplicationHandler_UpdateApp(t *testing.T) {
 				tc.dbFn(app)
 			}
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, new(config.Configuration))
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}
@@ -710,7 +714,7 @@ func TestApplicationHandler_CreateAppEndpoint(t *testing.T) {
 				tc.dbFn(app)
 			}
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, new(config.Configuration))
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}
@@ -855,7 +859,7 @@ func TestApplicationHandler_UpdateAppEndpoint(t *testing.T) {
 				tc.dbFn(app)
 			}
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, provideFakeOverride())
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}

--- a/server/dashboard_test.go
+++ b/server/dashboard_test.go
@@ -49,7 +49,7 @@ func Test_fetchAllConfigDetails(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := config.LoadConfig("./testdata/Auth_Config/none-convoy.json")
+			err := config.LoadConfig("./testdata/Auth_Config/none-convoy.json", provideFakeOverride())
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}

--- a/server/event_test.go
+++ b/server/event_test.go
@@ -343,7 +343,7 @@ func TestApplicationHandler_CreateAppEvent(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, provideFakeOverride())
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}
@@ -662,7 +662,7 @@ func Test_resendEventDelivery(t *testing.T) {
 				tc.dbFn(tc.args.event, tc.args.message, app)
 			}
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, provideFakeOverride())
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}
@@ -871,7 +871,7 @@ func TestApplicationHandler_BatchRetryEventDelivery(t *testing.T) {
 				tc.dbFn(tc.args.event, tc.args.message, app)
 			}
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, provideFakeOverride())
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}

--- a/server/group_test.go
+++ b/server/group_test.go
@@ -96,7 +96,7 @@ func TestApplicationHandler_GetGroup(t *testing.T) {
 				tc.dbFn(app)
 			}
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, provideFakeOverride())
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}
@@ -172,7 +172,7 @@ func TestApplicationHandler_CreateGroup(t *testing.T) {
 				tc.dbFn(app)
 			}
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, provideFakeOverride())
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}
@@ -263,7 +263,7 @@ func TestApplicationHandler_UpdateGroup(t *testing.T) {
 				tc.dbFn(app)
 			}
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, provideFakeOverride())
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}
@@ -341,7 +341,7 @@ func TestApplicationHandler_GetGroups(t *testing.T) {
 				tc.dbFn(app)
 			}
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, provideFakeOverride())
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}

--- a/server/middleware_test.go
+++ b/server/middleware_test.go
@@ -53,7 +53,7 @@ func TestRequirePermission_Basic(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, provideFakeOverride())
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}
@@ -121,7 +121,7 @@ func TestRequirePermission_Noop(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, provideFakeOverride())
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}

--- a/worker/task/process_event_delivery_test.go
+++ b/worker/task/process_event_delivery_test.go
@@ -611,7 +611,7 @@ func TestProcessEventDelivery(t *testing.T) {
 			appRepo := mocks.NewMockApplicationRepository(ctrl)
 			msgRepo := mocks.NewMockEventDeliveryRepository(ctrl)
 
-			err := config.LoadConfig(tc.cfgPath)
+			err := config.LoadConfig(tc.cfgPath, new(config.Configuration))
 			if err != nil {
 				t.Errorf("Failed to load config file: %v", err)
 			}


### PR DESCRIPTION
Resolves #282 
This PR adds extra flags to the convoy cli which will override the redis and mongodb DSNs originally set in the config file.

There's a small issue with the way config is being loaded, the `LoadConfig()` function in the config package takes in only s string hence overriding the config values can only be done in after the config is already loaded. My initial thought was to override it on the fly but I don't think that will work. The issue now is that after overriding the config values calling `config.Get()` in a different package will fetch the old values loaded into the atomic store from the convoy.json file and not the overridden value.