### PR TITLE
Set span in ProcessEventDelivery

### DIFF
--- a/.github/workflows/immune-test.yml
+++ b/.github/workflows/immune-test.yml
@@ -74,6 +74,10 @@ jobs:
           CONVOY_REDIS_DSN: "redis://localhost:6379"
           CONVOY_QUEUE_PROVIDER: "redis"
           IMMUNE_EVENT_TARGET_URL: https://www.endpoint.url:9098
+          CONVOY_NEWRELIC_APP_NAME: "convoy"
+          CONVOY_NEWRELIC_LICENSE_KEY: "5db1332e7566e37ab0979b5bed086d77FFFFNRAL"
+          CONVOY_NEWRELIC_CONFIG_ENABLED: true
+          CONVOY_NEWRELIC_DISTRIBUTED_TRACER_ENABLED: true
           IMMUNE_SSL: true
         run: |
           ref=$(certgen -domains="www.endpoint.url,endpoint.url")

--- a/.github/workflows/immune-test.yml
+++ b/.github/workflows/immune-test.yml
@@ -74,10 +74,6 @@ jobs:
           CONVOY_REDIS_DSN: "redis://localhost:6379"
           CONVOY_QUEUE_PROVIDER: "redis"
           IMMUNE_EVENT_TARGET_URL: https://www.endpoint.url:9098
