### PR TITLE
Refactored configuration implementation

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/frain-dev/convoy/config"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func addConfigCommand(a *app) *cobra.Command {
+
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "config outputs your instances computed configuration",
+		Run: func(cmd *cobra.Command, args []string) {
+			cfg, err := config.Get()
+			if err != nil {
+				log.Fatalf("Error getting config: %v\n", err)
+			}
+
+			data, err := json.MarshalIndent(cfg, "", "    ")
+			if err != nil {
+				log.Fatalf("Error printing config: %v\n", err)
+			}
+
+			fmt.Println(string(data))
+		},
+	}
+
+	return cmd
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/frain-dev/convoy/notification"
 	"github.com/frain-dev/convoy/notification/email"
 	"github.com/frain-dev/convoy/notification/noop"
+	"github.com/frain-dev/convoy/util"
 
 	"github.com/frain-dev/convoy/cache"
 	"github.com/frain-dev/convoy/internal/pkg/apm"
@@ -145,10 +146,13 @@ func preRun(app *app, db *mongo.Client) func(cmd *cobra.Command, args []string) 
 			return err
 		}
 
-		err = config.OverrideConfigWithCliFlags(cmd, &cfg)
+		// Override with CLI Flags
+		cliConfig, err := buildCliConfiguration(cmd)
 		if err != nil {
 			return err
 		}
