### PR TITLE
fix: return proper error instead of nil the process event delivery

### DIFF
--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -3,8 +3,9 @@ package worker
 import (
 	"context"
 	"fmt"
-	"github.com/frain-dev/convoy/internal/pkg/rdb"
 	"net/http"
+
+	"github.com/frain-dev/convoy/internal/pkg/rdb"
 
 	"github.com/frain-dev/convoy"
 	"github.com/frain-dev/convoy/analytics"

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -96,10 +96,6 @@ func ProcessEventDelivery(endpointRepo datastore.EndpointRepository, eventDelive
 
 		res, err := rateLimiter.Allow(ctx, endpoint.TargetURL, rlc.Count, int(rlc.Duration))
 		if err != nil {
-			return &EndpointError{Err: err, delay: delayDuration}
-		}
-
-		if res.Remaining <= 0 {
 			err := fmt.Errorf("too many events to %s, limit of %v would be reached", endpoint.TargetURL, res.Limit)
 			log.WithError(ErrRateLimit).Error(err.Error())
 

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -214,8 +214,7 @@ func ProcessEventDelivery(endpointRepo datastore.EndpointRepository, eventDelive
 
 		// Request failed but statusCode is 200 <= x <= 299
 		if err != nil {
-			log.Errorf("%s failed. Reason: %s", ed.UID, err)
-			return &EndpointError{Err: err, delay: delayDuration}
+			log.FromContext(ctx).WithError(err).Errorf("%s failed. Reason: %s", ed.UID, err)
 		}
 
 		if done && e.Status == datastore.PendingEndpointStatus && p.Config.DisableEndpoint {


### PR DESCRIPTION
Returning `nil` in the `process_event_delivery.go` causes some events to be stuck indefinitely in the `Scheduled` state. This pr fixes this.