### PR TITLE
Fix mongo aggregations

### DIFF
--- a/datastore/mongo/event.go
+++ b/datastore/mongo/event.go
@@ -214,7 +214,7 @@ func (db *eventRepo) LoadEventsPaged(ctx context.Context, f *datastore.Filter) (
 			{Key: "from", Value: datastore.AppCollection},
 			{Key: "localField", Value: "app_id"},
 			{Key: "foreignField", Value: "uid"},
-			{Key: "as", Value: "app"},
+			{Key: "as", Value: "app_metadata"},
 			{Key: "pipeline", Value: bson.A{
 				bson.D{
 					{Key: "$project",
@@ -229,13 +229,14 @@ func (db *eventRepo) LoadEventsPaged(ctx context.Context, f *datastore.Filter) (
 			}},
 		}},
 	}
+	unwindAppStage := bson.D{{Key: "$unwind", Value: bson.D{{Key: "path", Value: "$app_metadata"}, {Key: "preserveNullAndEmptyArrays", Value: true}}}}
 
 	sourceLookupStage := bson.D{
 		{Key: "$lookup", Value: bson.D{
 			{Key: "from", Value: datastore.SourceCollection},
 			{Key: "localField", Value: "source_id"},
 			{Key: "foreignField", Value: "uid"},
-			{Key: "as", Value: "source"},
+			{Key: "as", Value: "source_metadata"},
 			{Key: "pipeline", Value: bson.A{
 				bson.D{
 					{Key: "$project",
@@ -248,29 +249,21 @@ func (db *eventRepo) LoadEventsPaged(ctx context.Context, f *datastore.Filter) (
 			}},
 		}},
 	}
+	unwindSourceStage := bson.D{{Key: "$unwind", Value: bson.D{{Key: "path", Value: "$source_metadata"}, {Key: "preserveNullAndEmptyArrays", Value: true}}}}
 
-	projectStage := bson.D{
-		{Key: "$addFields", Value: bson.M{
-			"source_metadata": bson.M{
-				"$first": "$source",
-			},
-			"app_metadata": bson.M{
-				"$first": "$app",
-			},
-		}},
-	}
-
-	unsetStage := bson.D{{Key: "$unset", Value: []string{"app", "source"}}}
+	skipStage := bson.D{{Key: "$skip", Value: getSkip(f.Pageable.Page, f.Pageable.PerPage)}}
+	sortStage := bson.D{{Key: "$sort", Value: bson.D{{Key: "created_at", Value: -1}}}}
+	limitStage := bson.D{{Key: "$limit", Value: f.Pageable.PerPage}}
 
 	pipeline := mongo.Pipeline{
 		matchStage,
-		{{Key: "$skip", Value: getSkip(f.Pageable.Page, f.Pageable.PerPage)}},
-		{{Key: "$sort", Value: bson.D{{Key: "created_at", Value: -1}}}},
-		{{Key: "$limit", Value: f.Pageable.PerPage}},
+		skipStage,
+		sortStage,
+		limitStage,
 		appLookupStage,
 		sourceLookupStage,
-		projectStage,
-		unsetStage,
+		unwindSourceStage,
+		unwindAppStage,
 	}
 
 	var events []datastore.Event

--- a/datastore/mongo/event.go
+++ b/datastore/mongo/event.go
@@ -305,16 +305,7 @@ func (db *eventRepo) LoadEventsPaged(ctx context.Context, f *datastore.Filter) (
 }
 
 func getCreatedDateFilter(searchParams datastore.SearchParams) bson.M {
-	sf := bson.M{}
-	if searchParams.CreatedAtStart > 0 {
-		sf["$gte"] = primitive.NewDateTimeFromTime(time.Unix(searchParams.CreatedAtStart, 0))
-	}
-
-	if searchParams.CreatedAtEnd > 0 {
-		sf["$lte"] = primitive.NewDateTimeFromTime(time.Unix(searchParams.CreatedAtEnd, 0))
-	}
-
-	return sf
+	return bson.M{"$gte": primitive.NewDateTimeFromTime(time.Unix(searchParams.CreatedAtStart, 0)), "$lte": primitive.NewDateTimeFromTime(time.Unix(searchParams.CreatedAtEnd, 0))}
 }
 
 func (db *eventRepo) setCollectionInContext(ctx context.Context) context.Context {

--- a/datastore/mongo/event_delivery.go
+++ b/datastore/mongo/event_delivery.go
@@ -302,7 +302,7 @@ func (db *eventDeliveryRepo) LoadEventDeliveriesPaged(ctx context.Context, group
 			{Key: "from", Value: datastore.AppCollection},
 			{Key: "localField", Value: "app_id"},
 			{Key: "foreignField", Value: "uid"},
-			{Key: "as", Value: "app"},
+			{Key: "as", Value: "app_metadata"},
 			{Key: "pipeline", Value: bson.A{
 				bson.D{
 					{Key: "$project",
@@ -318,13 +318,14 @@ func (db *eventDeliveryRepo) LoadEventDeliveriesPaged(ctx context.Context, group
 			}},
 		}},
 	}
+	unwindAppStage := bson.D{{Key: "$unwind", Value: bson.D{{Key: "path", Value: "$app_metadata"}, {Key: "preserveNullAndEmptyArrays", Value: true}}}}
 
 	eventLookupStage := bson.D{
 		{Key: "$lookup", Value: bson.D{
 			{Key: "from", Value: datastore.EventCollection},
 			{Key: "localField", Value: "event_id"},
 			{Key: "foreignField", Value: "uid"},
-			{Key: "as", Value: "event"},
+			{Key: "as", Value: "event_metadata"},
 			{Key: "pipeline", Value: bson.A{
 				bson.D{
 					{Key: "$project",
@@ -337,13 +338,14 @@ func (db *eventDeliveryRepo) LoadEventDeliveriesPaged(ctx context.Context, group
 			}},
 		}},
 	}
+	unwindEventStage := bson.D{{Key: "$unwind", Value: bson.D{{Key: "path", Value: "$event_metadata"}, {Key: "preserveNullAndEmptyArrays", Value: true}}}}
 
 	deviceLookupStage := bson.D{
 		{Key: "$lookup", Value: bson.D{
 			{Key: "from", Value: datastore.DeviceCollection},
 			{Key: "localField", Value: "device_id"},
 			{Key: "foreignField", Value: "uid"},
-			{Key: "as", Value: "device"},
+			{Key: "as", Value: "device_metadata"},
 			{Key: "pipeline",
 				Value: bson.A{
 					bson.D{
@@ -358,20 +360,7 @@ func (db *eventDeliveryRepo) LoadEventDeliveriesPaged(ctx context.Context, group
 			},
 		}},
 	}
-
-	projectStage := bson.D{
-		{Key: "$addFields", Value: bson.M{
-			"device_metadata": bson.M{
-				"$first": "$device",
-			},
-			"event_metadata": bson.M{
-				"$first": "$event",
-			},
-			"app_metadata": bson.M{
-				"$first": "$app",
-			},
-		}},
-	}
+	unwindDeviceStage := bson.D{{Key: "$unwind", Value: bson.D{{Key: "path", Value: "$device_metadata"}, {Key: "preserveNullAndEmptyArrays", Value: true}}}}
 
 	setStage := bson.D{
 		{
@@ -400,9 +389,6 @@ func (db *eventDeliveryRepo) LoadEventDeliveriesPaged(ctx context.Context, group
 		{
 			Key: "$unset",
 			Value: []string{
-				"device",
-				"app",
-				"event",
 				"app_metadata.endpoints",
 				"endpoint_metadata.secrets",
 				"endpoint_metadata.authentication",
@@ -410,15 +396,21 @@ func (db *eventDeliveryRepo) LoadEventDeliveriesPaged(ctx context.Context, group
 		},
 	}
 
+	skipStage := bson.D{{Key: "$skip", Value: getSkip(pageable.Page, pageable.PerPage)}}
+	sortStage := bson.D{{Key: "$sort", Value: bson.D{{Key: "created_at", Value: -1}}}}
+	limitStage := bson.D{{Key: "$limit", Value: pageable.PerPage}}
+
 	pipeline := mongo.Pipeline{
 		matchStage,
-		{{Key: "$skip", Value: getSkip(pageable.Page, pageable.PerPage)}},
-		{{Key: "$sort", Value: bson.D{{Key: "created_at", Value: -1}}}},
-		{{Key: "$limit", Value: pageable.PerPage}},
+		skipStage,
+		sortStage,
+		limitStage,
 		appLookupStage,
+		unwindAppStage,
 		eventLookupStage,
+		unwindEventStage,
 		deviceLookupStage,
-		projectStage,
+		unwindDeviceStage,
 		setStage,
 		unsetStage,
 	}

--- a/datastore/mongo/mongo.go
+++ b/datastore/mongo/mongo.go
@@ -187,71 +187,74 @@ func compoundIndices() map[string][]mongo.IndexModel {
 		datastore.EventCollection: {
 			{
 				Keys: bson.D{
-					{Key: "group_id", Value: 1},
-					{Key: "deleted_at", Value: 1},
+					{Key: "created_at", Value: -1},
 					{Key: "document_status", Value: 1},
+					{Key: "group_id", Value: 1},
+				},
+			},
+
+			{
+				Keys: bson.D{
+					{Key: "created_at", Value: -1},
+					{Key: "document_status", Value: 1},
+					{Key: "source_id", Value: 1},
+				},
+			},
+
+			{
+				Keys: bson.D{
+					{Key: "created_at", Value: -1},
+					{Key: "document_status", Value: 1},
+					{Key: "app_id", Value: 1},
+				},
+			},
+
+			{
+				Keys: bson.D{
+					{Key: "created_at", Value: -1},
+					{Key: "document_status", Value: 1},
+					{Key: "group_id", Value: 1},
+					{Key: "app_id", Value: 1},
+				},
+			},
+
+			{
+				Keys: bson.D{
+					{Key: "created_at", Value: -1},
+					{Key: "document_status", Value: 1},
+					{Key: "group_id", Value: 1},
+					{Key: "source_id", Value: 1},
+				},
+			},
+
+			{
+				Keys: bson.D{
+					{Key: "created_at", Value: -1},
+					{Key: "document_status", Value: 1},
+					{Key: "app_id", Value: 1},
+					{Key: "source_id", Value: 1},
+				},
+			},
+
+			{
+				Keys: bson.D{
+					{Key: "created_at", Value: -1},
+					{Key: "document_status", Value: 1},
+					{Key: "group_id", Value: 1},
+					{Key: "source_id", Value: 1},
+					{Key: "app_id", Value: 1},
+				},
+			},
+
+			{
+				Keys: bson.D{
 					{Key: "created_at", Value: -1},
 				},
 			},
 
 			{
 				Keys: bson.D{
-					{Key: "group_id", Value: 1},
-					{Key: "app_id", Value: 1},
-					{Key: "deleted_at", Value: 1},
-					{Key: "document_status", Value: 1},
-					{Key: "created_at", Value: -1},
-				},
-			},
-
-			{
-				Keys: bson.D{
-					{Key: "app_id", Value: 1},
-					{Key: "deleted_at", Value: 1},
-					{Key: "document_status", Value: 1},
-					{Key: "created_at", Value: -1},
-				},
-			},
-
-			{
-				Keys: bson.D{
-					{Key: "group_id", Value: 1},
-					{Key: "app_id", Value: 1},
-					{Key: "created_at", Value: -1},
-				},
-			},
-
-			{
-				Keys: bson.D{
-					{Key: "app_id", Value: 1},
-					{Key: "group_id", Value: 1},
-					{Key: "deleted_at", Value: 1},
-					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: 1},
-				},
-			},
-
-			{
-				Keys: bson.D{
-					{Key: "app_id", Value: 1},
-					{Key: "deleted_at", Value: 1},
-					{Key: "document_status", Value: 1},
-					{Key: "created_at", Value: 1},
-				},
-			},
-
-			{
-				Keys: bson.D{
-					{Key: "group_id", Value: 1},
-					{Key: "deleted_at", Value: 1},
-					{Key: "document_status", Value: 1},
-					{Key: "created_at", Value: 1},
-				},
-			},
-
-			{
-				Keys: bson.D{
-					{Key: "created_at", Value: -1},
 				},
 			},
 		},
@@ -259,26 +262,23 @@ func compoundIndices() map[string][]mongo.IndexModel {
 		datastore.EventDeliveryCollection: {
 			{
 				Keys: bson.D{
-					{Key: "event_id", Value: 1},
-					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: 1},
+					{Key: "event_id", Value: 1},
 				},
 			},
 
 			{
 				Keys: bson.D{
-					{Key: "event_id", Value: 1},
-					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: 1},
+					{Key: "event_id", Value: 1},
 					{Key: "status", Value: 1},
 				},
 			},
 
 			{
 				Keys: bson.D{
-					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: 1},
 					{Key: "group_id", Value: 1},
@@ -289,23 +289,20 @@ func compoundIndices() map[string][]mongo.IndexModel {
 			{
 				Keys: bson.D{
 					{Key: "uid", Value: 1},
-					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 				},
 			},
 
 			{
 				Keys: bson.D{
-					{Key: "group_id", Value: 1},
-					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: 1},
+					{Key: "group_id", Value: 1},
 				},
 			},
 
 			{
 				Keys: bson.D{
-					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: -1},
 					{Key: "group_id", Value: 1},
@@ -314,7 +311,6 @@ func compoundIndices() map[string][]mongo.IndexModel {
 
 			{
 				Keys: bson.D{
-					{Key: "deleted_at", Value: 1},
 					{Key: "document_status", Value: 1},
 					{Key: "created_at", Value: -1},
 					{Key: "app_id", Value: 1},
@@ -325,6 +321,12 @@ func compoundIndices() map[string][]mongo.IndexModel {
 			{
 				Keys: bson.D{
 					{Key: "created_at", Value: -1},
+				},
+			},
+
+			{
+				Keys: bson.D{
+					{Key: "created_at", Value: 1},
 				},
 			},
 		},

--- a/datastore/mongo/subscription.go
+++ b/datastore/mongo/subscription.go
@@ -196,25 +196,21 @@ func (s *subscriptionRepo) LoadSubscriptionsPaged(ctx context.Context, groupId s
 		},
 	}
 	unwindEndpointStage := bson.D{{Key: "$unwind", Value: bson.D{{Key: "path", Value: "$endpoint_metadata"}, {Key: "preserveNullAndEmptyArrays", Value: true}}}}
-	sortAndLimitStages := []bson.D{
-		{{Key: "$sort", Value: bson.D{{Key: "created_at", Value: -1}}}},
-		{{Key: "$sort", Value: bson.D{{Key: "_id", Value: 1}}}},
-		{{Key: "$skip", Value: getSkip(pageable.Page, pageable.PerPage)}},
-		{{Key: "$limit", Value: pageable.PerPage}},
-	}
 
 	// pipeline definition
 	pipeline := mongo.Pipeline{
 		matchStage,
+		{{Key: "$skip", Value: getSkip(pageable.Page, pageable.PerPage)}},
+		{{Key: "$sort", Value: bson.D{{Key: "created_at", Value: -1}}}},
+		{{Key: "$limit", Value: pageable.PerPage}},
 		appStage,
-		unwindAppStage,
 		sourceStage,
-		unwindSourceStage,
 		endpointStage,
+		unwindAppStage,
+		unwindSourceStage,
 		unwindEndpointStage,
 	}
 
-	pipeline = append(pipeline, sortAndLimitStages...)
 	err := s.store.Aggregate(ctx, pipeline, &subscriptions, true)
 	if err != nil {
 		return nil, datastore.PaginationData{}, err

--- a/datastore/mongo/subscription.go
+++ b/datastore/mongo/subscription.go
@@ -196,13 +196,16 @@ func (s *subscriptionRepo) LoadSubscriptionsPaged(ctx context.Context, groupId s
 		},
 	}
 	unwindEndpointStage := bson.D{{Key: "$unwind", Value: bson.D{{Key: "path", Value: "$endpoint_metadata"}, {Key: "preserveNullAndEmptyArrays", Value: true}}}}
+	skipStage := bson.D{{Key: "$skip", Value: getSkip(pageable.Page, pageable.PerPage)}}
+	sortStage := bson.D{{Key: "$sort", Value: bson.D{{Key: "created_at", Value: -1}}}}
+	limitStage := bson.D{{Key: "$limit", Value: pageable.PerPage}}
 
 	// pipeline definition
 	pipeline := mongo.Pipeline{
 		matchStage,
-		{{Key: "$skip", Value: getSkip(pageable.Page, pageable.PerPage)}},
-		{{Key: "$sort", Value: bson.D{{Key: "created_at", Value: -1}}}},
-		{{Key: "$limit", Value: pageable.PerPage}},
+		skipStage,
+		sortStage,
+		limitStage,
 		appStage,
 		sourceStage,
 		endpointStage,


### PR DESCRIPTION
For mongodb aggregations, the hack is to `skip`, `sort` and `limit(n)` immediately, then we'd only have to do `lookups` on the remaining `n` records.