### PR TITLE
Fix server panic #902

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -170,10 +170,12 @@ func preRun(app *app, db *mongo.Client) func(cmd *cobra.Command, args []string) 
 
 		apm.SetApplication(nRApp)
 
-		db, err = mongo.New(cfg)
+		database, err := mongo.New(cfg)
 		if err != nil {
 			return err
 		}
+
+		*db = *database
 
 		var tr tracer.Tracer
 		var ca cache.Cache


### PR DESCRIPTION
The server panics because the mongo client in the `postRun` hook doesn't have the same pointer address as the mongo client in the `preRun` hook. This is because the pointer address gets reassigned when `mongo.New` is called. Fixes #902 