### PR TITLE
Fix: Add delay to task handler errors

### DIFF
--- a/services/event_service.go
+++ b/services/event_service.go
@@ -134,7 +134,7 @@ func (e *EventService) CreateAppEvent(ctx context.Context, newMessage *models.Ev
 		taskName := convoy.EventProcessor.SetPrefix(g.Name)
 
 		if eventDelivery.Status != datastore.DiscardedEventStatus {
-			err = e.eventQueue.Write(ctx, taskName, eventDelivery, 1*time.Second)
+			err = e.eventQueue.Write(context.Background(), taskName, eventDelivery, 1*time.Second)
 			if err != nil {
 				log.Errorf("Error occurred sending new event to the queue %s", err)
 			}
@@ -305,7 +305,7 @@ func (e *EventService) requeueEventDelivery(ctx context.Context, eventDelivery *
 	}
 
 	taskName := convoy.EventProcessor.SetPrefix(g.Name)
-	err = e.eventQueue.Write(ctx, taskName, eventDelivery, 1*time.Second)
+	err = e.eventQueue.Write(context.Background(), taskName, eventDelivery, 1*time.Second)
 	if err != nil {
 		return fmt.Errorf("error occurred re-enqueing old event - %s: %v", eventDelivery.UID, err)
 	}

--- a/services/event_service.go
+++ b/services/event_service.go
@@ -134,7 +134,7 @@ func (e *EventService) CreateAppEvent(ctx context.Context, newMessage *models.Ev
 		taskName := convoy.EventProcessor.SetPrefix(g.Name)
 
 		if eventDelivery.Status != datastore.DiscardedEventStatus {
-			err = e.eventQueue.Write(context.Background(), taskName, eventDelivery, 1*time.Second)
+			err = e.eventQueue.Write(ctx, taskName, eventDelivery, 1*time.Second)
 			if err != nil {
 				log.Errorf("Error occurred sending new event to the queue %s", err)
 			}
@@ -305,7 +305,7 @@ func (e *EventService) requeueEventDelivery(ctx context.Context, eventDelivery *
 	}
 
 	taskName := convoy.EventProcessor.SetPrefix(g.Name)
-	err = e.eventQueue.Write(context.Background(), taskName, eventDelivery, 1*time.Second)
+	err = e.eventQueue.Write(ctx, taskName, eventDelivery, 1*time.Second)
 	if err != nil {
 		return fmt.Errorf("error occurred re-enqueing old event - %s: %v", eventDelivery.UID, err)
 	}

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -86,6 +86,7 @@ func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDelivery
 
 		dbEndpoint, err := appRepo.FindApplicationEndpointByID(context.Background(), m.AppMetadata.UID, e.UID)
 		if err != nil {
+			log.WithError(err).Errorf("could not retrieve endpoint %s", e.UID)
 			delayDuration = retrystrategies.NewRetryStrategyFromMetadata(*m.Metadata).NextDuration(m.Metadata.NumTrials)
 			return &EndpointError{Err: err, delay: delayDuration}
 		}

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -23,6 +23,7 @@ import (
 )
 
 var ErrDeliveryAttemptFailed = errors.New("Error sending event")
+var defaultDelay = time.Duration(20)
 
 type EndpointError struct {
 	delay time.Duration
@@ -46,7 +47,7 @@ func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDelivery
 
 		if err != nil {
 			log.WithError(err).Errorf("Failed to load event - %s", Id)
-			return &EndpointError{Err: err}
+			return &EndpointError{Err: err, delay: defaultDelay}
 		}
 		var delayDuration time.Duration = retrystrategies.NewRetryStrategyFromMetadata(*m.Metadata).NextDuration(m.Metadata.NumTrials)
 

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -44,9 +44,12 @@ func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDelivery
 		// Load message from DB and switch state to prevent concurrent processing.
 		m, err := eventDeliveryRepo.FindEventDeliveryByID(context.Background(), Id)
 
+		var delayDuration time.Duration
+
 		if err != nil {
 			log.WithError(err).Errorf("Failed to load event - %s", Id)
-			return nil
+			delayDuration = retrystrategies.NewRetryStrategyFromMetadata(*m.Metadata).NextDuration(m.Metadata.NumTrials)
+			return &EndpointError{Err: err, delay: delayDuration}
 		}
 
 		switch m.Status {
@@ -58,7 +61,8 @@ func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDelivery
 		err = eventDeliveryRepo.UpdateStatusOfEventDelivery(context.Background(), *m, datastore.ProcessingEventStatus)
 		if err != nil {
 			log.WithError(err).Error("failed to update status of messages - ")
-			return nil
+			delayDuration = retrystrategies.NewRetryStrategyFromMetadata(*m.Metadata).NextDuration(m.Metadata.NumTrials)
+			return &EndpointError{Err: err, delay: delayDuration}
 		}
 
 		var attempt datastore.DeliveryAttempt
@@ -66,7 +70,8 @@ func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDelivery
 
 		cfg, err := config.Get()
 		if err != nil {
-			return &EndpointError{Err: err}
+			delayDuration = retrystrategies.NewRetryStrategyFromMetadata(*m.Metadata).NextDuration(m.Metadata.NumTrials)
+			return &EndpointError{Err: err, delay: delayDuration}
 		}
 
 		dispatch := net.NewDispatcher()
@@ -81,8 +86,8 @@ func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDelivery
 
 		dbEndpoint, err := appRepo.FindApplicationEndpointByID(context.Background(), m.AppMetadata.UID, e.UID)
 		if err != nil {
-			log.WithError(err).Errorf("could not retrieve endpoint %s", e.UID)
-			return &EndpointError{Err: err}
+			delayDuration = retrystrategies.NewRetryStrategyFromMetadata(*m.Metadata).NextDuration(m.Metadata.NumTrials)
+			return &EndpointError{Err: err, delay: delayDuration}
 		}
 
 		if dbEndpoint.Status == datastore.InactiveEndpointStatus {
@@ -95,7 +100,8 @@ func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDelivery
 		encoder.SetEscapeHTML(false)
 		if err := encoder.Encode(m.Metadata.Data); err != nil {
 			log.WithError(err).Error("Failed to encode data")
-			return &EndpointError{Err: err}
+			delayDuration = retrystrategies.NewRetryStrategyFromMetadata(*m.Metadata).NextDuration(m.Metadata.NumTrials)
+			return &EndpointError{Err: err, delay: delayDuration}
 		}
 
 		bStr := strings.TrimSuffix(buff.String(), "\n")
@@ -103,7 +109,8 @@ func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDelivery
 		g, err := groupRepo.FetchGroupByID(context.Background(), m.AppMetadata.GroupID)
 		if err != nil {
 			log.WithError(err).Error("could not find error")
-			return &EndpointError{Err: err}
+			delayDuration = retrystrategies.NewRetryStrategyFromMetadata(*m.Metadata).NextDuration(m.Metadata.NumTrials)
+			return &EndpointError{Err: err, delay: delayDuration}
 		}
 
 		timestamp := fmt.Sprint(time.Now().Unix())
@@ -115,7 +122,8 @@ func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDelivery
 		hmac, err := util.ComputeJSONHmac(g.Config.Signature.Hash, signedPayload.String(), secret, false)
 		if err != nil {
 			log.Errorf("error occurred while generating hmac - %+v\n", err)
-			return &EndpointError{Err: err}
+			delayDuration = retrystrategies.NewRetryStrategyFromMetadata(*m.Metadata).NextDuration(m.Metadata.NumTrials)
+			return &EndpointError{Err: err, delay: delayDuration}
 		}
 
 		attemptStatus := false
@@ -138,7 +146,7 @@ func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDelivery
 			"duration": duration,
 		})
 
-		var delayDuration time.Duration = retrystrategies.NewRetryStrategyFromMetadata(*m.Metadata).NextDuration(m.Metadata.NumTrials)
+		delayDuration = retrystrategies.NewRetryStrategyFromMetadata(*m.Metadata).NextDuration(m.Metadata.NumTrials)
 		if err == nil && statusCode >= 200 && statusCode <= 299 {
 			requestLogger.Infof("%s", m.UID)
 			log.Infof("%s sent", m.UID)

--- a/worker/task/process_event_delivery_test.go
+++ b/worker/task/process_event_delivery_test.go
@@ -35,6 +35,12 @@ func TestProcessEventDelivery(t *testing.T) {
 				m.EXPECT().
 					FindEventDeliveryByID(gomock.Any(), gomock.Any()).
 					Return(&datastore.EventDelivery{
+						Metadata: &datastore.Metadata{
+							Data:            []byte(`{"event": "invoice.completed"}`),
+							NumTrials:       0,
+							RetryLimit:      3,
+							IntervalSeconds: 20,
+						},
 						Status: datastore.SuccessEventStatus,
 					}, nil).Times(1)
 			},
@@ -50,6 +56,12 @@ func TestProcessEventDelivery(t *testing.T) {
 				m.EXPECT().
 					FindEventDeliveryByID(gomock.Any(), gomock.Any()).
 					Return(&datastore.EventDelivery{
+						Metadata: &datastore.Metadata{
+							Data:            []byte(`{"event": "invoice.completed"}`),
+							NumTrials:       0,
+							RetryLimit:      3,
+							IntervalSeconds: 20,
+						},
 						AppMetadata: &datastore.AppMetadata{},
 						EndpointMetadata: &datastore.EndpointMetadata{
 							Status: datastore.InactiveEndpointStatus,


### PR DESCRIPTION
- pass `context.background()` when writing to queue
- add delay to all task handler errors 