### PR TITLE
remove app portal app id requirement

### DIFF
--- a/server/application.go
+++ b/server/application.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -254,21 +253,7 @@ func (a *applicationHandler) CreateAppEndpoint(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	appID := chi.URLParam(r, "appID")
-	app, err := a.appRepo.FindApplicationByID(r.Context(), appID)
-	if err != nil {
-
-		msg := "an error occurred while retrieving app details"
-		statusCode := http.StatusBadRequest
-
-		if errors.Is(err, datastore.ErrApplicationNotFound) {
-			msg = err.Error()
-			statusCode = http.StatusNotFound
-		}
-
-		_ = render.Render(w, r, newErrorResponse(msg, statusCode))
-		return
-	}
+	app := getApplicationFromContext(r.Context())
 
 	// Events being nil means it wasn't passed at all, which automatically
 	// translates into a accept all scenario. This is quite different from

--- a/server/application_test.go
+++ b/server/application_test.go
@@ -741,7 +741,7 @@ func TestApplicationHandler_CreateAppEndpoint(t *testing.T) {
 					Return(nil)
 
 				a.EXPECT().
-					FindApplicationByID(gomock.Any(), gomock.Any()).Times(2).
+					FindApplicationByID(gomock.Any(), gomock.Any()).Times(1).
 					Return(&datastore.Application{
 						UID:       appId,
 						GroupID:   groupID,

--- a/server/middleware.go
+++ b/server/middleware.go
@@ -149,7 +149,7 @@ func requireApp(appRepo datastore.ApplicationRepository) func(next http.Handler)
 	}
 }
 
-func requireAppId() func(next http.Handler) http.Handler {
+func requireAppID() func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/route.go
+++ b/server/route.go
@@ -285,24 +285,23 @@ func buildRoutes(app *applicationHandler) http.Handler {
 		portalRouter.Use(setupCORS)
 		portalRouter.Use(requireAuth())
 		portalRouter.Use(requireGroup(app.groupRepo))
-		portalRouter.Use(requireAppId())
+		portalRouter.Use(requireAppID())
 
 		portalRouter.Route("/apps", func(appRouter chi.Router) {
-			appRouter.Route("/{appID}", func(appSubRouter chi.Router) {
-				appSubRouter.Use(requireAppPortalApplication(app.appRepo))
-				appSubRouter.Use(requireAppPortalPermission(auth.RoleUIAdmin))
-				appSubRouter.Get("/", app.GetApp)
+			appRouter.Use(requireAppPortalApplication(app.appRepo))
+			appRouter.Use(requireAppPortalPermission(auth.RoleUIAdmin))
 
-				appSubRouter.Route("/endpoints", func(endpointAppSubRouter chi.Router) {
-					endpointAppSubRouter.Get("/", app.GetAppEndpoints)
-					endpointAppSubRouter.Post("/", app.CreateAppEndpoint)
+			appRouter.Get("/", app.GetApp)
 
-					endpointAppSubRouter.Route("/{endpointID}", func(e chi.Router) {
-						e.Use(requireAppEndpoint())
+			appRouter.Route("/endpoints", func(endpointAppSubRouter chi.Router) {
+				endpointAppSubRouter.Get("/", app.GetAppEndpoints)
+				endpointAppSubRouter.Post("/", app.CreateAppEndpoint)
 
-						e.Get("/", app.GetAppEndpoint)
-						e.Put("/", app.UpdateAppEndpoint)
-					})
+				endpointAppSubRouter.Route("/{endpointID}", func(e chi.Router) {
+					e.Use(requireAppEndpoint())
+
+					e.Get("/", app.GetAppEndpoint)
+					e.Put("/", app.UpdateAppEndpoint)
 				})
 			})
 		})

--- a/server/route.go
+++ b/server/route.go
@@ -285,12 +285,12 @@ func buildRoutes(app *applicationHandler) http.Handler {
 		portalRouter.Use(setupCORS)
 		portalRouter.Use(requireAuth())
 		portalRouter.Use(requireGroup(app.groupRepo))
+		portalRouter.Use(requireAppId())
 
 		portalRouter.Route("/apps", func(appRouter chi.Router) {
 			appRouter.Route("/{appID}", func(appSubRouter chi.Router) {
 				appSubRouter.Use(requireAppPortalApplication(app.appRepo))
 				appSubRouter.Use(requireAppPortalPermission(auth.RoleUIAdmin))
-
 				appSubRouter.Get("/", app.GetApp)
 
 				appSubRouter.Route("/endpoints", func(endpointAppSubRouter chi.Router) {


### PR DESCRIPTION
This removes the need for always passing the App ID as a query string to access the routes under app portal. 