### PR TITLE
removes group id requirement

### DIFF
--- a/server/route.go
+++ b/server/route.go
@@ -83,6 +83,7 @@ func buildRoutes(app *applicationHandler) http.Handler {
 			})
 
 			r.Route("/applications", func(appRouter chi.Router) {
+				appRouter.Use(requireGroupID())
 				appRouter.Use(requireGroup(app.groupRepo))
 				appRouter.Use(rateLimitByGroupID(app.limiter))
 				appRouter.Use(requirePermission(auth.RoleAdmin))
@@ -115,6 +116,7 @@ func buildRoutes(app *applicationHandler) http.Handler {
 			})
 
 			r.Route("/events", func(eventRouter chi.Router) {
+				eventRouter.Use(requireGroupID())
 				eventRouter.Use(requireGroup(app.groupRepo))
 				eventRouter.Use(rateLimitByGroupID(app.limiter))
 				eventRouter.Use(requirePermission(auth.RoleAdmin))
@@ -129,6 +131,7 @@ func buildRoutes(app *applicationHandler) http.Handler {
 			})
 
 			r.Route("/eventdeliveries", func(eventDeliveryRouter chi.Router) {
+				eventDeliveryRouter.Use(requireGroupID())
 				eventDeliveryRouter.Use(requireGroup(app.groupRepo))
 				eventDeliveryRouter.Use(requirePermission(auth.RoleAdmin))
 
@@ -165,6 +168,7 @@ func buildRoutes(app *applicationHandler) http.Handler {
 
 				securityRouter.Route("/applications/{appID}/keys", func(securitySubRouter chi.Router) {
 					securitySubRouter.Use(requirePermission(auth.RoleAdmin))
+					securitySubRouter.Use(requireGroupID())
 					securitySubRouter.Use(requireGroup(app.groupRepo))
 					securitySubRouter.Use(requireApp(app.appRepo))
 					securitySubRouter.Use(requireBaseUrl())
@@ -284,6 +288,7 @@ func buildRoutes(app *applicationHandler) http.Handler {
 		portalRouter.Use(jsonResponse)
 		portalRouter.Use(setupCORS)
 		portalRouter.Use(requireAuth())
+		portalRouter.Use(requireGroupID())
 		portalRouter.Use(requireGroup(app.groupRepo))
 		portalRouter.Use(requireAppID())
 


### PR DESCRIPTION
Removes the need for always passing the groupID as a query string while authenticating with an API Key. 