### PR TITLE
Performance tweaks

### DIFF
--- a/api/dashboard/event.go
+++ b/api/dashboard/event.go
@@ -409,8 +409,26 @@ func (a *DashboardHandler) GetEventsPaged(w http.ResponseWriter, r *http.Request
 		pagedResponse{Content: &m, Pagination: &paginationData}, http.StatusOK))
 }
 
+func parseStatus(rawStatus string) []datastore.EventDeliveryStatus {
+	var parsedStatus []string
+	err := json.Unmarshal([]byte(rawStatus), &parsedStatus)
+
+	if err != nil {
+		log.Errorf("Invalid status filter received => %+v", rawStatus)
+	}
+
+	statusList := make([]datastore.EventDeliveryStatus, 0)
+	for _, v := range parsedStatus {
+		if !util.IsStringEmpty(v) {
+			statusList = append(statusList, datastore.EventDeliveryStatus(v))
+		}
+	}
+
+	return statusList
+}
+
 func (a *DashboardHandler) GetEventDeliveriesPaged(w http.ResponseWriter, r *http.Request) {
-	status := make([]datastore.EventDeliveryStatus, 0)
+	status := parseStatus(r.URL.Query().Get("status"))
 	for _, s := range r.URL.Query()["status"] {
 		if !util.IsStringEmpty(s) {
 			status = append(status, datastore.EventDeliveryStatus(s))

--- a/api/ingest.go
+++ b/api/ingest.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -28,19 +29,43 @@ func createSourceService(a *ApplicationHandler) *services.SourceService {
 	return services.NewSourceService(sourceRepo, a.A.Cache)
 }
 
+func retrieveSourceConfigurationFromMaskId(a *ApplicationHandler, ctx context.Context, maskId string) (*datastore.Source, error) {
+	var source *datastore.Source
+	var err error
+
+	// Tries to retrieve the source configuration from the cache service
+	err = a.A.Cache.Get(ctx, maskId, &source)
+
+	if err != nil {
+		a.A.Logger.WithError(err)
+	}
+
+	if source == nil {
+		// 2. Retrieve source using mask ID.
+		source, err = postgres.NewSourceRepo(a.A.DB).FindSourceByMaskID(ctx, maskId)
+		if err != nil {
+			return nil, err
+		}
+		err = a.A.Cache.Set(ctx, maskId, &source, time.Minute*2)
+		if err != nil {
+			a.A.Logger.WithError(err)
+		}
+	}
+	return source, nil
+}
+
 func (a *ApplicationHandler) IngestEvent(w http.ResponseWriter, r *http.Request) {
 	// s.AppService.CountProjectApplications()
 	// 1. Retrieve mask ID
 	maskID := chi.URLParam(r, "maskID")
 
-	// 2. Retrieve source using mask ID.
-	source, err := postgres.NewSourceRepo(a.A.DB).FindSourceByMaskID(r.Context(), maskID)
+	source, err := retrieveSourceConfigurationFromMaskId(a, r.Context(), maskID)
+
 	if err != nil {
 		if err == datastore.ErrSourceNotFound {
 			_ = render.Render(w, r, util.NewErrorResponse(err.Error(), http.StatusNotFound))
 			return
 		}
-
 		_ = render.Render(w, r, util.NewErrorResponse("error retrieving source", http.StatusBadRequest))
 		return
 	}
@@ -95,15 +120,28 @@ func (a *ApplicationHandler) IngestEvent(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	projectRepo := postgres.NewProjectRepo(a.A.DB)
+	// passivel de cache
+	var project *datastore.Project
 
-	g, err := projectRepo.FetchProjectByID(r.Context(), source.ProjectID)
-	if err != nil {
-		_ = render.Render(w, r, util.NewServiceErrResponse(err))
-		return
+	a.A.Cache.Get(r.Context(), source.ProjectID, &project)
+
+	if project == nil {
+		// 2. Retrieve source using mask ID.
+		projectRepo := postgres.NewProjectRepo(a.A.DB)
+		projectFromDb, err := projectRepo.FetchProjectByID(r.Context(), source.ProjectID)
+		if err != nil {
+			_ = render.Render(w, r, util.NewServiceErrResponse(err))
+			return
+		}
+		a.A.Cache.Set(r.Context(), source.ProjectID, &projectFromDb, time.Minute*2)
+		project = projectFromDb
 	}
 
-	maxIngestSize := g.Config.MaxIngestSize
+	var maxIngestSize uint64
+	if project.Config != nil && project.Config.MaxIngestSize == 0 {
+		maxIngestSize = project.Config.MaxIngestSize
+	}
+
 	if maxIngestSize == 0 {
 		cfg, err := config.Get()
 		if err != nil {
@@ -177,32 +215,17 @@ func (a *ApplicationHandler) IngestEvent(w http.ResponseWriter, r *http.Request)
 
 func (a *ApplicationHandler) HandleCrcCheck(w http.ResponseWriter, r *http.Request) {
 	maskID := chi.URLParam(r, "maskID")
-
-	var source *datastore.Source
 	sourceCacheKey := convoy.SourceCacheKey.Get(maskID).String()
 
-	err := a.A.Cache.Get(r.Context(), sourceCacheKey, &source)
+	source, err := retrieveSourceConfigurationFromMaskId(a, r.Context(), sourceCacheKey)
+
 	if err != nil {
-		a.A.Logger.WithError(err)
-	}
-
-	if source == nil {
-		source, err = postgres.NewSourceRepo(a.A.DB).FindSourceByMaskID(r.Context(), maskID)
-		if err != nil {
-			if err == datastore.ErrSourceNotFound {
-				_ = render.Render(w, r, util.NewErrorResponse(err.Error(), http.StatusNotFound))
-				return
-			}
-
-			_ = render.Render(w, r, util.NewErrorResponse("error retrieving source", http.StatusBadRequest))
+		if err == datastore.ErrSourceNotFound {
+			_ = render.Render(w, r, util.NewErrorResponse(err.Error(), http.StatusNotFound))
 			return
 		}
-
-		err = a.A.Cache.Set(r.Context(), sourceCacheKey, &source, time.Hour*24)
-		if err != nil {
-			a.A.Logger.WithError(err)
-		}
-
+		_ = render.Render(w, r, util.NewErrorResponse("error retrieving source", http.StatusBadRequest))
+		return
 	}
 
 	if source.Type != datastore.HTTPSource {

--- a/cmd/retry/retry.go
+++ b/cmd/retry/retry.go
@@ -13,6 +13,7 @@ import (
 func AddRetryCommand(a *cli.App) *cobra.Command {
 	var status string
 	var timeInterval string
+	var eventId string
 
 	cmd := &cobra.Command{
 		Use:   "retry",
@@ -28,11 +29,12 @@ func AddRetryCommand(a *cli.App) *cobra.Command {
 			}
 
 			statuses := []datastore.EventDeliveryStatus{datastore.EventDeliveryStatus(status)}
-			task.RetryEventDeliveries(statuses, timeInterval, a.DB, a.Queue)
+			task.RetryEventDeliveries(a.DB, a.Queue, statuses, timeInterval, eventId)
 		},
 	}
 
 	cmd.Flags().StringVar(&status, "status", "", "Status of event deliveries to requeue")
 	cmd.Flags().StringVar(&timeInterval, "time", "", "Time interval")
+	cmd.Flags().StringVar(&eventId, "eventid", "", "Requeue the informed eventId")
 	return cmd
 }

--- a/cmd/stream/stream.go
+++ b/cmd/stream/stream.go
@@ -73,8 +73,7 @@ func AddStreamCommand(a *cli.App) *cobra.Command {
 			lo.SetLevel(lvl)
 
 			handler := socket.BuildRoutes(h, r)
-
-			consumer := worker.NewConsumer(a.Queue, lo)
+			consumer := worker.NewConsumer(c.ConsumerPoolSize, a.Queue, lo)
 			consumer.RegisterHandlers(convoy.StreamCliEventsProcessor, h.EventDeliveryCLiHandler(r))
 
 			// start worker

--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,7 @@ var DefaultConfiguration = Configuration{
 			Enabled: true,
 		},
 	},
+	ConsumerPoolSize: 100,
 }
 
 type DatabaseConfiguration struct {
@@ -296,6 +297,7 @@ type Configuration struct {
 	FeatureFlag        FeatureFlagConfiguration   `json:"feature_flag"`
 	Analytics          AnalyticsConfiguration     `json:"analytics"`
 	StoragePolicy      StoragePolicyConfiguration `json:"storage_policy"`
+	ConsumerPoolSize   int                        `json:"consumer_pool_size" envconfig:"CONVOY_CONSUMER_POOL_SIZE"`
 }
 
 // Get fetches the application configuration. LoadConfig must have been called

--- a/database/postgres/endpoint.go
+++ b/database/postgres/endpoint.go
@@ -47,11 +47,10 @@ const (
 	e.authentication_type_api_key_header_name AS "authentication.api_key.header_name",
 	e.authentication_type_api_key_header_value AS "authentication.api_key.header_value"
 	FROM convoy.endpoints AS e
-	LEFT JOIN convoy.events_endpoints AS ee ON e.id = ee.endpoint_id
 	WHERE e.deleted_at IS NULL
 	`
 
-	fetchEndpointById = baseEndpointFetch + ` AND e.id = $1 AND e.project_id = $2 GROUP BY e.id ORDER BY e.id;`
+	fetchEndpointById = baseEndpointFetch + ` AND e.id = $1 AND e.project_id = $2;`
 
 	fetchEndpointsById = baseEndpointFetch + ` AND e.id IN (?) AND e.project_id = ? GROUP BY e.id ORDER BY e.id;`
 

--- a/database/postgres/event.go
+++ b/database/postgres/event.go
@@ -89,7 +89,8 @@ const (
 	`
 
 	baseEventFilter = ` AND ev.project_id = :project_id 
-	AND (ev.source_id = :source_id OR :source_id = '') 
+	AND (ev.source_id = :source_id OR :source_id = '')
+	AND (ev.id = :event_id OR :event_id = '') 
 	AND ev.created_at >= :start_date 
 	AND ev.created_at <= :end_date`
 
@@ -245,6 +246,7 @@ func (e *eventRepo) LoadEventsPaged(ctx context.Context, projectID string, filte
 		"start_date":   startDate,
 		"end_date":     endDate,
 		"cursor":       filter.Pageable.Cursor(),
+		"event_id":     filter.Query,
 	}
 
 	var baseQueryPagination string

--- a/queue/redis/client.go
+++ b/queue/redis/client.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hibiken/asynq"
 	"github.com/hibiken/asynqmon"
 	"github.com/oklog/ulid/v2"
-	"time"
 )
 
 type RedisQueue struct {
@@ -30,7 +29,8 @@ func (q *RedisQueue) Write(taskName convoy.TaskName, queueName convoy.QueueName,
 		job.ID = ulid.Make().String()
 	}
 	t := asynq.NewTask(string(taskName), job.Payload, asynq.Queue(string(queueName)), asynq.TaskID(job.ID), asynq.ProcessIn(job.Delay))
-	_, err := q.client.Enqueue(t, asynq.Retention(24*time.Hour))
+	// According to the documentation, the Retention time will keep the message in Redis after completion. :F:
+	_, err := q.client.Enqueue(t)
 	return err
 }
 

--- a/worker/consumer.go
+++ b/worker/consumer.go
@@ -17,11 +17,12 @@ type Consumer struct {
 	log   log.StdLogger
 }
 
-func NewConsumer(q queue.Queuer, lo log.StdLogger) *Consumer {
+func NewConsumer(consumerPoolSize int, q queue.Queuer, lo log.StdLogger) *Consumer {
+	lo.Infof("The consumer pool size has been set to %d.", consumerPoolSize)
 	srv := asynq.NewServer(
 		q.Options().RedisClient,
 		asynq.Config{
-			Concurrency: convoy.Concurrency,
+			Concurrency: consumerPoolSize,
 			BaseContext: func() context.Context {
 				return log.NewContext(context.Background(), lo, nil)
 			},


### PR DESCRIPTION
Hello

Last week our team ran a load test on convoy and noticed that the worker module was consuming a lot of cache memory and database CPU. So we started investigating the root cause and identified some points that would benefit from caching and also that the limitRater class could be passed as an argument to the event delivery function. The changes mentioned provided us with a gain of approximately 300% in application performance and also reduced resource usage. Below is a list of the most relevant changes we made:

  - 2 minute cache of subscription configuration in event creation consumer
  - Creation of indexing events only if the search engine is typesense
  - Creation of an environment variable that allows controlling the size of the connection pool for asynq consumers
  - Early return in the event processing function if the event status is success
  - Removal of the left join with the events_endpoints table when fetching event endpoint data.
 
We also made an adjustment to the function that searches events by status that is used in dashboard and now it is possible to use it in searches.

I hope you find changes that are satisfactory and that can be used in your project.

PS: We have not reviewed existing tests and they are likely to fail