### PR TITLE
feat: Preview Environments for PRs — Uffizzi Integration

### DIFF
--- a/.github/workflows/uffizzi-build.yml
+++ b/.github/workflows/uffizzi-build.yml
@@ -1,0 +1,104 @@
+name: Build PR Image
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed, review_requested]
+
+jobs:
+
+  build-convoy:
+    name: Build and push `Convoy`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    if: ${{ github.event.action != 'closed' }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "UUID_WORKER=$(uuidgen)" >> $GITHUB_ENV
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ttl.sh/${{ env.UUID_WORKER }}
+          tags: type=raw,value=60d
+      
+      - name: Build and Push Image to registry.uffizzi.com - Uffizzi's ephemeral Registry
+        uses: docker/build-push-action@v3
+        with:
+          context: ./
+          file: ./Dockerfile.uffizzi
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha, mode=max
+
+  render-compose-file:
+    name: Render Docker Compose File
+    # Pass output of this workflow to another triggered by `workflow_run` event.
+    runs-on: ubuntu-latest
+    needs:
+      - build-convoy
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          CONVOY_IMAGE=${{ needs.build-convoy.outputs.tags }}
+          export CONVOY_IMAGE
+          export UFFIZZI_URL=\$UFFIZZI_URL
+          GHA_ACTOR=${{github.actor}}
+          GHA_REPO=${{github.event.repository.name}}
+          GHA_BRANCH=${{github.head_ref}}
+          export GHA_ACTOR GHA_REPO GHA_BRANCH
+          # Render simple template from environment variables.
+          envsubst < docker-compose.uffizzi.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Upload Rendered Compose File as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: docker-compose.rendered.yml
+          retention-days: 2
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2
+
+  delete-preview:
+    name: Call for Preview Deletion
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'closed' }}
+    steps:
+      # If this PR is closing, we will not render a compose file nor pass it to the next workflow.
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }}
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2

