### PR TITLE
Fix search indexer

### DIFF
--- a/datastore/filter.go
+++ b/datastore/filter.go
@@ -41,7 +41,7 @@ type FilterBy struct {
 func (f *FilterBy) String() *string {
 	var s string
 	filterByBuilder := new(strings.Builder)
-	filterByBuilder.WriteString(fmt.Sprintf("group_id:=%s", f.ProjectID)) // TODO(daniel, RT): how to work around this?
+	filterByBuilder.WriteString(fmt.Sprintf("project_id:=%s", f.ProjectID)) // TODO(daniel, RT): how to work around this?
 	filterByBuilder.WriteString(fmt.Sprintf(" && created_at:[%d..%d]", f.SearchParams.CreatedAtStart, f.SearchParams.CreatedAtEnd))
 
 	if len(f.EndpointID) > 0 {

--- a/datastore/filter_test.go
+++ b/datastore/filter_test.go
@@ -16,7 +16,7 @@ func Test_FilterBy(t *testing.T) {
 	args := []Args{
 		{
 			name:     "complete_filter",
-			expected: "group_id:=uid-1 && created_at:[0..1] && app_id:=app-1",
+			expected: "project_id:=uid-1 && created_at:[0..1] && app_id:=app-1",
 			filter: FilterBy{
 				EndpointID: "app-1",
 				ProjectID:  "uid-1",
@@ -28,7 +28,7 @@ func Test_FilterBy(t *testing.T) {
 		},
 		{
 			name:     "missing_app_id",
-			expected: "group_id:=uid-1 && created_at:[0..1]",
+			expected: "project_id:=uid-1 && created_at:[0..1]",
 			filter: FilterBy{
 				ProjectID: "uid-1",
 				SearchParams: SearchParams{

--- a/datastore/mongo/mongo.go
+++ b/datastore/mongo/mongo.go
@@ -106,7 +106,7 @@ func (c *Client) ensureMongoIndices() {
 	c.ensureIndex(datastore.EventCollection, "endpoints", false, nil)
 	c.ensureIndex(datastore.EventCollection, "project_id", false, nil)
 
-	c.ensureIndex(datastore.EventDeliveryCollection, "group_id", false, nil)
+	c.ensureIndex(datastore.EventDeliveryCollection, "project_id", false, nil)
 	c.ensureIndex(datastore.EventDeliveryCollection, "status", false, nil)
 
 	c.ensureIndex(datastore.SourceCollection, "uid", true, nil)
@@ -326,7 +326,7 @@ func compoundIndices() map[string][]mongo.IndexModel {
 					{Key: "endpoint_id", Value: 1},
 					{Key: "deleted_at", Value: 1},
 					{Key: "created_at", Value: 1},
-					{Key: "group_id", Value: 1},
+					{Key: "project_id", Value: 1},
 					{Key: "status", Value: 1},
 				},
 			},
@@ -350,14 +350,14 @@ func compoundIndices() map[string][]mongo.IndexModel {
 				Keys: bson.D{
 					{Key: "deleted_at", Value: 1},
 					{Key: "created_at", Value: -1},
-					{Key: "group_id", Value: 1},
+					{Key: "project_id", Value: 1},
 				},
 			},
 
 			{
 				Keys: bson.D{
 					{Key: "created_at", Value: 1},
-					{Key: "group_id", Value: 1},
+					{Key: "project_id", Value: 1},
 				},
 			},
 

--- a/internal/pkg/searcher/noop/client.go
+++ b/internal/pkg/searcher/noop/client.go
@@ -1,7 +1,6 @@
 package noopsearcher
 
 import (
-	"github.com/frain-dev/convoy"
 	"github.com/frain-dev/convoy/datastore"
 )
 
@@ -16,7 +15,7 @@ func (n *NoopSearcher) Search(collection string, filter *datastore.SearchFilter)
 	return make([]string, 0), datastore.PaginationData{}, nil
 }
 
-func (n *NoopSearcher) Index(collection string, document convoy.GenericMap) error {
+func (n *NoopSearcher) Index(collection string, document map[string]interface{}) error {
 	return nil
 }
 

--- a/internal/pkg/searcher/searcher.go
+++ b/internal/pkg/searcher/searcher.go
@@ -1,7 +1,6 @@
 package searcher
 
 import (
-	"github.com/frain-dev/convoy"
 	"github.com/frain-dev/convoy/config"
 	"github.com/frain-dev/convoy/datastore"
 	noopsearcher "github.com/frain-dev/convoy/internal/pkg/searcher/noop"
@@ -14,7 +13,7 @@ type Searcher interface {
 
 	// Index upserts the collection and indexes documents in the typesense collection,
 	// each document must have the id, uid, created_at and updated_at fields
-	Index(collection string, document convoy.GenericMap) error
+	Index(collection string, document map[string]interface{}) error
 
 	// Remove removes documents from the typesense collection based on the search filters
 	Remove(collection string, filter *datastore.SearchFilter) error

--- a/internal/pkg/searcher/typesense/client.go
+++ b/internal/pkg/searcher/typesense/client.go
@@ -2,19 +2,15 @@ package typesense
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"strings"
 	"time"
 
-	"github.com/frain-dev/convoy"
 	"github.com/frain-dev/convoy/datastore"
 	"github.com/frain-dev/convoy/pkg/flatten"
 	"github.com/typesense/typesense-go/typesense"
 	"github.com/typesense/typesense-go/typesense/api"
 )
-
-const DateFormat = "2006-01-02T15:04:05Z07:00"
 
 var ErrIDFieldIsRequired = errors.New("id field does not exist on the document")
 
@@ -65,16 +61,6 @@ func (t *Typesense) Search(collection string, f *datastore.SearchFilter) ([]stri
 	sortBy := "created_at:desc"
 
 	sp := &api.MultiSearchParams{}
-
-	fmt.Printf("%+v", api.MultiSearchParameters{
-		Q:        &f.Query,
-		QueryBy:  &queryBy,
-		SortBy:   &sortBy,
-		FilterBy: f.FilterBy.String(),
-		Page:     &f.Pageable.Page,
-		PerPage:  &f.Pageable.PerPage,
-	})
-
 	msp := api.MultiSearchSearchesParameter{
 		Searches: []api.MultiSearchCollectionParameters{
 			{
@@ -123,7 +109,7 @@ func (t *Typesense) Search(collection string, f *datastore.SearchFilter) ([]stri
 	return docs, data, nil
 }
 
-func (t *Typesense) Index(collection string, document convoy.GenericMap) error {
+func (t *Typesense) Index(collection string, document map[string]interface{}) error {
 	// perform schema validation
 	if _, found := document["id"]; !found {
 		return ErrIDFieldIsRequired
@@ -139,7 +125,7 @@ func (t *Typesense) Index(collection string, document convoy.GenericMap) error {
 
 	if c, found := document["created_at"]; found {
 		if created_at, ok := c.(string); ok {
-			createdAt, err := time.Parse(DateFormat, created_at)
+			createdAt, err := time.Parse(time.RFC3339, created_at)
 			if err != nil {
 				return err
 			}
@@ -153,7 +139,7 @@ func (t *Typesense) Index(collection string, document convoy.GenericMap) error {
 
 	if u, found := document["updated_at"]; found {
 		if updated_at, ok := u.(string); ok {
-			updatedAt, err := time.Parse(DateFormat, updated_at)
+			updatedAt, err := time.Parse(time.RFC3339, updated_at)
 			if err != nil {
 				return err
 			}

--- a/internal/pkg/searcher/typesense/client_test.go
+++ b/internal/pkg/searcher/typesense/client_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/frain-dev/convoy"
 	"github.com/frain-dev/convoy/datastore"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -21,12 +20,12 @@ type Person struct {
 	UID       string `json:"uid,omitempty"`
 	Name      string `json:"name,omitempty"`
 	Age       int    `json:"age,omitempty"`
-	GroupID   string `json:"group_id,omitempty"`
+	ProjectID string `json:"project_id,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`
 	UpdatedAt string `json:"updated_at,omitempty"`
 }
 
-func (p *Person) toGenericMap(document *convoy.GenericMap) error {
+func toGenericMap(p Person, document *map[string]interface{}) error {
 	// convert event to map
 	eBytes, err := json.Marshal(p)
 	if err != nil {
@@ -76,8 +75,8 @@ func Test_IndexOne(t *testing.T) {
 		UpdatedAt: "2022-09-02T15:04:05+01:00",
 	}
 
-	var doc convoy.GenericMap
-	err = p.toGenericMap(&doc)
+	var doc map[string]interface{}
+	err = toGenericMap(p, &doc)
 	require.NoError(t, err)
 
 	err = ts.Index(testCollection, doc)
@@ -99,14 +98,14 @@ func Test_IndexMutiple(t *testing.T) {
 			Age:       1,
 			Name:      "subomi",
 			UID:       "uid-1",
-			GroupID:   "group-1",
+			ProjectID: "project-1",
 			ID:        uuid.NewString(),
 			CreatedAt: "2022-09-02T15:04:05+01:00",
 			UpdatedAt: "2022-09-02T15:04:05+01:00",
 		},
 		{
 			Age:       2,
-			GroupID:   "group-1",
+			ProjectID: "project-1",
 			Name:      "raymond",
 			ID:        uuid.NewString(),
 			UID:       "uid-2",
@@ -117,7 +116,7 @@ func Test_IndexMutiple(t *testing.T) {
 			Age:       2,
 			ID:        uuid.NewString(),
 			Name:      "emmanuel",
-			GroupID:   "group-1",
+			ProjectID: "project-1",
 			UID:       "uid-3",
 			CreatedAt: "2022-08-02T15:04:05+01:00",
 			UpdatedAt: "2022-09-02T15:04:05+01:00",
@@ -125,8 +124,8 @@ func Test_IndexMutiple(t *testing.T) {
 	}
 
 	for _, p := range people {
-		var doc convoy.GenericMap
-		err = p.toGenericMap(&doc)
+		var doc map[string]interface{}
+		err = toGenericMap(p, &doc)
 		require.NoError(t, err)
 
 		err = ts.Index(testCollection, doc)
@@ -159,7 +158,7 @@ func Test_Index(t *testing.T) {
 				ID:        uuid.NewString(),
 				UID:       "uid-5",
 				Age:       5,
-				GroupID:   "group-1",
+				ProjectID: "project-1",
 				Name:      "emmanuella",
 				CreatedAt: "2022-09-02T15:04:05+01:00",
 				UpdatedAt: "2022-09-02T15:04:05+01:00",
@@ -173,7 +172,7 @@ func Test_Index(t *testing.T) {
 			name: "Should fail to index the document - missing id field",
 			person: Person{
 				Age:       5,
-				GroupID:   "group-1",
+				ProjectID: "project-1",
 				Name:      "emmanuella",
 				CreatedAt: "2022-09-02T15:04:05+01:00",
 				UpdatedAt: "2022-09-02T15:04:05+01:00",
@@ -189,7 +188,7 @@ func Test_Index(t *testing.T) {
 			person: Person{
 				ID:        uuid.NewString(),
 				Age:       5,
-				GroupID:   "group-1",
+				ProjectID: "project-1",
 				UID:       "uid-2",
 				Name:      "emmanuella",
 				UpdatedAt: "2022-09-02T15:04:05+01:00",
@@ -205,7 +204,7 @@ func Test_Index(t *testing.T) {
 			person: Person{
 				Age:       5,
 				ID:        uuid.NewString(),
-				GroupID:   "group-1",
+				ProjectID: "project-1",
 				UID:       "uid-2",
 				Name:      "emmanuella",
 				CreatedAt: "2022-09-02T15:04:05+01:00",
@@ -221,7 +220,7 @@ func Test_Index(t *testing.T) {
 			person: Person{
 				Age:       5,
 				ID:        uuid.NewString(),
-				GroupID:   "group-1",
+				ProjectID: "project-1",
 				Name:      "emmanuella",
 				CreatedAt: "2022-09-02T15:04:05+01:00",
 			},
@@ -239,8 +238,8 @@ func Test_Index(t *testing.T) {
 			require.NoError(t, err)
 			defer deleteCollection(t, ts, testCollection)
 
-			var doc convoy.GenericMap
-			err = tt.person.toGenericMap(&doc)
+			var doc map[string]interface{}
+			err = toGenericMap(tt.person, &doc)
 			require.NoError(t, err)
 
 			err = ts.Index(testCollection, doc)
@@ -265,7 +264,7 @@ func Test_Search(t *testing.T) {
 			UID:       "uid-1",
 			ID:        uuid.NewString(),
 			Age:       1,
-			GroupID:   "group-1",
+			ProjectID: "project-1",
 			Name:      "subomi",
 			CreatedAt: "2022-09-02T15:04:05+01:00",
 			UpdatedAt: "2022-09-02T15:04:05+01:00",
@@ -274,7 +273,7 @@ func Test_Search(t *testing.T) {
 			ID:        uuid.NewString(),
 			UID:       "uid-2",
 			Age:       2,
-			GroupID:   "group-1",
+			ProjectID: "project-1",
 			Name:      "raymond",
 			CreatedAt: "2022-08-02T15:04:05+01:00",
 			UpdatedAt: "2022-09-02T15:04:05+01:00",
@@ -283,7 +282,7 @@ func Test_Search(t *testing.T) {
 			ID:        uuid.NewString(),
 			UID:       "uid-3",
 			Age:       2,
-			GroupID:   "group-1",
+			ProjectID: "project-1",
 			Name:      "emmanuel",
 			CreatedAt: "2022-08-02T15:04:05+01:00",
 			UpdatedAt: "2022-09-02T15:04:05+01:00",
@@ -291,7 +290,7 @@ func Test_Search(t *testing.T) {
 		{
 			ID:        uuid.NewString(),
 			UID:       "uid-4",
-			GroupID:   "group-1",
+			ProjectID: "project-1",
 			Age:       3,
 			Name:      "pelumi",
 			CreatedAt: "2022-09-02T15:04:05+01:00",
@@ -300,7 +299,7 @@ func Test_Search(t *testing.T) {
 		{
 			ID:        uuid.NewString(),
 			UID:       "uid-5",
-			GroupID:   "group-1",
+			ProjectID: "project-1",
 			Age:       5,
 			Name:      "emmanuella",
 			CreatedAt: "2022-09-02T15:04:05+01:00",
@@ -310,8 +309,8 @@ func Test_Search(t *testing.T) {
 
 	// seed the search db
 	for _, e := range people {
-		var doc convoy.GenericMap
-		err = e.toGenericMap(&doc)
+		var doc map[string]interface{}
+		err = toGenericMap(e, &doc)
 		require.NoError(t, err)
 
 		err = ts.Index(testCollection, doc)
@@ -353,7 +352,7 @@ func Test_Search(t *testing.T) {
 			pp, _, err := ts.Search(testCollection, &datastore.SearchFilter{
 				Query: tt.query,
 				FilterBy: datastore.FilterBy{
-					ProjectID: "group-1",
+					ProjectID: "project-1",
 					SearchParams: datastore.SearchParams{
 						CreatedAtStart: 0,
 						CreatedAtEnd:   10000000000,

--- a/internal/pkg/socket/server.go
+++ b/internal/pkg/socket/server.go
@@ -156,7 +156,7 @@ func (h *Hub) watchEventDeliveriesCollection() func(doc map[string]interface{}) 
 		}
 
 		// map[Data:base64Str Subtype:int]
-		var dataMap convoy.GenericMap
+		var dataMap map[string]interface{}
 		err = json.Unmarshal(ed.Metadata.Data, &dataMap)
 		if err != nil {
 			log.WithError(err).Error("failed to unmarshal metadata")
@@ -287,14 +287,14 @@ func watchCollection(fn func(map[string]interface{}), collection string, stop ch
 		default:
 			ok := cs.Next(ctx)
 			if ok {
-				var document *convoy.GenericMap
+				var document *map[string]interface{}
 				err := cs.Decode(&document)
 				if err != nil {
 					return err
 				}
 
 				if (*document)["operationType"].(string) == "insert" {
-					doc := (*document)["fullDocument"].(convoy.GenericMap)
+					doc := (*document)["fullDocument"].(map[string]interface{})
 					fn(doc)
 				}
 			}

--- a/mocks/searcher.go
+++ b/mocks/searcher.go
@@ -7,7 +7,6 @@ package mocks
 import (
 	reflect "reflect"
 
-	convoy "github.com/frain-dev/convoy"
 	datastore "github.com/frain-dev/convoy/datastore"
 	gomock "github.com/golang/mock/gomock"
 )
@@ -36,7 +35,7 @@ func (m *MockSearcher) EXPECT() *MockSearcherMockRecorder {
 }
 
 // Index mocks base method.
-func (m *MockSearcher) Index(collection string, document convoy.GenericMap) error {
+func (m *MockSearcher) Index(collection string, document map[string]interface{}) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Index", collection, document)
 	ret0, _ := ret[0].(error)

--- a/type.go
+++ b/type.go
@@ -14,8 +14,6 @@ type QueueName string
 
 type CacheKey string
 
-type GenericMap map[string]interface{}
-
 //go:embed VERSION
 var f embed.FS
 

--- a/worker/task/index_document.go
+++ b/worker/task/index_document.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/frain-dev/convoy"
-	"github.com/frain-dev/convoy/datastore"
 	"github.com/frain-dev/convoy/internal/pkg/searcher"
 	"github.com/frain-dev/convoy/pkg/log"
 	"github.com/hibiken/asynq"
@@ -26,40 +24,22 @@ func SearchIndex(search searcher.Searcher) func(ctx context.Context, t *asynq.Ta
 
 		buf := t.Payload()
 
-		var event datastore.Event
-		err := json.Unmarshal(buf, &event)
+		var payload map[string]interface{}
+		err := json.Unmarshal(buf, &payload)
 		if err != nil {
 			log.WithError(err).Error("[json]: failed to unmarshal event payload")
 			return &EndpointError{Err: err, delay: defaultDelay}
 		}
 
-		// convert event data field to map
-		rawData := event.Data
-		var eventData *convoy.GenericMap
-		err = json.Unmarshal(rawData, &eventData)
-		if err != nil {
-			return err
+		event, ok := payload["Event"].(map[string]interface{})
+		if !ok {
+			log.WithError(err).Error("[type cast]: type could not be cast to map[string]interface{}")
 		}
 
-		// convert event to bytes
-		eBytes, err := json.Marshal(event)
-		if err != nil {
-			return err
-		}
-
-		// convert event to map
-		var document convoy.GenericMap
-		err = json.Unmarshal(eBytes, &document)
-		if err != nil {
-			return err
-		}
-
-		document["data"] = eventData
-		document["id"] = document["uid"]
-
-		if g, found := document["project_id"]; found {
+		event["id"] = event["uid"]
+		if g, found := event["project_id"]; found {
 			if project_id, ok := g.(string); ok {
-				err = search.Index(project_id, document)
+				err = search.Index(project_id, event)
 				if err != nil {
 					log.Errorf("[typesense] error indexing event: %s", err)
 					return &EndpointError{Err: err, delay: time.Second * 5}

--- a/worker/task/index_document.go
+++ b/worker/task/index_document.go
@@ -24,16 +24,11 @@ func SearchIndex(search searcher.Searcher) func(ctx context.Context, t *asynq.Ta
 
 		buf := t.Payload()
 
-		var payload map[string]interface{}
-		err := json.Unmarshal(buf, &payload)
+		var event map[string]interface{}
+		err := json.Unmarshal(buf, &event)
 		if err != nil {
 			log.WithError(err).Error("[json]: failed to unmarshal event payload")
 			return &EndpointError{Err: err, delay: defaultDelay}
-		}
-
-		event, ok := payload["Event"].(map[string]interface{})
-		if !ok {
-			log.WithError(err).Error("[type cast]: type could not be cast to map[string]interface{}")
 		}
 
 		event["id"] = event["uid"]

--- a/worker/task/index_document_test.go
+++ b/worker/task/index_document_test.go
@@ -36,6 +36,7 @@ func TestIndexDocument(t *testing.T) {
 				ProjectID: "project-id-1",
 				Endpoints: []string{"endpoint-id-1"},
 				Data:      []byte(`{}`),
+				Raw:       "",
 				CreatedAt: primitive.NewDateTimeFromTime(time.Now()),
 				UpdatedAt: primitive.NewDateTimeFromTime(time.Now()),
 			},
@@ -54,6 +55,7 @@ func TestIndexDocument(t *testing.T) {
 				ProjectID: "project-id-1",
 				Endpoints: []string{"endpoint-id-1"},
 				Data:      []byte(`{}`),
+				Raw:       "",
 				CreatedAt: primitive.NewDateTimeFromTime(time.Now()),
 				UpdatedAt: primitive.NewDateTimeFromTime(time.Now()),
 			},
@@ -103,6 +105,7 @@ func TestIndexDocument(t *testing.T) {
 			require.NoError(t, err)
 
 			job := queue.Job{
+				ID:      tt.event.UID,
 				Payload: payload,
 			}
 

--- a/worker/task/process_event_creation.go
+++ b/worker/task/process_event_creation.go
@@ -158,9 +158,14 @@ func ProcessEventCreation(endpointRepo datastore.EndpointRepository, eventRepo d
 			}
 		}
 
+		eBytes, err := json.Marshal(event)
+		if err != nil {
+			log.Errorf("[asynq]: an error occurred marshalling event to be indexed %s", err)
+		}
+
 		job := &queue.Job{
 			ID:      event.UID,
-			Payload: t.Payload(), // t.Payload() is the original event bytes
+			Payload: eBytes,
 			Delay:   5 * time.Second,
 		}
 


### PR DESCRIPTION
There was an issue regarding how the data was being indexed and searched. When we released v0.8 we changed the payload format slightly so the documents were not indexed and when searching we were passing `group_id` instead of `project_id`. We were also incorrectly storing array information in the search backend.