### PR TITLE
Fix MongoDB indexes

### DIFF
--- a/datastore/models.go
+++ b/datastore/models.go
@@ -527,9 +527,9 @@ type Subscription struct {
 	SourceID   string             `json:"-" bson:"source_id"`
 	EndpointID string             `json:"-" bson:"endpoint_id"`
 
-	Source   *Source      `json:"source_metadata,omitempty" bson:"-"`
-	Endpoint *Endpoint    `json:"endpoint_metadata,omitempty" bson:"-"`
-	App      *Application `json:"app_metadata,omitempty" bson:"-"`
+	Source   *Source      `json:"source_metadata" bson:"-"`
+	Endpoint *Endpoint    `json:"endpoint_metadata" bson:"-"`
+	App      *Application `json:"app_metadata" bson:"-"`
 
 	// subscription config
 	AlertConfig  *AlertConfiguration  `json:"alert_config,omitempty" bson:"alert_config,omitempty"`

--- a/datastore/mongo/mongo.go
+++ b/datastore/mongo/mongo.go
@@ -257,6 +257,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 				Keys: bson.D{
 					{Key: "organisation_id", Value: 1},
 					{Key: "name", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 				},
 				Options: options.Index().SetUnique(true),
@@ -266,6 +267,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 			{
 				Keys: bson.D{
 					{Key: "group_id", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: -1},
 				},
@@ -275,6 +277,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 				Keys: bson.D{
 					{Key: "group_id", Value: 1},
 					{Key: "app_id", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: -1},
 				},
@@ -283,6 +286,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 			{
 				Keys: bson.D{
 					{Key: "app_id", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: -1},
 				},
@@ -300,6 +304,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 				Keys: bson.D{
 					{Key: "app_id", Value: 1},
 					{Key: "group_id", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: 1},
 				},
@@ -308,6 +313,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 			{
 				Keys: bson.D{
 					{Key: "app_id", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: 1},
 				},
@@ -316,6 +322,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 			{
 				Keys: bson.D{
 					{Key: "group_id", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: 1},
 				},
@@ -332,6 +339,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 			{
 				Keys: bson.D{
 					{Key: "event_id", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: 1},
 				},
@@ -339,6 +347,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 
 			{
 				Keys: bson.D{
+					{Key: "deleted_at", Value: 1},
 					{Key: "event_id", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: 1},
@@ -348,6 +357,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 
 			{
 				Keys: bson.D{
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: 1},
 					{Key: "group_id", Value: 1},
@@ -359,11 +369,13 @@ func compoundIndices() map[string][]mongo.IndexModel {
 				Keys: bson.D{
 					{Key: "uid", Value: 1},
 					{Key: "document_status", Value: 1},
+					{Key: "deleted_at", Value: 1},
 				},
 			},
 
 			{
 				Keys: bson.D{
+					{Key: "deleted_at", Value: 1},
 					{Key: "group_id", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: 1},
@@ -372,6 +384,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 
 			{
 				Keys: bson.D{
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: -1},
 					{Key: "group_id", Value: 1},
@@ -380,6 +393,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 
 			{
 				Keys: bson.D{
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: -1},
 					{Key: "app_id", Value: 1},
@@ -399,6 +413,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 				Keys: bson.D{
 					{Key: "group_id", Value: 1},
 					{Key: "document_status", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "created_at", Value: 1},
 				},
 			},
@@ -406,6 +421,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 				Keys: bson.D{
 					{Key: "group_id", Value: 1},
 					{Key: "document_status", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "title", Value: 1},
 				},
 				Options: options.Index().SetUnique(true),
@@ -417,6 +433,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 				Keys: bson.D{
 					{Key: "organisation_id", Value: 1},
 					{Key: "invitee_email", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 				},
 				Options: options.Index().SetUnique(true),
@@ -435,6 +452,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 				Keys: bson.D{
 					{Key: "organisation_id", Value: 1},
 					{Key: "user_id", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 				},
 				Options: options.Index().SetUnique(true),
@@ -445,6 +463,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 			{
 				Keys: bson.D{
 					{Key: "email", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 				},
 				Options: options.Index().SetUnique(true),
@@ -458,6 +477,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 					{Key: "group_id", Value: 1},
 					{Key: "source_id", Value: 1},
 					{Key: "endpoint_id", Value: 1},
+					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 				},
 				Options: options.Index().SetUnique(true),

--- a/services/subscription_service.go
+++ b/services/subscription_service.go
@@ -282,6 +282,8 @@ func (s *SubcriptionService) LoadSubscriptionsPaged(ctx context.Context, filter 
 					SupportEmail: a.SupportEmail,
 				}
 				appMap[sub.AppID] = aa
+			} else {
+				log.Errorf("an error occured fetching application for subscription: %v", err)
 			}
 		}
 
@@ -298,6 +300,8 @@ func (s *SubcriptionService) LoadSubscriptionsPaged(ctx context.Context, filter 
 					IsDisabled: ev.IsDisabled,
 				}
 				sourceMap[sub.SourceID] = source
+			} else {
+				log.Errorf("an error occured fetching source for subscription: %v", err)
 			}
 		}
 
@@ -314,6 +318,8 @@ func (s *SubcriptionService) LoadSubscriptionsPaged(ctx context.Context, filter 
 					RateLimitDuration: en.RateLimitDuration,
 				}
 				endpointMap[sub.EndpointID] = endpoint
+			} else {
+				log.Errorf("an error occured fetching endpoint for subscription: %v", err)
 			}
 		}
 


### PR DESCRIPTION
This PR adds the `deleted_at` field to all the compound indexes which include the `document status` field. This is because the timestamp is more unique than `Active`/`Deleted` and would prevent duplicate errors to be thrown from the mongodb driver 