### PR TITLE
Use queue configuration from convoy.json

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -337,7 +337,7 @@ func parsePersistentArgs(app *app, cmd *cobra.Command) {
 	var configFile string
 
 	cmd.PersistentFlags().StringVar(&configFile, "config", "./convoy.json", "Configuration file for convoy")
-	cmd.PersistentFlags().StringVar(&queue, "queue", "redis", "Queue provider (\"redis\" or \"in-memory\")")
+	cmd.PersistentFlags().StringVar(&queue, "queue", "", "Queue provider (\"redis\" or \"in-memory\")")
 	cmd.PersistentFlags().StringVar(&dbDsn, "db", "", "Database dsn or path to in-memory file")
 	cmd.PersistentFlags().StringVar(&redisDsn, "redis", "", "Redis dsn")
 

--- a/datastore/badger/badger_test.go
+++ b/datastore/badger/badger_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+// +build integration
 
 package badger
 


### PR DESCRIPTION
This PR removes the default value `"redis"` being set by the queue flag. This caused convoy to still expect a redis DSN even when we set `"in-memory"` in the config file 