### PR TITLE
allow version command to run without config file

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,8 +55,9 @@ func main() {
 	var db datastore.DatabaseClient
 
 	cmd := &cobra.Command{
-		Use:   "Convoy",
-		Short: "Fast & reliable webhooks service",
+		Use:     "Convoy",
+		Version: convoy.GetVersion(),
+		Short:   "Fast & reliable webhooks service",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			cfgPath, err := cmd.Flags().GetString("config")
 			if err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,29 +1,20 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
-	"github.com/frain-dev/convoy"
 	"github.com/spf13/cobra"
 )
 
 func addVersionCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "version",
-		Short: "Print the version",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			v := "0.1.0"
-
-			f, err := convoy.ReadVersion()
-			if err != nil {
-				fmt.Println(v)
-				return nil
-			}
-			v = strings.TrimSuffix(string(f), "\n")
-			fmt.Println(v)
-			return nil
+		Use:              "version",
+		Short:            "Print the version",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {},
+		Run: func(cmd *cobra.Command, args []string) {
+			root := cmd.Root()
+			root.SetArgs([]string{"--version"})
+			root.Execute()
 		},
+		PersistentPostRun: func(cmd *cobra.Command, args []string) {},
 	}
 
 	return cmd

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,10 +9,15 @@ func addVersionCommand() *cobra.Command {
 		Use:              "version",
 		Short:            "Print the version",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {},
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			root := cmd.Root()
 			root.SetArgs([]string{"--version"})
-			root.Execute()
+			err := root.Execute()
+			if err != nil {
+				return err
+			}
+
+			return nil
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {},
 	}

--- a/type.go
+++ b/type.go
@@ -32,6 +32,18 @@ func ReadVersion() ([]byte, error) {
 	return data, nil
 }
 
+func GetVersion() string {
+	v := "0.1.0"
+
+	f, err := ReadVersion()
+	if err != nil {
+		return v
+	}
+
+	v = strings.TrimSuffix(string(f), "\n")
+	return v
+}
+
 const (
 	EventProcessor      TaskName = "EventProcessor"
 	DeadLetterProcessor TaskName = "DeadLetterProcessor"


### PR DESCRIPTION
This allows the version command to run without the `convoy.json` file by introducing a `PersistentPreRun` and `PersistentPostRun` hook on the command itself. 

This also adds a Version field on the root command. So you can run `convoy --version`, which is the same command being run in the version command. 

Resolves #457 