### PR TITLE
Feat: use contains instead of get / error handling

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -166,12 +166,8 @@ func main() {
 			app.logger = lo
 			app.tracer = tr
 
-			err = ensureDefaultGroup(context.Background(), cfg, app)
-			if err != nil {
-				return err
-			}
+			return ensureDefaultGroup(context.Background(), cfg, app)
 
-			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 			defer func() {

--- a/queue/redis/client.go
+++ b/queue/redis/client.go
@@ -80,12 +80,7 @@ func (q *RedisQueue) Write(ctx context.Context, name convoy.TaskName, e *datasto
 		Delay:    delay,
 	}
 
-	err := q.queue.Add(m)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return q.queue.Add(m)
 }
 
 func (q *RedisQueue) Consumer() taskq.QueueConsumer {

--- a/queue/storage.go
+++ b/queue/storage.go
@@ -13,15 +13,18 @@ type Storage interface {
 
 var _ Storage = (*localStorage)(nil)
 
+const defaultStorageSize = 128000
+
 // LOCAL
 
 type localStorage struct {
 	mu    sync.Mutex
 	cache *simplelru.LRU
+	size  int
 }
 
 func NewLocalStorage() Storage {
-	return &localStorage{}
+	return &localStorage{size: defaultStorageSize}
 }
 
 func (s *localStorage) Exists(_ context.Context, key string) bool {
@@ -30,14 +33,13 @@ func (s *localStorage) Exists(_ context.Context, key string) bool {
 
 	if s.cache == nil {
 		var err error
-		s.cache, err = simplelru.NewLRU(128000, nil)
+		s.cache, err = simplelru.NewLRU(s.size, nil)
 		if err != nil {
 			panic(err)
 		}
 	}
 
-	_, ok := s.cache.Get(key)
-	if ok {
+	if ok := s.cache.Contains(key); ok {
 		return true
 	}
 

--- a/queue/storage.go
+++ b/queue/storage.go
@@ -39,10 +39,5 @@ func (s *localStorage) Exists(_ context.Context, key string) bool {
 		}
 	}
 
-	if ok := s.cache.Contains(key); ok {
-		return true
-	}
-
-	s.cache.Add(key, nil)
-	return false
+	return s.cache.Contains(key)
 }


### PR DESCRIPTION
This PR addresses two things:
1. In `localStorage` we use `Get` and then check if the key exists in the LRU cache. We can use `Contains` to just peek if the key exists. 
2. return errors/nil if there is no error, no need for extra checks. 
