### PR TITLE
feat: add health check endpoints

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -92,5 +92,7 @@ func StartConvoyServer(a *app, cfg config.Configuration, withWorkers bool) error
 		log.Infof("Started server with SSL: cert_file: %s, key_file: %s", httpConfig.SSLCertFile, httpConfig.SSLKeyFile)
 		return srv.ListenAndServeTLS(httpConfig.SSLCertFile, httpConfig.SSLKeyFile)
 	}
+
+	log.Infof("Server running on port %v", cfg.Server.HTTP.Port)
 	return srv.ListenAndServe()
 }

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -45,8 +45,10 @@ func addWorkerCommand(a *app) *cobra.Command {
 
 			srv := &http.Server{
 				Handler: router,
-				Addr:    fmt.Sprintf(":%d", cfg.Server.HTTP.Port),
+				Addr:    fmt.Sprintf(":%d", cfg.Server.HTTP.WorkerPort),
 			}
+
+			log.Infof("Worker running on port %v", cfg.Server.HTTP.WorkerPort)
 
 			e := srv.ListenAndServe()
 			if e != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,7 @@ type HTTPServerConfiguration struct {
 	SSLCertFile string `json:"ssl_cert_file" envconfig:"CONVOY_SSL_CERT_FILE"`
 	SSLKeyFile  string `json:"ssl_key_file" envconfig:"CONVOY_SSL_KEY_FILE"`
 	Port        uint32 `json:"port" envconfig:"PORT"`
+	WorkerPort  uint32 `json:"worker_port" envconfig:"WORKER_PORT"`
 }
 
 type QueueConfiguration struct {

--- a/server/route.go
+++ b/server/route.go
@@ -19,6 +19,7 @@ import (
 	"github.com/frain-dev/convoy/queue"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/httprate"
+	"github.com/go-chi/render"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
@@ -243,6 +244,9 @@ func buildRoutes(app *applicationHandler) http.Handler {
 	})
 
 	router.Handle("/v1/metrics", promhttp.Handler())
+	router.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		_ = render.Render(w, r, newServerResponse("Convoy", nil, http.StatusOK))
+	})
 	router.HandleFunc("/*", reactRootHandler)
 
 	return router

--- a/web/ui/website/content/docs/configuration.md
+++ b/web/ui/website/content/docs/configuration.md
@@ -135,6 +135,7 @@ Alternatively, you can configure Convoy using the following environment variable
 -   `CONVOY_DB_DSN`
 -   `CONVOY_REDIS_DSN`
 -   `PORT`
+-   `WORKER_PORT`
 -   `CONVOY_ENV`
 -   `CONVOY_SENTRY_DSN`
 -   `CONVOY_SIGNATURE_HEADER`


### PR DESCRIPTION
This PR exposes a dedicated health check resource (`/health`) for both the server and worker processes.

Possible issues that might arise could be that the same port is used for both server and worker when running on the same machine or inside the same container. To mitigate this we might need to add another config field to set the worker port, or offset the server port if it's not set.