### PR TITLE
fix: pause events polling on search and filtering

### DIFF
--- a/web/ui/dashboard/src/app/pipes/source-value/source-value.pipe.ts
+++ b/web/ui/dashboard/src/app/pipes/source-value/source-value.pipe.ts
@@ -20,7 +20,7 @@ export class SourceValuePipe implements PipeTransform {
 	pubSubTypes = [
 		{ value: 'google', viewValue: 'Google Pub/Sub' },
 		{ value: 'sqs', viewValue: 'AWS SQS' },
-		{ value: 'kafka', viewValue: 'Kafka Pub/Sub' }
+		{ value: 'kafka', viewValue: 'Kafka' }
 	];
 
 	transform(value: string, type: 'sourceType' | 'verifier' | 'pub_sub'): string {

--- a/web/ui/dashboard/src/app/private/components/create-source/create-source.component.ts
+++ b/web/ui/dashboard/src/app/private/components/create-source/create-source.component.ts
@@ -78,7 +78,7 @@ export class CreateSourceComponent implements OnInit {
 	];
 	pubSubTypes = [
 		{ uid: 'google', name: 'Google Pub/Sub' },
-		{ uid: 'kafka', name: 'Kafka Pub/Sub' },
+		{ uid: 'kafka', name: 'Kafka' },
 		{ uid: 'sqs', name: 'AWS SQS' }
 	];
 	httpTypes = [

--- a/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.html
@@ -62,14 +62,7 @@
 			</div>
 		</div>
 
-		<button
-			convoy-button
-			size="sm"
-			fill="outline"
-			class="ml-14px px-10px border-primary-400 h-36px whitespace-nowrap"
-			[disabled]="(eventsDateFilterFromURL.startDate == '' || eventsDateFilterFromURL.endDate == '') && (eventSource?.length == 0 || eventSource == undefined)"
-			(click)="fetchRetryCount()"
-		>
+		<button convoy-button size="sm" fill="outline" class="ml-14px px-10px border-primary-400 h-36px whitespace-nowrap" [disabled]="!(queryParams?.startDate || queryParams?.endDate || queryParams?.sourceId || queryParams?.query)" (click)="fetchRetryCount()">
 			Batch Replay
 		</button>
 	</div>

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-deliveries/event-deliveries.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-deliveries/event-deliveries.component.ts
@@ -88,7 +88,7 @@ export class EventDeliveriesComponent implements OnInit {
 	getEventDeliveriesAtInterval(requestDetails?: FILTER_QUERY_PARAM) {
 		this.getEventDeliveriesInterval = setInterval(() => {
 			this.getEventDeliveries({ ...requestDetails });
-		}, 4000);
+		}, 7000);
 	}
 
 	async getEventDeliveries(requestDetails?: FILTER_QUERY_PARAM): Promise<HTTP_RESPONSE> {
@@ -172,14 +172,14 @@ export class EventDeliveriesComponent implements OnInit {
 	getSelectedDateRange(dateRange: { startDate: string; endDate: string }) {
 		const data = this.addFilterToURL(dateRange);
 		clearInterval(this.getEventDeliveriesInterval);
-		this.getEventDeliveries({ ...data, showLoader: true }).then(() => this.getEventDeliveriesAtInterval(data));
+		this.getEventDeliveries({ ...data, showLoader: true });
 	}
 
 	getSelectedStatusFilter() {
 		const eventDelsStatus = this.eventDeliveryFilteredByStatus.length > 0 ? JSON.stringify(this.eventDeliveryFilteredByStatus) : '';
 		const data = this.addFilterToURL({ status: eventDelsStatus });
 		clearInterval(this.getEventDeliveriesInterval);
-		this.getEventDeliveries({ ...data, showLoader: true }).then(() => this.getEventDeliveriesAtInterval(data));
+		this.getEventDeliveries({ ...data, showLoader: true });
 	}
 
 	clearFilters(filterType?: 'startDate' | 'endDate' | 'eventId' | 'endpointId' | 'status' | 'sourceId' | 'next_page_cursor' | 'prev_page_cursor' | 'direction') {
@@ -206,7 +206,8 @@ export class EventDeliveriesComponent implements OnInit {
 		}
 
 		clearInterval(this.getEventDeliveriesInterval);
-		this.getEventDeliveries({ ...this.queryParams, showLoader: true }).then(() => this.getEventDeliveriesAtInterval(this.queryParams));
+		if (Object.keys(this.queryParams).length === 0) this.getEventDeliveries({ ...this.queryParams, showLoader: true }).then(() => this.getEventDeliveriesAtInterval(this.queryParams));
+		else this.getEventDeliveries({ ...this.queryParams, showLoader: true });
 	}
 
 	async fetchRetryCount() {
@@ -240,13 +241,19 @@ export class EventDeliveriesComponent implements OnInit {
 	updateEndpointFilter() {
 		const data = this.addFilterToURL({ endpointId: this.eventDeliveriesEndpoint });
 		clearInterval(this.getEventDeliveriesInterval);
-		this.getEventDeliveries({ ...data, showLoader: true }).then(() => this.getEventDeliveriesAtInterval(data));
+		this.getEventDeliveries({ ...data, showLoader: true });
 	}
 
 	updateSourceFilter() {
 		const data = this.addFilterToURL({ sourceId: this.eventDeliveriesSource });
 		clearInterval(this.getEventDeliveriesInterval);
-		this.getEventDeliveries({ ...data, showLoader: true }).then(() => this.getEventDeliveriesAtInterval(data));
+		this.getEventDeliveries({ ...data, showLoader: true });
+	}
+
+	paginateEvents(event: CURSOR) {
+		const data = this.addFilterToURL({ next_page_cursor: event.next_page_cursor, prev_page_cursor: event.prev_page_cursor });
+		clearInterval(this.getEventDeliveriesInterval);
+		this.getEventDeliveries({ ...data, showLoader: true });
 	}
 
 	async retryEvent(requestDetails: { e: any; index: number; eventDeliveryId: string }) {
@@ -292,11 +299,5 @@ export class EventDeliveriesComponent implements OnInit {
 			this.isRetrying = false;
 			return error;
 		}
-	}
-
-	paginateEvents(event: CURSOR) {
-		this.addFilterToURL({ next_page_cursor: event.next_page_cursor, prev_page_cursor: event.prev_page_cursor });
-		clearInterval(this.getEventDeliveriesInterval);
-		this.getEventDeliveries({ ...event, showLoader: true }).then(() => this.getEventDeliveriesAtInterval(event));
 	}
 }


### PR DESCRIPTION
In this pr, an update was made to pause events and event deliveries whenever a search or filtering is initiated, this is to help minimize data conflict whenever a search or filter request is made.