-          CONVOY_NEWRELIC_APP_NAME: "convoy"
-          CONVOY_NEWRELIC_LICENSE_KEY: "5db1332e7566e37ab0979b5bed086d77FFFFNRAL"
-          CONVOY_NEWRELIC_CONFIG_ENABLED: true
-          CONVOY_NEWRELIC_DISTRIBUTED_TRACER_ENABLED: true
           IMMUNE_SSL: true
         run: |
           ref=$(certgen -domains="www.endpoint.url,endpoint.url")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -166,7 +166,7 @@ func StartConvoyServer(a *app, cfg config.Configuration, withWorkers bool) error
 
 	if withWorkers {
 		// register tasks.
-		handler := task.ProcessEventDelivery(a.applicationRepo, a.eventDeliveryRepo, a.groupRepo, a.limiter)
+		handler := task.ProcessEventDelivery(a.applicationRepo, a.eventDeliveryRepo, a.groupRepo, a.limiter, a.tracer)
 		if err := task.CreateTasks(a.groupRepo, convoy.EventProcessor, handler); err != nil {
 			log.WithError(err).Error("failed to register tasks")
 			return err
@@ -179,7 +179,7 @@ func StartConvoyServer(a *app, cfg config.Configuration, withWorkers bool) error
 			return err
 		}
 
-		worker.RegisterNewGroupTask(a.applicationRepo, a.eventDeliveryRepo, a.groupRepo, a.limiter, a.eventRepo, a.cache, a.eventQueue)
+		worker.RegisterNewGroupTask(a.applicationRepo, a.eventDeliveryRepo, a.groupRepo, a.limiter, a.eventRepo, a.cache, a.eventQueue, a.tracer)
 
 		log.Infof("Starting Convoy workers...")
 

--- a/cmd/worker.go
+++ b/cmd/worker.go
@@ -27,7 +27,7 @@ func addWorkerCommand(a *app) *cobra.Command {
 				return err
 			}
 
-			worker.RegisterNewGroupTask(a.applicationRepo, a.eventDeliveryRepo, a.groupRepo, a.limiter, a.eventRepo, a.cache, a.eventQueue)
+			worker.RegisterNewGroupTask(a.applicationRepo, a.eventDeliveryRepo, a.groupRepo, a.limiter, a.eventRepo, a.cache, a.eventQueue, a.tracer)
 			// register workers.
 			ctx := context.Background()
 			eventCreationProducer := worker.NewProducer(a.createEventQueue)

--- a/worker/scheduler.go
+++ b/worker/scheduler.go
@@ -12,12 +12,13 @@ import (
 	"github.com/frain-dev/convoy/limiter"
 	"github.com/frain-dev/convoy/queue"
 	redisqueue "github.com/frain-dev/convoy/queue/redis"
+	"github.com/frain-dev/convoy/tracer"
 	"github.com/frain-dev/convoy/worker/task"
 	"github.com/frain-dev/taskq/v3"
 	log "github.com/sirupsen/logrus"
 )
 
-func RegisterNewGroupTask(applicationRepo datastore.ApplicationRepository, eventDeliveryRepo datastore.EventDeliveryRepository, groupRepo datastore.GroupRepository, rateLimiter limiter.RateLimiter, eventRepo datastore.EventRepository, cache cache.Cache, eventQueue queue.Queuer) {
+func RegisterNewGroupTask(applicationRepo datastore.ApplicationRepository, eventDeliveryRepo datastore.EventDeliveryRepository, groupRepo datastore.GroupRepository, rateLimiter limiter.RateLimiter, eventRepo datastore.EventRepository, cache cache.Cache, eventQueue queue.Queuer, tracer tracer.Tracer) {
 	go func() {
 		for {
 			filter := &datastore.GroupFilter{}
@@ -31,7 +32,7 @@ func RegisterNewGroupTask(applicationRepo datastore.ApplicationRepository, event
 
 				if t := taskq.Tasks.Get(string(pEvtCrtTask)); t == nil {
 					if s := taskq.Tasks.Get(string(pEvtDelTask)); s == nil {
-						handler := task.ProcessEventDelivery(applicationRepo, eventDeliveryRepo, groupRepo, rateLimiter)
+						handler := task.ProcessEventDelivery(applicationRepo, eventDeliveryRepo, groupRepo, rateLimiter, tracer)
 						log.Infof("Registering event delivery task handler for %s", g.Name)
 						task.CreateTask(pEvtDelTask, *g, handler)
 

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -50,8 +50,8 @@ func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDelivery
 		var txn *newrelic.Transaction
 		if tracer != nil {
 			txn = tracer.StartTransaction("ProcessEventDelivery")
+			defer txn.End()
 		}
-		defer txn.End()
 
 		Id := job.ID
 

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -16,6 +16,7 @@ import (
 	"github.com/frain-dev/convoy/net"
 	"github.com/frain-dev/convoy/queue"
 	"github.com/frain-dev/convoy/retrystrategies"
+	"github.com/frain-dev/convoy/tracer"
 	"github.com/frain-dev/convoy/util"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -43,8 +44,10 @@ type SignatureValues struct {
 	Timestamp string
 }
 
-func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDeliveryRepo datastore.EventDeliveryRepository, groupRepo datastore.GroupRepository, rateLimiter limiter.RateLimiter) func(*queue.Job) error {
+func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDeliveryRepo datastore.EventDeliveryRepository, groupRepo datastore.GroupRepository, rateLimiter limiter.RateLimiter, tracer tracer.Tracer) func(*queue.Job) error {
 	return func(job *queue.Job) error {
+		txn := tracer.StartTransaction("ProcessEventDelivery")
+		defer txn.End()
 		Id := job.ID
 
 		// Load message from DB and switch state to prevent concurrent processing.

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -19,6 +19,7 @@ import (
 	"github.com/frain-dev/convoy/tracer"
 	"github.com/frain-dev/convoy/util"
 	"github.com/google/uuid"
+	"github.com/newrelic/go-agent/v3/newrelic"
 	log "github.com/sirupsen/logrus"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -46,8 +47,12 @@ type SignatureValues struct {
 
 func ProcessEventDelivery(appRepo datastore.ApplicationRepository, eventDeliveryRepo datastore.EventDeliveryRepository, groupRepo datastore.GroupRepository, rateLimiter limiter.RateLimiter, tracer tracer.Tracer) func(*queue.Job) error {
 	return func(job *queue.Job) error {
-		txn := tracer.StartTransaction("ProcessEventDelivery")
+		var txn *newrelic.Transaction
+		if tracer != nil {
+			txn = tracer.StartTransaction("ProcessEventDelivery")
+		}
 		defer txn.End()
+
 		Id := job.ID
 
 		// Load message from DB and switch state to prevent concurrent processing.

--- a/worker/task/process_event_delivery_test.go
+++ b/worker/task/process_event_delivery_test.go
@@ -735,6 +735,7 @@ func TestProcessEventDelivery(t *testing.T) {
 			msgRepo := mocks.NewMockEventDeliveryRepository(ctrl)
 			apiKeyRepo := mocks.NewMockAPIKeyRepository(ctrl)
 			rateLimiter := mocks.NewMockRateLimiter(ctrl)
+			tracer := mocks.NewMockTracer(ctrl)
 
 			err := config.LoadConfig(tc.cfgPath)
 			if err != nil {
@@ -760,7 +761,7 @@ func TestProcessEventDelivery(t *testing.T) {
 				tc.dbFn(appRepo, groupRepo, msgRepo, rateLimiter)
 			}
 
-			processFn := ProcessEventDelivery(appRepo, msgRepo, groupRepo, rateLimiter)
+			processFn := ProcessEventDelivery(appRepo, msgRepo, groupRepo, rateLimiter, tracer)
 
 			job := queue.Job{
 				ID: tc.msg.UID,

--- a/worker/task/process_event_delivery_test.go
+++ b/worker/task/process_event_delivery_test.go
@@ -22,7 +22,7 @@ func TestProcessEventDelivery(t *testing.T) {
 		cfgPath       string
 		expectedError error
 		msg           *datastore.EventDelivery
-		dbFn          func(*mocks.MockApplicationRepository, *mocks.MockGroupRepository, *mocks.MockEventDeliveryRepository, *mocks.MockRateLimiter)
+		dbFn          func(*mocks.MockApplicationRepository, *mocks.MockGroupRepository, *mocks.MockEventDeliveryRepository, *mocks.MockRateLimiter, *mocks.MockTracer)
 		nFn           func() func()
 	}{
 		{
@@ -32,7 +32,8 @@ func TestProcessEventDelivery(t *testing.T) {
 			msg: &datastore.EventDelivery{
 				UID: "",
 			},
-			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter) {
+			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter, t *mocks.MockTracer) {
+				t.EXPECT().StartTransaction(gomock.Any()).Times(1)
 				m.EXPECT().
 					FindEventDeliveryByID(gomock.Any(), gomock.Any()).
 					Return(&datastore.EventDelivery{
@@ -53,7 +54,8 @@ func TestProcessEventDelivery(t *testing.T) {
 			msg: &datastore.EventDelivery{
 				UID: "",
 			},
-			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter) {
+			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter, t *mocks.MockTracer) {
+				t.EXPECT().StartTransaction(gomock.Any()).Times(1)
 				m.EXPECT().
 					FindEventDeliveryByID(gomock.Any(), gomock.Any()).
 					Return(&datastore.EventDelivery{
@@ -101,7 +103,8 @@ func TestProcessEventDelivery(t *testing.T) {
 			msg: &datastore.EventDelivery{
 				UID: "",
 			},
-			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter) {
+			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter, t *mocks.MockTracer) {
+				t.EXPECT().StartTransaction(gomock.Any()).Times(1)
 				m.EXPECT().
 					FindEventDeliveryByID(gomock.Any(), gomock.Any()).
 					Return(&datastore.EventDelivery{
@@ -186,7 +189,8 @@ func TestProcessEventDelivery(t *testing.T) {
 			msg: &datastore.EventDelivery{
 				UID: "",
 			},
-			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter) {
+			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter, t *mocks.MockTracer) {
+				t.EXPECT().StartTransaction(gomock.Any()).Times(1)
 				m.EXPECT().
 					FindEventDeliveryByID(gomock.Any(), gomock.Any()).
 					Return(&datastore.EventDelivery{
@@ -273,7 +277,8 @@ func TestProcessEventDelivery(t *testing.T) {
 			msg: &datastore.EventDelivery{
 				UID: "",
 			},
-			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter) {
+			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter, t *mocks.MockTracer) {
+				t.EXPECT().StartTransaction(gomock.Any()).Times(1)
 				m.EXPECT().
 					FindEventDeliveryByID(gomock.Any(), gomock.Any()).
 					Return(&datastore.EventDelivery{
@@ -366,7 +371,8 @@ func TestProcessEventDelivery(t *testing.T) {
 			msg: &datastore.EventDelivery{
 				UID: "",
 			},
-			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter) {
+			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter, t *mocks.MockTracer) {
+				t.EXPECT().StartTransaction(gomock.Any()).Times(1)
 				m.EXPECT().
 					FindEventDeliveryByID(gomock.Any(), gomock.Any()).
 					Return(&datastore.EventDelivery{
@@ -454,7 +460,8 @@ func TestProcessEventDelivery(t *testing.T) {
 			msg: &datastore.EventDelivery{
 				UID: "",
 			},
-			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter) {
+			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter, t *mocks.MockTracer) {
+				t.EXPECT().StartTransaction(gomock.Any()).Times(1)
 				m.EXPECT().
 					FindEventDeliveryByID(gomock.Any(), gomock.Any()).
 					Return(&datastore.EventDelivery{
@@ -548,7 +555,8 @@ func TestProcessEventDelivery(t *testing.T) {
 			msg: &datastore.EventDelivery{
 				UID: "",
 			},
-			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter) {
+			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter, t *mocks.MockTracer) {
+				t.EXPECT().StartTransaction(gomock.Any()).Times(1)
 				m.EXPECT().
 					FindEventDeliveryByID(gomock.Any(), gomock.Any()).
 					Return(&datastore.EventDelivery{
@@ -636,7 +644,8 @@ func TestProcessEventDelivery(t *testing.T) {
 			msg: &datastore.EventDelivery{
 				UID: "",
 			},
-			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter) {
+			dbFn: func(a *mocks.MockApplicationRepository, o *mocks.MockGroupRepository, m *mocks.MockEventDeliveryRepository, r *mocks.MockRateLimiter, t *mocks.MockTracer) {
+				t.EXPECT().StartTransaction(gomock.Any()).Times(1)
 				m.EXPECT().
 					FindEventDeliveryByID(gomock.Any(), gomock.Any()).
 					Return(&datastore.EventDelivery{
@@ -758,7 +767,7 @@ func TestProcessEventDelivery(t *testing.T) {
 			}
 
 			if tc.dbFn != nil {
-				tc.dbFn(appRepo, groupRepo, msgRepo, rateLimiter)
+				tc.dbFn(appRepo, groupRepo, msgRepo, rateLimiter, tracer)
 			}
 
 			processFn := ProcessEventDelivery(appRepo, msgRepo, groupRepo, rateLimiter, tracer)


### PR DESCRIPTION
- Sets a span in ProcessEventDelivery using newrelic tracer, so that we can have an estimate of the average time it takes to process an event delivery. 