### PR TITLE
add support for signing checksums and docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ on:
       # Release binary for every tag.
       - v0.*
 
+permissions:
+  id-token: write
+
 jobs:
   build_ui:
     name: Build UI
@@ -53,6 +56,11 @@ jobs:
           name: dist-without-markdown
           path: server/ui/build
           fetch-depth: 0
+
+      - uses: sigstore/cosign-installer@main
+        name: Install cosign
+        with: 
+           cosign-release: 'v1.6.0'
 
       - uses: docker/login-action@v1
         name: Authenticate with Docker

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -59,3 +59,27 @@ dockers:
 
 checksum:
   name_template: "{{ .ProjectName}}_checksums.txt"
+
+signs:
+  - cmd: cosign
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+    artifacts: checksum
+    output: true
+
+docker_signs:
+  - cmd: cosign
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    artifacts: images
+    output: true
+    args: 
+      - sign
+      - "--force"
+      - "${artifact}"

--- a/.publisher.yml
+++ b/.publisher.yml
@@ -81,3 +81,27 @@ dockers:
 
 checksum:
   name_template: "{{ .ProjectName}}_checksums.txt"
+
+signs:
+  - cmd: cosign
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-certificate=${certificate}"
+      - "--output-signature=${signature}"
+      - "${artifact}"
+    artifacts: checksum
+    output: true
+
+docker_signs:
+  - cmd: cosign
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    artifacts: images
+    output: true
+    args: 
+      - sign
+      - "--force"
+      - "${artifact}"


### PR DESCRIPTION
Adds support for signing the checksum file and docker images generated during the release cycle. The signing is handled by [cosign](https://github.com/sigstore/cosign)

