### PR TITLE
Force Retry Bug

### DIFF
--- a/datastore/models.go
+++ b/datastore/models.go
@@ -140,7 +140,7 @@ var (
 
 	DefaultRateLimitConfig = RateLimitConfiguration{
 		Count:    1000,
-		Duration: "1m",
+		Duration: 60,
 	}
 
 	DefaultRetryConfig = RetryConfiguration{
@@ -247,7 +247,7 @@ type GroupConfig struct {
 
 type RateLimitConfiguration struct {
 	Count    int    `json:"count" bson:"count"`
-	Duration string `json:"duration" bson:"duration"`
+	Duration uint64 `json:"duration" bson:"duration"`
 }
 
 type StrategyConfiguration struct {

--- a/services/event_service.go
+++ b/services/event_service.go
@@ -387,7 +387,7 @@ func (e *EventService) requeueEventDelivery(ctx context.Context, eventDelivery *
 		return errors.New("an error occurred while trying to resend event")
 	}
 
-	taskName := convoy.CreateEventProcessor
+	taskName := convoy.EventProcessor
 
 	job := &queue.Job{
 		ID:      eventDelivery.UID,

--- a/services/event_service_test.go
+++ b/services/event_service_test.go
@@ -1818,7 +1818,7 @@ func TestEventService_requeueEventDelivery(t *testing.T) {
 					Times(1).Return(nil)
 
 				eq, _ := es.queue.(*mocks.MockQueuer)
-				eq.EXPECT().Write(convoy.CreateEventProcessor, convoy.EventQueue, gomock.Any()).
+				eq.EXPECT().Write(convoy.EventProcessor, convoy.EventQueue, gomock.Any()).
 					Times(1).Return(nil)
 			},
 		},
@@ -1850,7 +1850,7 @@ func TestEventService_requeueEventDelivery(t *testing.T) {
 					Times(1).Return(nil)
 
 				eq, _ := es.queue.(*mocks.MockQueuer)
-				eq.EXPECT().Write(convoy.CreateEventProcessor, convoy.EventQueue, gomock.Any()).
+				eq.EXPECT().Write(convoy.EventProcessor, convoy.EventQueue, gomock.Any()).
 					Times(1).Return(errors.New("failed"))
 			},
 			wantErr:    true,

--- a/services/group_service_test.go
+++ b/services/group_service_test.go
@@ -66,7 +66,7 @@ func TestGroupService_CreateGroup(t *testing.T) {
 						},
 						RateLimit: &datastore.RateLimitConfiguration{
 							Count:    1000,
-							Duration: "1m",
+							Duration: 60,
 						},
 						DisableEndpoint: true,
 						ReplayAttacks:   true,
@@ -108,7 +108,7 @@ func TestGroupService_CreateGroup(t *testing.T) {
 					},
 					RateLimit: &datastore.RateLimitConfiguration{
 						Count:    1000,
-						Duration: "1m",
+						Duration: 60,
 					},
 					DisableEndpoint: true,
 					ReplayAttacks:   true,
@@ -139,7 +139,7 @@ func TestGroupService_CreateGroup(t *testing.T) {
 						},
 						RateLimit: &datastore.RateLimitConfiguration{
 							Count:    1000,
-							Duration: "1m",
+							Duration: 60,
 						},
 						DisableEndpoint: true,
 						ReplayAttacks:   true,
@@ -181,7 +181,7 @@ func TestGroupService_CreateGroup(t *testing.T) {
 					},
 					RateLimit: &datastore.RateLimitConfiguration{
 						Count:    1000,
-						Duration: "1m",
+						Duration: 60,
 					},
 					DisableEndpoint: true,
 					ReplayAttacks:   true,


### PR DESCRIPTION
Fixed force retry bug. It was writing the `EventDelivery` to the wrong queue. 