--- a/.github/workflows/uffizzi-preview.yml
+++ b/.github/workflows/uffizzi-preview.yml
@@ -1,0 +1,88 @@
+name: Deploy Uffizzi Preview
+
+on:
+  workflow_run:
+    workflows:
+      - "Build PR Image"
+    types:
+      - completed
+
+
+jobs:
+  cache-compose-file:
+    name: Cache Compose File
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      compose-file-cache-key: ${{ env.HASH }}
+      pr-number: ${{ env.PR_NUMBER }}
+    steps:
+      - name: 'Download artifacts'
+        # Fetch output (zip archive) from the workflow run that triggered this workflow.
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "preview-spec"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
+
+      - name: 'Unzip artifact'
+        run: unzip preview-spec.zip
+      - name: Read Event into ENV
+        run: |
+          echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
+          cat event.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+
+      - name: Hash Rendered Compose File
+        id: hash
+        # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        run: echo "HASH=$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')" >> $GITHUB_ENV
+      - name: Cache Rendered Compose File
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
+        uses: actions/cache@v3
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ env.HASH }}
+
+      - name: Read PR Number From Event Object
+        id: pr
+        run: echo "PR_NUMBER=${{ fromJSON(env.EVENT_JSON).number }}" >> $GITHUB_ENV
+      - name: DEBUG - Print Job Outputs
+        if: ${{ runner.debug }}
+        run: |
+          echo "PR number: ${{ env.PR_NUMBER }}"
+          echo "Compose file hash: ${{ env.HASH }}"
+          cat event.json
+
+  deploy-uffizzi-preview:
+    name: Use Remote Workflow to Preview on Uffizzi
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    needs:
+      - cache-compose-file
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2test
+    with:
+      # If this workflow was triggered by a PR close event, cache-key will be an empty string
+      # and this reusable workflow will delete the preview deployment.
+      compose-file-cache-key: ${{ needs.cache-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: docker-compose.rendered.yml
+      server: https://app.uffizzi.com
+      pr-number: ${{ needs.cache-compose-file.outputs.pr-number }}
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write

--- a/Dockerfile.uffizzi
+++ b/Dockerfile.uffizzi
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+FROM node:14 as node-env
+WORKDIR /app
+COPY ./web/ui/dashboard .
+RUN git config --global url."https://".insteadOf git://
+RUN npm install
+RUN npm run build
+
+FROM golang:1.16 as build-env
+WORKDIR /go/src/frain-dev/convoy
+
+COPY ./go.mod /go/src/frain-dev/convoy
+COPY ./go.sum /go/src/frain-dev/convoy
+
+COPY --from=node-env /app/dist /go/src/frain-dev/convoy/server/ui/build
+# Get dependancies - will also be cached if we don't change mod/sum
+RUN go mod download
+RUN go mod verify
+
+# COPY the source code as the last step
+COPY . .
+
+RUN CGO_ENABLED=0
+RUN go install ./cmd
+
+FROM gcr.io/distroless/base:debug
+COPY --from=busybox:1.35.0-uclibc /bin/sh /bin/sh
+COPY --from=build-env /go/bin/cmd /
+COPY --from=build-env /go/src/frain-dev/convoy/internal/email/templates/* templates/
+
+ENTRYPOINT ["/cmd"]
+CMD [ "server", "--config", "convoy.json" ]

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,7 @@ var DefaultConfiguration = Configuration{
 	Queue: QueueConfiguration{
 		Type: RedisQueueProvider,
 		Redis: RedisQueueConfiguration{
-			Dsn: "redis://localhost:6378",
+			Dsn: "redis://localhost:6379",
 		},
 	},
 	Logger: LoggerConfiguration{

--- a/datastore/mongo/mongo.go
+++ b/datastore/mongo/mongo.go
@@ -22,7 +22,7 @@ type Client struct {
 }
 
 func New(cfg config.Configuration) (*Client, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	opts := options.Client()
@@ -35,7 +35,7 @@ func New(cfg config.Configuration) (*Client, error) {
 		return nil, err
 	}
 
-	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	if err := client.Ping(ctx, nil); err != nil {
@@ -142,7 +142,7 @@ func (c *Client) ensureIndex(collectionName string, field string, unique bool, p
 		Options: createIndexOpts,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	collection := c.db.Collection(collectionName)
@@ -159,7 +159,7 @@ func (c *Client) ensureIndex(collectionName string, field string, unique bool, p
 func (c *Client) ensureCompoundIndex(collectionName string) bool {
 	collection := c.db.Collection(collectionName)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	compoundIndices := compoundIndices()

--- a/docker-compose.uffizzi.yml
+++ b/docker-compose.uffizzi.yml
@@ -1,0 +1,67 @@
+version: "3"
+
+x-uffizzi:
+  ingress:
+    service: web
+    port: 5005
+
+services:
+    web:
+        image: "${CONVOY_IMAGE}"
+        entrypoint: ["/bin/sh"] 
+        command: /uffizzi/start.sh
+        ports:
+        - "5005:5005"
+        volumes:
+            - ./uffizzi:/uffizzi
+        deploy:
+          resources:
+            limits:
+              memory: 2000M
+    
+    scheduler:
+        image: "${CONVOY_IMAGE}"
+        volumes:
+            - ./uffizzi:/uffizzi:rw
+        entrypoint: ["./cmd", "scheduler", "--config", "./uffizzi/convoy-uffizzi.json"]
+        deploy:
+          resources:
+            limits:
+              memory: 1000M
+
+    worker:
+        image: "${CONVOY_IMAGE}"
+        volumes:
+            - ./uffizzi:/uffizzi:rw
+        entrypoint: ["./cmd", "worker", "--config", "./uffizzi/convoy-uffizzi.json"]
+        deploy:
+          resources:
+            limits:
+              memory: 2000M
+
+    mongo:
+      image: mongo:5.0.14
+      entrypoint: ["/usr/bin/mongod", "--replSet", "localhost"]
+      ports: 
+        - "27017:27017"
+        - "27018:27018"
+        - "27019:27019"
+      deploy:
+          resources:
+            limits:
+              memory: 2000M  
+   
+    mongosetup:
+        image: mongo:5.0.14
+        entrypoint: [ "bash", "-c", "sleep 10 && mongo --host 127.0.0.1:27017 --eval 'rs.initiate()'"]    
+        deploy:
+          resources:
+            limits:
+              memory: 1000M   
+
+    redis_server:
+        image: redis:alpine
+        deploy:
+          resources:
+            limits:
+              memory: 500M

--- a/uffizzi/convoy-uffizzi.json
+++ b/uffizzi/convoy-uffizzi.json
@@ -1,0 +1,48 @@
+{
+    "environment": "dev",
+    "queue": {
+        "type": "redis",
+        "redis": {
+            "dsn": "redis://localhost:6379"
+        }
+    },
+    "cache": {
+        "type": "redis",
+        "redis": {
+            "dsn": "redis://localhost:6379"
+        }
+    },
+    "host": "localhost:5005",
+    "base_url": "localhost:5005",
+    "logger": {
+        "level": "info"
+    },
+    "server": {
+        "http": {
+            "ssl": false,
+            "ssl_cert_file": "",
+            "ssl_key_file": "",
+            "port": 5005
+        }
+    },
+    "database": {
+        "type": "mongo",
+        "dsn": "mongodb://127.0.0.1:27017/convoy?replicaSet=localhost"
+    },
+    "auth": {
+        "jwt": {
+            "enabled": true
+        },
+        "file": {
+            "basic": [
+                {
+                    "username": "test",
+                    "password": "test",
+                    "role": {
+                        "type": "super_user"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/uffizzi/start.sh
+++ b/uffizzi/start.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+cat ./uffizzi/convoy-uffizzi.json > convoy.json
+./cmd migrate up
+./cmd server --config convoy.json

--- a/web/ui/dashboard/package-lock.json
+++ b/web/ui/dashboard/package-lock.json
@@ -42517,7 +42517,9 @@
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
 			"integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
 			"dev": true,
-			"requires": {}
+			"requires": {
+				"ajv": "^8.0.0"
+			}
 		},
 		"ajv-keywords": {
 			"version": "5.1.0",
@@ -55464,6 +55466,7 @@
 				"normalize-path": "^3.0.0",
 				"object-hash": "^3.0.0",
 				"picocolors": "^1.0.0",
+				"postcss": "^8.4.18",
 				"postcss-import": "^14.1.0",
 				"postcss-js": "^4.0.0",
 				"postcss-load-config": "^3.1.4",


### PR DESCRIPTION
Fixes #1275 

A WiP PR for Uffizzi Integration with Convoy. 

This PR uses two GHA workflows — `uffizzi-build.yml` and `uffizzi-preview.yml` — to build and provision preview environments. 

This PR uses `convoy's Dockerfile` to build `convoy worker`, `convoy scheduler` and `convoy web` from source, ensuring changes are reflected in the preview environment. These containers are defined in the `docker-compose.uffizzi.yml` file, which adds the `Uffizzi` integration to `convoy`. Other containers include `redis server` and `replica set Mongo servers (2 in total)`. 

[Here is a test PR](https://github.com/ShrutiC-git/convoy/pull/1) opened on my fork. The [comment posted on the PR](https://github.com/ShrutiC-git/convoy/pull/1#issuecomment-1400380156) will take me to the preview. 

Opening this draft PR to get some help on getting the previews functional and efficient for the `convoy` community.