### PR TITLE
Add missing comma to convoy.json.example

### DIFF
--- a/convoy.json.example
+++ b/convoy.json.example
@@ -20,12 +20,12 @@
     }
   },
   "tracer": {
-    "type": "new_relic"
+    "type": "new_relic",
     "new_relic": {
-    "license_key": "<insert-new-relic-license-key>",
-    "app_name": "convoy",
-    "config_enabled": true,
-    "distributed_tracer_enabled": true
+      "license_key": "<insert-new-relic-license-key>",
+      "app_name": "convoy",
+      "config_enabled": true,
+      "distributed_tracer_enabled": true
     }
   },
   "server": {


### PR DESCRIPTION
I was running the convoy example and ran into the following error:

```
Error: invalid character '"' after object key:value pair
```

It looks like there was a comma missing in the example configuration file.