+
+		config.Override(cliConfig)
 
 		nwCfg := cfg.Tracer.NewRelic
 		nRApp, err := newrelic.NewApplication(
@@ -311,4 +315,42 @@ func (c *ConvoyCli) SetArgs(args []string) {
 
 func (c *ConvoyCli) Execute() error {
 	return c.cmd.Execute()
+}
+
+func buildCliConfiguration(cmd *cobra.Command) (*config.Configuration, error) {
+	c := &config.Configuration{}
+
+	// CONVOY_DB_DSN, CONVOY_DB_TYPE
+	dbDsn, err := cmd.Flags().GetString("db")
+	if err != nil {
+		return nil, err
+	}
+
+	if !util.IsStringEmpty(dbDsn) {
+		c.Database = config.DatabaseConfiguration{
+			Type: config.MongodbDatabaseProvider,
+			Dsn:  dbDsn,
+		}
+	}
+
+	// CONVOY_REDIS_DSN
+	redisDsn, err := cmd.Flags().GetString("redis")
+	if err != nil {
+		return nil, err
+	}
+
+	// CONVOY_QUEUE_PROVIDER
+	queueDsn, err := cmd.Flags().GetString("queue")
+	if err != nil {
+		return nil, err
+	}
+
+	if !util.IsStringEmpty(queueDsn) {
+		c.Queue.Type = config.QueueProvider(queueDsn)
+		if queueDsn == "redis" && !util.IsStringEmpty(redisDsn) {
+			c.Queue.Redis.Dsn = redisDsn
+		}
+	}
+
+	return c, nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -291,6 +291,7 @@ func parsePersistentArgs(app *app, cmd *cobra.Command) {
 	cmd.AddCommand(addSchedulerCommand(app))
 	cmd.AddCommand(addUpgradeCommand(app))
 	cmd.AddCommand(addIndexCommand(app))
+	cmd.AddCommand(addConfigCommand(app))
 }
 
 type ConvoyCli struct {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -152,7 +152,9 @@ func preRun(app *app, db *mongo.Client) func(cmd *cobra.Command, args []string) 
 			return err
 		}
 
-		config.Override(cliConfig)
+		if err = config.Override(cliConfig); err != nil {
+			return err
+		}
 
 		nwCfg := cfg.Tracer.NewRelic
 		nRApp, err := newrelic.NewApplication(

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -81,11 +81,6 @@ func addServerCommand(a *app) *cobra.Command {
 
 			config.Override(cliConfig)
 
-			err = config.SetServerConfigDefaults(&c)
-			if err != nil {
-				return err
-			}
-
 			err = StartConvoyServer(a, c, withWorkers)
 
 			if err != nil {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -74,10 +74,12 @@ func addServerCommand(a *app) *cobra.Command {
 			}
 
 			// override config with cli flags
-			err = loadServerConfigFromCliFlags(cmd, &c)
+			cliConfig, err := buildServerCliConfiguration(cmd)
 			if err != nil {
 				return err
 			}
+
+			config.Override(cliConfig)
 
 			err = config.SetServerConfigDefaults(&c)
 			if err != nil {
@@ -237,11 +239,13 @@ func StartConvoyServer(a *app, cfg config.Configuration, withWorkers bool) error
 	return nil
 }
 
-func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) error {
+func buildServerCliConfiguration(cmd *cobra.Command) (*config.Configuration, error) {
+	c := &config.Configuration{}
+
 	// CONVOY_ENV
 	env, err := cmd.Flags().GetString("env")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(env) {
@@ -251,21 +255,11 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_HOST
 	host, err := cmd.Flags().GetString("host")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(host) {
 		c.Host = host
-	}
-
-	// CONVOY_SENTRY_DSN
-	sentryDsn, err := cmd.Flags().GetString("sentry")
-	if err != nil {
-		return err
-	}
-
-	if !util.IsStringEmpty(sentryDsn) {
-		c.Sentry.Dsn = sentryDsn
 	}
 
 	// CONVOY_MULTIPLE_TENANTS
@@ -273,7 +267,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	if isMTSet {
 		multipleTenants, err := cmd.Flags().GetBool("multi-tenant")
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		c.MultipleTenants = multipleTenants
@@ -282,13 +276,13 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_REDIS_DSN
 	redis, err := cmd.Flags().GetString("redis")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// CONVOY_LIMITER_PROVIDER
 	rateLimiter, err := cmd.Flags().GetString("limiter")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(rateLimiter) {
@@ -301,7 +295,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_CACHE_PROVIDER
 	cache, err := cmd.Flags().GetString("cache")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(cache) {
@@ -314,7 +308,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_LOGGER_LEVEL
 	logLevel, err := cmd.Flags().GetString("log-level")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(logLevel) {
@@ -324,7 +318,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_LOGGER_PROVIDER
 	logger, err := cmd.Flags().GetString("logger")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(logger) {
@@ -336,7 +330,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	if isSslSet {
 		ssl, err := cmd.Flags().GetBool("ssl")
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		c.Server.HTTP.SSL = ssl
@@ -345,7 +339,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// PORT
 	port, err := cmd.Flags().GetUint32("port")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if port != 0 {
@@ -355,7 +349,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// WORKER_PORT
 	workerPort, err := cmd.Flags().GetUint32("worker-port")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if workerPort != 0 {
@@ -365,7 +359,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_SSL_KEY_FILE
 	sslKeyFile, err := cmd.Flags().GetString("ssl-key-file")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(sslKeyFile) {
@@ -375,7 +369,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_SSL_CERT_FILE
 	sslCertFile, err := cmd.Flags().GetString("ssl-cert-file")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(sslCertFile) {
@@ -385,7 +379,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_SMTP_PROVIDER
 	smtpProvider, err := cmd.Flags().GetString("smtp-provider")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(smtpProvider) {
@@ -395,7 +389,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_SMTP_URL
 	smtpUrl, err := cmd.Flags().GetString("smtp-url")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(smtpUrl) {
@@ -405,7 +399,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_SMTP_USERNAME
 	smtpUsername, err := cmd.Flags().GetString("smtp-username")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(smtpUsername) {
@@ -415,7 +409,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_SMTP_PASSWORDvar configFile string
 	smtpPassword, err := cmd.Flags().GetString("smtp-password")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(smtpPassword) {
@@ -425,7 +419,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_SMTP_FROM
 	smtpFrom, err := cmd.Flags().GetString("smtp-from")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(smtpFrom) {
@@ -435,7 +429,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_SMTP_REPLY_TO
 	smtpReplyTo, err := cmd.Flags().GetString("smtp-reply-to")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(smtpReplyTo) {
@@ -445,7 +439,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_SMTP_PORT
 	smtpPort, err := cmd.Flags().GetUint32("smtp-port")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if smtpPort != 0 {
@@ -455,7 +449,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_MAX_RESPONSE_SIZE
 	maxResponseSize, err := cmd.Flags().GetUint64("max-response-size")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if maxResponseSize != 0 {
@@ -467,7 +461,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_NEWRELIC_APP_NAME
 	newReplicApp, err := cmd.Flags().GetString("new-relic-app")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(newReplicApp) {
@@ -477,7 +471,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_NEWRELIC_LICENSE_KEY
 	newReplicKey, err := cmd.Flags().GetString("new-relic-key")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(newReplicKey) {
@@ -487,7 +481,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_SEARCH_TYPE
 	searcher, err := cmd.Flags().GetString("searcher")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(searcher) {
@@ -497,7 +491,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_TYPESENSE_HOST
 	typesenseHost, err := cmd.Flags().GetString("typesense-host")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(typesenseHost) {
@@ -507,7 +501,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_TYPESENSE_API_KEY
 	typesenseApiKey, err := cmd.Flags().GetString("typesense-api-key")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(typesenseApiKey) {
@@ -519,7 +513,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	if isNRCESet {
 		newReplicConfigEnabled, err := cmd.Flags().GetBool("new-relic-config-enabled")
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		c.Tracer.NewRelic.ConfigEnabled = newReplicConfigEnabled
@@ -530,7 +524,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	if isNRTESet {
 		newReplicTracerEnabled, err := cmd.Flags().GetBool("new-relic-tracer-enabled")
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		c.Tracer.NewRelic.DistributedTracerEnabled = newReplicTracerEnabled
@@ -541,7 +535,7 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	if isNativeRealmSet {
 		nativeRealmEnabled, err := cmd.Flags().GetBool("native")
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		c.Auth.Native.Enabled = nativeRealmEnabled
@@ -550,14 +544,14 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_API_KEY_CONFIG
 	apiKeyAuthConfig, err := cmd.Flags().GetString("api-auth")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(apiKeyAuthConfig) {
 		config := config.APIKeyAuthConfig{}
 		err = config.Decode(apiKeyAuthConfig)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		c.Auth.File.APIKey = config
@@ -566,18 +560,18 @@ func loadServerConfigFromCliFlags(cmd *cobra.Command, c *config.Configuration) e
 	// CONVOY_BASIC_AUTH_CONFIG
 	basicAuthConfig, err := cmd.Flags().GetString("basic-auth")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if !util.IsStringEmpty(basicAuthConfig) {
 		config := config.BasicAuthConfig{}
 		err = config.Decode(basicAuthConfig)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		c.Auth.File.Basic = config
 	}
 
-	return nil
+	return c, nil
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -79,7 +79,9 @@ func addServerCommand(a *app) *cobra.Command {
 				return err
 			}
 
-			config.Override(cliConfig)
+			if err = config.Override(cliConfig); err != nil {
+				return err
+			}
 
 			err = StartConvoyServer(a, c, withWorkers)
 

--- a/config/config.go
+++ b/config/config.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"sync/atomic"
 
 	"github.com/kelseyhightower/envconfig"
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 )
 
 const (
@@ -24,10 +24,6 @@ var cfgSingleton atomic.Value
 type DatabaseConfiguration struct {
 	Type DatabaseProvider `json:"type" envconfig:"CONVOY_DB_TYPE"`
 	Dsn  string           `json:"dsn" envconfig:"CONVOY_DB_DSN"`
-}
-
-type SentryConfiguration struct {
-	Dsn string `json:"dsn" envconfig:"CONVOY_SENTRY_DSN"`
 }
 
 type ServerConfiguration struct {
@@ -137,25 +133,6 @@ type TypesenseConfiguration struct {
 	ApiKey string `json:"api_key" envconfig:"CONVOY_TYPESENSE_API_KEY"`
 }
 
-type Configuration struct {
-	Auth            AuthConfiguration       `json:"auth,omitempty"`
-	Database        DatabaseConfiguration   `json:"database"`
-	Sentry          SentryConfiguration     `json:"sentry"`
-	Queue           QueueConfiguration      `json:"queue"`
-	Prometheus      PrometheusConfiguration `json:"prometheus"`
-	Server          ServerConfiguration     `json:"server"`
-	MaxResponseSize uint64                  `json:"max_response_size" envconfig:"CONVOY_MAX_RESPONSE_SIZE"`
-	SMTP            SMTPConfiguration       `json:"smtp"`
-	Environment     string                  `json:"env" envconfig:"CONVOY_ENV" required:"true" default:"development"`
-	MultipleTenants bool                    `json:"multiple_tenants"`
-	Logger          LoggerConfiguration     `json:"logger"`
-	Tracer          TracerConfiguration     `json:"tracer"`
-	Cache           CacheConfiguration      `json:"cache"`
-	Limiter         LimiterConfiguration    `json:"limiter"`
-	Host            string                  `json:"host" envconfig:"CONVOY_HOST"`
-	Search          SearchConfiguration     `json:"search"`
-}
-
 const (
 	envPrefix string = "convoy"
 
@@ -190,6 +167,24 @@ func (s SignatureHeaderProvider) String() string {
 	return string(s)
 }
 
+type Configuration struct {
+	Auth            AuthConfiguration       `json:"auth,omitempty"`
+	Database        DatabaseConfiguration   `json:"database"`
+	Queue           QueueConfiguration      `json:"queue"`
+	Prometheus      PrometheusConfiguration `json:"prometheus"`
+	Server          ServerConfiguration     `json:"server"`
+	MaxResponseSize uint64                  `json:"max_response_size" envconfig:"CONVOY_MAX_RESPONSE_SIZE" default:"50"`
+	SMTP            SMTPConfiguration       `json:"smtp"`
+	Environment     string                  `json:"env" envconfig:"CONVOY_ENV" required:"true" default:"development"`
+	MultipleTenants bool                    `json:"multiple_tenants"`
+	Logger          LoggerConfiguration     `json:"logger"`
+	Tracer          TracerConfiguration     `json:"tracer"`
+	Cache           CacheConfiguration      `json:"cache"`
+	Limiter         LimiterConfiguration    `json:"limiter"`
+	Host            string                  `json:"host" envconfig:"CONVOY_HOST" default:"localhost"`
+	Search          SearchConfiguration     `json:"search"`
+}
+
 // Get fetches the application configuration. LoadConfig must have been called
 // previously for this to work.
 // Use this when you need to get access to the config object at runtime
@@ -205,263 +200,32 @@ func Get() (Configuration, error) {
 // IsStringEmpty checks if the given string s is empty or not
 func IsStringEmpty(s string) bool { return len(strings.TrimSpace(s)) == 0 }
 
-func OverrideConfigWithCliFlags(cmd *cobra.Command, cfg *Configuration) error {
-	// CONVOY_DB_DSN, CONVOY_DB_TYPE
-	dbDsn, err := cmd.Flags().GetString("db")
+func Override(newCfg *Configuration) error {
+	c, err := Get()
 	if err != nil {
 		return err
 	}
 
-	if !IsStringEmpty(dbDsn) {
-		cfg.Database.Type = InMemoryDatabaseProvider
+	ov := reflect.ValueOf(&c).Elem()
+	nv := reflect.ValueOf(newCfg).Elem()
 
-		parts := strings.Split(dbDsn, "://")
-		if len(parts) == 2 {
-			// parts[0] must be either "mongodb" or "mongodb+srv"
-			if parts[0] == string(MongodbDatabaseProvider) || parts[0] == string(MongodbDatabaseProvider)+"+srv" {
-				cfg.Database.Type = MongodbDatabaseProvider
-			}
+	for i := 0; i < ov.NumField(); i++ {
+		if !ov.Field(i).CanInterface() {
+			continue
 		}
 
-		cfg.Database.Dsn = dbDsn
-	}
+		fv := nv.Field(i).Interface()
+		isZero := reflect.ValueOf(fv).IsZero()
 
-	// CONVOY_REDIS_DSN
-	redisDsn, err := cmd.Flags().GetString("redis")
-	if err != nil {
-		return err
-	}
-
-	// CONVOY_QUEUE_PROVIDER
-	queueDsn, err := cmd.Flags().GetString("queue")
-	if err != nil {
-		return err
-	}
-
-	if !IsStringEmpty(queueDsn) {
-		cfg.Queue.Type = QueueProvider(queueDsn)
-		if queueDsn == "redis" && !IsStringEmpty(redisDsn) {
-			cfg.Queue.Redis.Dsn = redisDsn
+		if isZero {
+			continue
 		}
+
+		ov.Field(i).Set(reflect.ValueOf(fv))
 	}
 
-	cfgSingleton.Store(cfg)
-
+	cfgSingleton.Store(&c)
 	return nil
-}
-
-func overrideConfigWithEnvVars(c *Configuration, override *Configuration) {
-	// CONVOY_ENV
-	if !IsStringEmpty(override.Environment) {
-		c.Environment = override.Environment
-	}
-
-	// CONVOY_HOST
-	if !IsStringEmpty(override.Host) {
-		c.Host = override.Host
-	}
-
-	// CONVOY_DB_TYPE
-	if !IsStringEmpty(string(override.Database.Type)) {
-		c.Database.Type = override.Database.Type
-	}
-
-	// CONVOY_DB_DSN
-	if !IsStringEmpty(override.Database.Dsn) {
-		c.Database.Dsn = override.Database.Dsn
-	}
-
-	// CONVOY_LIMITER_TYPE
-	if !IsStringEmpty(override.Sentry.Dsn) {
-		c.Sentry.Dsn = override.Sentry.Dsn
-	}
-
-	// CONVOY_LIMITER_TYPE
-	if !IsStringEmpty(string(override.Limiter.Type)) {
-		c.Limiter.Type = override.Limiter.Type
-	}
-
-	// CONVOY_REDIS_DSN
-	if !IsStringEmpty(override.Limiter.Redis.Dsn) {
-		c.Limiter.Redis.Dsn = override.Limiter.Redis.Dsn
-	}
-
-	// CONVOY_CACHE_PROVIDER
-	if !IsStringEmpty(string(override.Cache.Type)) {
-		c.Cache.Type = override.Cache.Type
-	}
-
-	// CONVOY_REDIS_DSN
-	if !IsStringEmpty(override.Cache.Redis.Dsn) {
-		c.Cache.Redis.Dsn = override.Cache.Redis.Dsn
-	}
-
-	// CONVOY_QUEUE_PROVIDER
-	if !IsStringEmpty(string(override.Queue.Type)) {
-		c.Queue.Type = override.Queue.Type
-	}
-
-	// CONVOY_REDIS_DSN
-	if !IsStringEmpty(override.Queue.Redis.Dsn) {
-		c.Queue.Redis.Dsn = override.Queue.Redis.Dsn
-	}
-
-	// CONVOY_PROM_DSN
-	if !IsStringEmpty(override.Queue.Redis.Dsn) {
-		c.Prometheus.Dsn = override.Prometheus.Dsn
-	}
-
-	// CONVOY_REDIS_DSN
-	if !IsStringEmpty(override.Queue.Redis.Dsn) {
-		c.Queue.Redis.Dsn = override.Queue.Redis.Dsn
-	}
-
-	// CONVOY_LOGGER_PROVIDER
-	if !IsStringEmpty(string(override.Logger.Type)) {
-		c.Logger.Type = override.Logger.Type
-	}
-
-	// CONVOY_LOGGER_LEVEL
-	if !IsStringEmpty(override.Logger.ServerLog.Level) {
-		c.Logger.ServerLog.Level = override.Logger.ServerLog.Level
-	}
-
-	// PORT
-	if override.Server.HTTP.Port != 0 {
-		c.Server.HTTP.Port = override.Server.HTTP.Port
-	}
-
-	// WORKER_PORT
-	if override.Server.HTTP.WorkerPort != 0 {
-		c.Server.HTTP.WorkerPort = override.Server.HTTP.WorkerPort
-	}
-
-	// CONVOY_SSL_CERT_FILE
-	if !IsStringEmpty(override.Server.HTTP.SSLCertFile) {
-		c.Server.HTTP.SSLCertFile = override.Server.HTTP.SSLCertFile
-	}
-
-	// CONVOY_SSL_KEY_FILE
-	if !IsStringEmpty(override.Server.HTTP.SSLKeyFile) {
-		c.Server.HTTP.SSLKeyFile = override.Server.HTTP.SSLKeyFile
-	}
-
-	// CONVOY_SMTP_PROVIDER
-	if !IsStringEmpty(override.SMTP.Provider) {
-		c.SMTP.Provider = override.SMTP.Provider
-	}
-
-	// CONVOY_SMTP_FROM
-	if !IsStringEmpty(override.SMTP.From) {
-		c.SMTP.From = override.SMTP.From
-	}
-
-	// CONVOY_SMTP_PASSWORD
-	if !IsStringEmpty(override.SMTP.Password) {
-		c.SMTP.Password = override.SMTP.Password
-	}
-
-	// CONVOY_SMTP_REPLY_TO
-	if !IsStringEmpty(override.SMTP.ReplyTo) {
-		c.SMTP.ReplyTo = override.SMTP.ReplyTo
-	}
-
-	// CONVOY_SMTP_USERNAME
-	if !IsStringEmpty(override.SMTP.URL) {
-		c.SMTP.URL = override.SMTP.URL
-	}
-
-	// CONVOY_SMTP_USERNAME
-	if !IsStringEmpty(override.SMTP.Username) {
-		c.SMTP.Username = override.SMTP.Username
-	}
-
-	// CONVOY_SMTP_PORT
-	if override.SMTP.Port != 0 {
-		c.SMTP.Port = override.SMTP.Port
-	}
-
-	// CONVOY_MAX_RESPONSE_SIZE
-	if override.MaxResponseSize != 0 {
-		c.MaxResponseSize = override.MaxResponseSize
-	}
-
-	// CONVOY_NEWRELIC_APP_NAME
-	if !IsStringEmpty(override.Tracer.NewRelic.AppName) {
-		c.Tracer.NewRelic.AppName = override.Tracer.NewRelic.AppName
-	}
-
-	// CONVOY_SEARCH_TYPE
-	if !IsStringEmpty(string(override.Search.Type)) {
-		c.Search.Type = override.Search.Type
-	}
-
-	// CONVOY_TYPESENSE_HOST
-	if !IsStringEmpty(override.Search.Typesense.Host) {
-		c.Search.Typesense.Host = override.Search.Typesense.Host
-	}
-
-	// CONVOY_TYPESENSE_API_KEY
-	if !IsStringEmpty(override.Search.Typesense.ApiKey) {
-		c.Search.Typesense.ApiKey = override.Search.Typesense.ApiKey
-	}
-
-	// CONVOY_NEWRELIC_LICENSE_KEY
-	if !IsStringEmpty(override.Tracer.NewRelic.LicenseKey) {
-		c.Tracer.NewRelic.LicenseKey = override.Tracer.NewRelic.LicenseKey
-	}
-
-	// CONVOY_API_KEY_CONFIG
-	if override.Auth.File.APIKey != nil {
-		c.Auth.File.APIKey = override.Auth.File.APIKey
-	}
-
-	// CONVOY_BASIC_AUTH_CONFIG
-	if override.Auth.File.Basic != nil {
-		c.Auth.File.Basic = override.Auth.File.Basic
-	}
-
-	// CONVOY_JWT_SECRET
-	if !IsStringEmpty(override.Auth.Jwt.Secret) {
-		c.Auth.Jwt.Secret = override.Auth.Jwt.Secret
-	}
-
-	// CONVOY_JWT_EXPIRY
-	if override.Auth.Jwt.Expiry != 0 {
-		c.Auth.Jwt.Expiry = override.Auth.Jwt.Expiry
-	}
-
-	// CONVOY_JWT_REFRESH_SECRET
-	if !IsStringEmpty(override.Auth.Jwt.RefreshSecret) {
-		c.Auth.Jwt.RefreshSecret = override.Auth.Jwt.RefreshSecret
-	}
-
-	// CONVOY_JWT_REFRESH_EXPIRY
-	if override.Auth.Jwt.RefreshExpiry != 0 {
-		c.Auth.Jwt.RefreshExpiry = override.Auth.Jwt.RefreshExpiry
-	}
-
-	// boolean values are weird; we have to check if they are actually set
-
-	if _, ok := os.LookupEnv("CONVOY_MULTIPLE_TENANTS"); ok {
-		c.MultipleTenants = override.MultipleTenants
-	}
-
-	if _, ok := os.LookupEnv("SSL"); ok {
-		c.Server.HTTP.SSL = override.Server.HTTP.SSL
-	}
-
-	if _, ok := os.LookupEnv("CONVOY_NEWRELIC_CONFIG_ENABLED"); ok {
-		c.Tracer.NewRelic.ConfigEnabled = override.Tracer.NewRelic.ConfigEnabled
-	}
-
-	if _, ok := os.LookupEnv("CONVOY_NATIVE_REALM_ENABLED"); ok {
-		c.Auth.Native.Enabled = override.Auth.Native.Enabled
-	}
-
-	if _, ok := os.LookupEnv("CONVOY_JWT_REALM_ENABLED"); ok {
-		c.Auth.Jwt.Enabled = override.Auth.Jwt.Enabled
-	}
 }
 
 // LoadConfig is used to load the configuration from either the json config file
@@ -489,51 +253,6 @@ func LoadConfig(p string) error {
 
 	// load config from environment variables
 	err := envconfig.Process(envPrefix, ec)
-	if err != nil {
-		return err
-	}
-
-	overrideConfigWithEnvVars(c, ec)
-
-	cfgSingleton.Store(c)
-	return nil
-}
-
-func SetServerConfigDefaults(c *Configuration) error {
-	// if it's still empty, set it to development
-	if c.Environment == "" {
-		c.Environment = DevelopmentEnvironment
-	}
-
-	if c.Server.HTTP.Port == 0 {
-		return errors.New("http port cannot be zero")
-	}
-
-	if c.Host == "" {
-		c.Host = fmt.Sprint("localhost:", c.Server.HTTP.Port)
-	}
-
-	err := ensureSSL(c.Server)
-	if err != nil {
-		return err
-	}
-
-	kb := c.MaxResponseSize * 1024 // to kilobyte
-	if kb == 0 {
-		c.MaxResponseSize = MaxResponseSize
-	} else if kb > MaxResponseSize {
-		log.Warnf("maximum response size of %dkb too large, using default value of %dkb", c.MaxResponseSize, c.MaxResponseSize/1024)
-		c.MaxResponseSize = MaxResponseSize
-	} else {
-		c.MaxResponseSize = kb
-	}
-
-	err = ensureQueueConfig(c.Queue)
-	if err != nil {
-		return err
-	}
-
-	err = ensureAuthConfig(c.Auth)
 	if err != nil {
 		return err
 	}
@@ -588,5 +307,37 @@ func ensureQueueConfig(queueCfg QueueConfiguration) error {
 	default:
 		return fmt.Errorf("unsupported queue type: %s", queueCfg.Type)
 	}
+	return nil
+}
+
+func ensureMaxResponseSize(c *Configuration) {
+	bytes := c.MaxResponseSize * 1024
+
+	if bytes == 0 {
+		c.MaxResponseSize = MaxResponseSize
+	} else if bytes > MaxResponseSize {
+		log.Warnf("maximum response size of %dkb too large, using default value of %dkb", c.MaxResponseSize, c.MaxResponseSize/1024)
+		c.MaxResponseSize = MaxResponseSize
+	} else {
+		c.MaxResponseSize = bytes
+	}
+}
+
+func validate(c *Configuration) error {
+
+	ensureMaxResponseSize(c)
+
+	if err := ensureAuthConfig(c.Auth); err != nil {
+		return err
+	}
+
+	if err := ensureQueueConfig(c.Queue); err != nil {
+		return err
+	}
+
+	if err := ensureSSL(c.Server); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -288,33 +288,6 @@ func LoadConfig(p string) error {
 	return nil
 }
 
-func ensureAuthConfig(authCfg AuthConfiguration) error {
-	var err error
-	for _, r := range authCfg.File.Basic {
-		if r.Username == "" || r.Password == "" {
-			return errors.New("username and password are required for basic auth config")
-		}
-
-		err = r.Role.Validate("basic auth")
-		if err != nil {
-			return err
-		}
-	}
-
-	for _, r := range authCfg.File.APIKey {
-		if r.APIKey == "" {
-			return errors.New("api-key is required for api-key auth config")
-		}
-
-		err = r.Role.Validate("api-key auth")
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func ensureSSL(s ServerConfiguration) error {
 	if s.HTTP.SSL {
 		if s.HTTP.SSLCertFile == "" || s.HTTP.SSLKeyFile == "" {
@@ -353,10 +326,6 @@ func ensureMaxResponseSize(c *Configuration) {
 func validate(c *Configuration) error {
 
 	ensureMaxResponseSize(c)
-
-	if err := ensureAuthConfig(c.Auth); err != nil {
-		return err
-	}
 
 	if err := ensureQueueConfig(c.Queue); err != nil {
 		return err

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -124,9 +124,10 @@ func TestLoadConfig(t *testing.T) {
 				path: "./testdata/Config/valid-convoy.json",
 			},
 			wantCfg: Configuration{
-				Host: "localhost:80",
+				Host: "localhost:5005",
 				Database: DatabaseConfiguration{
-					Dsn: "mongodb://inside-config-file",
+					Type: MongodbDatabaseProvider,
+					Dsn:  "mongodb://inside-config-file",
 				},
 				Queue: QueueConfiguration{
 					Type: RedisQueueProvider,
@@ -136,7 +137,8 @@ func TestLoadConfig(t *testing.T) {
 				},
 				Server: ServerConfiguration{
 					HTTP: HTTPServerConfiguration{
-						Port: 80,
+						Port:       80,
+						WorkerPort: 5006,
 					},
 				},
 				MaxResponseSize: 40 * 1024,
@@ -152,9 +154,10 @@ func TestLoadConfig(t *testing.T) {
 				path: "./testdata/Config/too-large-max-response-size-convoy.json",
 			},
 			wantCfg: Configuration{
-				Host: "localhost:80",
+				Host: "localhost:5005",
 				Database: DatabaseConfiguration{
-					Dsn: "mongodb://inside-config-file",
+					Type: MongodbDatabaseProvider,
+					Dsn:  "mongodb://inside-config-file",
 				},
 				Queue: QueueConfiguration{
 					Type: RedisQueueProvider,
@@ -164,7 +167,8 @@ func TestLoadConfig(t *testing.T) {
 				},
 				Server: ServerConfiguration{
 					HTTP: HTTPServerConfiguration{
-						Port: 80,
+						Port:       80,
+						WorkerPort: 5006,
 					},
 				},
 				MaxResponseSize: MaxResponseSize,
@@ -180,9 +184,10 @@ func TestLoadConfig(t *testing.T) {
 				path: "./testdata/Config/zero-max-response-size-convoy.json",
 			},
 			wantCfg: Configuration{
-				Host: "localhost:80",
+				Host: "localhost:5005",
 				Database: DatabaseConfiguration{
-					Dsn: "mongodb://inside-config-file",
+					Type: MongodbDatabaseProvider,
+					Dsn:  "mongodb://inside-config-file",
 				},
 				Queue: QueueConfiguration{
 					Type: RedisQueueProvider,
@@ -192,7 +197,8 @@ func TestLoadConfig(t *testing.T) {
 				},
 				Server: ServerConfiguration{
 					HTTP: HTTPServerConfiguration{
-						Port: 80,
+						Port:       80,
+						WorkerPort: 5006,
 					},
 				},
 				MaxResponseSize: MaxResponseSize,
@@ -208,9 +214,10 @@ func TestLoadConfig(t *testing.T) {
 				path: "./testdata/Config/zero-groups-for-superuser.json",
 			},
 			wantCfg: Configuration{
-				Host: "localhost:80",
+				Host: "localhost:5005",
 				Database: DatabaseConfiguration{
-					Dsn: "mongodb://inside-config-file",
+					Type: MongodbDatabaseProvider,
+					Dsn:  "mongodb://inside-config-file",
 				},
 				Queue: QueueConfiguration{
 					Type: RedisQueueProvider,
@@ -220,7 +227,8 @@ func TestLoadConfig(t *testing.T) {
 				},
 				Server: ServerConfiguration{
 					HTTP: HTTPServerConfiguration{
-						Port: 80,
+						Port:       80,
+						WorkerPort: 5006,
 					},
 				},
 				MaxResponseSize: MaxResponseSize,
@@ -241,15 +249,6 @@ func TestLoadConfig(t *testing.T) {
 				MultipleTenants: false,
 			},
 			wantErr: false,
-		},
-		{
-			name: "should_error_for_zero_port",
-			args: args{
-				path: "./testdata/Config/no-port-convoy.json",
-			},
-			wantCfg:    Configuration{},
-			wantErr:    true,
-			wantErrMsg: "http port cannot be zero",
 		},
 		{
 			name: "should_error_for_empty_ssl_key_file",
@@ -338,22 +337,29 @@ func TestLoadConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := LoadConfig(tt.args.path)
-			require.NoError(t, err)
 
-			cfg, err := Get()
-			require.NoError(t, err)
-
-			err = SetServerConfigDefaults(&cfg)
 			if tt.wantErr {
 				require.NotNil(t, err)
 				require.Equal(t, tt.wantErrMsg, err.Error())
 				return
 			}
 
-			require.Nil(t, err)
+			require.NoError(t, err)
+
+			cfg, err := Get()
+			require.NoError(t, err)
 			require.Equal(t, tt.wantCfg, cfg)
 		})
 	}
+}
+
+func TestConfigDefaults(t *testing.T) {
+	err := LoadConfig("./testdata/Config/empty-config")
+	require.NoError(t, err)
+
+	cfg, err := Get()
+	require.NoError(t, err)
+	require.Equal(t, DefaultConfiguration, cfg)
 }
 
 func TestOverride(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/frain-dev/convoy/auth"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,12 +20,6 @@ func Test_EnvironmentTakesPrecedence(t *testing.T) {
 			key:       "PORT",
 			testType:  "number",
 			envConfig: "8080",
-		},
-		{
-			name:      "Basic Auth (interface)",
-			key:       "CONVOY_BASIC_AUTH_CONFIG",
-			testType:  "interface",
-			envConfig: "[{\"username\": \"some-admin\",\"password\": \"some-password\",\"role\": {\"type\": \"super_user\",\"group\": \"\"}}]",
 		},
 	}
 	for _, tc := range tests {
@@ -48,11 +40,6 @@ func Test_EnvironmentTakesPrecedence(t *testing.T) {
 				port, e := strconv.ParseInt(tc.envConfig, 10, 64)
 				require.NoError(t, e)
 				require.Equal(t, port, int64(cfg.Server.HTTP.Port))
-			case "interface":
-				basicAuth := BasicAuthConfig{}
-				e := basicAuth.Decode(tc.envConfig)
-				require.NoError(t, e)
-				require.Equal(t, basicAuth, cfg.Auth.File.Basic)
 			}
 		})
 	}
@@ -73,13 +60,6 @@ func Test_NilEnvironmentVariablesDontOverride(t *testing.T) {
 			envConfig: "0",
 			expected:  "8080",
 		},
-		{
-			name:      "Basic Auth (interface)",
-			key:       "CONVOY_BASIC_AUTH_CONFIG",
-			testType:  "interface",
-			envConfig: "",
-			expected:  "[{\"username\": \"admin\",\"password\": \"qwerty\",\"role\": {\"type\": \"super_user\",\"groups\": \"\"}}]",
-		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -97,11 +77,6 @@ func Test_NilEnvironmentVariablesDontOverride(t *testing.T) {
 				port, e := strconv.ParseInt(tc.expected, 10, 64)
 				require.NoError(t, e)
 				require.Equal(t, port, int64(cfg.Server.HTTP.Port))
-			case "interface":
-				basicAuth := BasicAuthConfig{}
-				e := basicAuth.Decode(tc.expected)
-				require.NoError(t, e)
-				require.Equal(t, basicAuth, cfg.Auth.File.Basic)
 			}
 		})
 	}
@@ -209,48 +184,6 @@ func TestLoadConfig(t *testing.T) {
 			wantErrMsg: "",
 		},
 		{
-			name: "should_allow_zero_groups_for_superuser",
-			args: args{
-				path: "./testdata/Config/zero-groups-for-superuser.json",
-			},
-			wantCfg: Configuration{
-				Host: "localhost:5005",
-				Database: DatabaseConfiguration{
-					Type: MongodbDatabaseProvider,
-					Dsn:  "mongodb://inside-config-file",
-				},
-				Queue: QueueConfiguration{
-					Type: RedisQueueProvider,
-					Redis: RedisQueueConfiguration{
-						Dsn: "redis://localhost:8379",
-					},
-				},
-				Server: ServerConfiguration{
-					HTTP: HTTPServerConfiguration{
-						Port:       80,
-						WorkerPort: 5006,
-					},
-				},
-				MaxResponseSize: MaxResponseSize,
-				Auth: AuthConfiguration{
-					File: FileRealmOption{
-						Basic: []BasicAuth{
-							{
-								Username: "123",
-								Password: "abc",
-								Role: auth.Role{
-									Type: "super_user",
-								},
-							},
-						},
-					},
-				},
-				Environment:     DevelopmentEnvironment,
-				MultipleTenants: false,
-			},
-			wantErr: false,
-		},
-		{
 			name: "should_error_for_empty_ssl_key_file",
 			args: args{
 				path: "./testdata/Config/empty-ssl-key-file.json",
@@ -283,55 +216,6 @@ func TestLoadConfig(t *testing.T) {
 			},
 			wantErr:    true,
 			wantErrMsg: "unsupported queue type: abc",
-		},
-		{
-			name: "should_error_for_empty_password_for_basic_auth",
-			args: args{
-				path: "./testdata/Config/empty-password-for-basic-auth.json",
-			},
-			wantErr:    true,
-			wantErrMsg: "username and password are required for basic auth config",
-		},
-		{
-			name: "should_error_for_invalid_role",
-			args: args{
-				path: "./testdata/Config/invalid-role.json",
-			},
-			wantErr:    true,
-			wantErrMsg: "invalid role type: abc",
-		},
-		{
-			name: "should_error_for_zero_groups",
-			args: args{
-				path: "./testdata/Config/zero-groups-for-non-superuser.json",
-			},
-			wantErr:    true,
-			wantErrMsg: "please specify group for basic auth",
-		},
-		{
-			name: "should_error_for_empty_group",
-			args: args{
-				path: "./testdata/Config/empty-basic-auth-group-name.json",
-			},
-			wantErr:    true,
-			wantErrMsg: "please specify group for basic auth",
-		},
-		{
-			name: "should_error_for_empty_api_key",
-			args: args{
-				path: "./testdata/Config/empty-api-key.json",
-			},
-			wantErr:    true,
-			wantErrMsg: "api-key is required for api-key auth config",
-		},
-
-		{
-			name: "should_error_for_empty_api_key_group_name",
-			args: args{
-				path: "./testdata/Config/empty-api-key-auth-group-name.json",
-			},
-			wantErr:    true,
-			wantErrMsg: "please specify group for api-key auth",
 		},
 	}
 	for _, tt := range tests {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -300,6 +300,7 @@ func TestOverride(t *testing.T) {
 
 			// Act.
 			err = Override(tc.config)
+			require.NoError(t, err)
 
 			// Assert.
 			c, err := Get()

--- a/config/testdata/Config/valid-convoy.json
+++ b/config/testdata/Config/valid-convoy.json
@@ -13,17 +13,5 @@
         "http": {
             "port": 80
         }
-    },
-    "group": {
-        "strategy": {
-            "type": "default",
-            "default": {
-                "intervalSeconds": 125,
-                "retryLimit": 15
-            }
-        },
-        "signature": {
-            "hash": "SHA256"
-        }
     }
 }


### PR DESCRIPTION
### Problems

- Enhanced readability for the entry point of the system. Currently, It’s pretty hard to follow through with how the system is set up from the `cmd` package. The various commands don’t have a consistent way they build `Configuration`. Here’s how the `server` works today;
    - `convoy.json` → `environment variables` → `CLI Flags` → `Server CLI Flags` → `Server Defaults`
- Simpler to the above, provide a consistent approach for `subcommands` to add override configuration rather than spin up ad-hoc mechanisms.
### Solution

1. Build `Configuration` with a more straightforward flow and API.
    - Flow
        
        `defaults` → `convoy.json` → `environment variable` → `CLI flags`
        
    - API
        
        ```go
        // Path to convoy.json
        cfgPath := "path/to/convoy.json"
        
        // Load default configuration
        err := config.LoadConfig(cfgPath)
        
        // Get configuration
        c, err := config.Get()
        
        // Override configuration
        err := config.Override(newConfig)
        ```
        
2. Create `convoy config` to output a JSON dump of the current shape of `Configuration` for debugging sake.