### PR TITLE
fix: add request validation for creating groups

### DIFF
--- a/server/group_test.go
+++ b/server/group_test.go
@@ -120,7 +120,22 @@ func TestApplicationHandler_CreateGroup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	bodyReader := strings.NewReader(`{"name": "ABC_DEF_TEST_UPDATE"}`)
+	bodyReader := strings.NewReader(`{
+		"name": "ABC_DEF_TEST_UPDATE",
+		"config": {
+		  "strategy": {
+			"type": "default",
+			"default": {
+			  "intervalSeconds": 10,
+			  "retryLimit": 3
+			}
+		  },
+		  "signature": {
+			"header": "X-Company-Signature",
+			"hash": "SHA1"
+		  }
+		}
+	  }`)
 
 	tt := []struct {
 		name       string


### PR DESCRIPTION
This adds additional request validation to the endpoint for creating a group. Addresses #290 