### PR TITLE
add Mayhem for API testing as a github workflow

### DIFF
--- a/.github/workflows/mapi.yml
+++ b/.github/workflows/mapi.yml
@@ -1,0 +1,54 @@
+name: mapi
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+
+jobs:
+    test:
+        strategy:
+            matrix:
+                go-version: [1.17.x]
+                redis-version: ["6.2.6"]
+
+        runs-on: ubuntu-latest
+        steps:
+            - name: Set up Go
+              uses: actions/setup-go@v2
+              with:
+                  go-version: ${{ matrix.go-version }}
+
+            - name: Check out code
+              uses: actions/checkout@v2
+
+            - name: Start convoy & run mapi
+              env:
+                  PORT: 5005
+                  CONVOY_BASIC_AUTH_CONFIG: "[{\"username\": \"default\",\"password\": \"default\",\"role\": {\"type\": \"super_user\",\"groups\": []}}]"
+                  CONVOY_DB_TYPE: "in-memory"
+                  CONVOY_REDIS_DSN: "redis://localhost:6379"
+                  CONVOY_QUEUE_PROVIDER: "redis"
+              run: |
+                  go run ./cmd server &
+                  sleep 70
+                  curl -v -H 'Authorization: BASIC ZGVmYXVsdDpkZWZhdWx0' -H 'Content-Type: application/json' -X POST -d '{"name": "test", "type": "incoming"}' localhost:5005/api/v1/groups
+
+            - name: Run Mayhem for API
+              uses: ForAllSecure/mapi-action@v1
+              continue-on-error: true
+              with:
+                mapi-token: ${{ secrets.MAPI_TOKEN }}
+                api-url: http://localhost:5005/api/v1/
+                api-spec: docs/v3/openapi3.json
+                target: mayhemheroes/convoy
+                duration: 1min
+                sarif-report: mapi.sarif
+                run-args: |
+                  --header-auth
+                  Authorization: BASIC ZGVmYXVsdDpkZWZhdWx0
+
+            - name: Upload SARIF file
+              uses: github/codeql-action/upload-sarif@v1
+              with:
+                sarif_file: mapi.sarif


### PR DESCRIPTION
Add a github action to run [Mayhem for API](https://mayhem4api.forallsecure.com/) (which is a free automated testing tool for http APIs) against the api: given the swagger spec and api server, it generates and runs random test payloads, looking for exceptional behavior.

Disclosure: working on this tool is my day job!

As with any github workflow, test results can be consumed through github. Alternatively, Mayhem for API also has a dashboard, over here: https://mayhem4api.forallsecure.com/mayhemheroes/convoy.

Currently this finds a bunch of Internal Server Errors and Server Crashes that can be pretty easily triggered, as well as lots of mismatches between the openapi spec and the empirical responses (these warnings can be disabled if they're not interesting, but might be useful to keep your spec and code aligned, depending on how you maintain the specs.)

To make it work in the upstream repo, there's a bit of out-of-PR effort to integrate:

- sign up for a free mapi account, creating a frain-dev organization
- create a mapi service account within the frain-dev organization
- modify the mapi.yaml action in this PR to point at your mapi organization
- add the service account's API token to github as a repository secret named MAPI_TOKEN