### PR TITLE
Prevent lowercasing endpoints during cleanup

### DIFF
--- a/util/endpoint.go
+++ b/util/endpoint.go
@@ -56,5 +56,5 @@ func CleanEndpoint(s string) (string, error) {
 		return "", errors.New("cannot use localhost or 127.0.0.1")
 	}
 
-	return strings.ToLower(u.String()), nil
+	return u.String(), nil
 }

--- a/util/endpoint_test.go
+++ b/util/endpoint_test.go
@@ -19,15 +19,17 @@ func TestCleanEndpoint(t *testing.T) {
 		{"https://localhost", true},
 		{"https://LocaLhOsT", true},
 		{"https://127.0.0.1", true},
+		{"https://GOOGLE.COM", false},
 	}
 
 	for _, v := range tt {
-		_, err := CleanEndpoint(v.url)
+		url, err := CleanEndpoint(v.url)
 		if v.hasError {
 			require.Error(t, err)
 			continue
 		}
 
 		require.NoError(t, err)
+		require.Equal(t, v.url, url)
 	}
 }


### PR DESCRIPTION
Application endpoints were being lower-cased before being saved to the database which causes events being delivered to them to return 404 as HTTP URIs are case sensitive according to [RFC3986](https://datatracker.ietf.org/doc/html/rfc3986#section-6.2.2.1).