### PR TITLE
Revert to load EventDelivery from DB

### DIFF
--- a/services/create_event.go
+++ b/services/create_event.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/frain-dev/convoy/pkg/msgpack"
 	"time"
+
+	"github.com/frain-dev/convoy/pkg/msgpack"
 
 	"github.com/frain-dev/convoy"
 	"github.com/frain-dev/convoy/api/models"

--- a/worker/task/process_dynamic_event_creation.go
+++ b/worker/task/process_dynamic_event_creation.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/frain-dev/convoy/pkg/msgpack"
 	"net/http"
 	"time"
+
+	"github.com/frain-dev/convoy/pkg/msgpack"
 
 	"github.com/google/uuid"
 
@@ -190,10 +191,8 @@ func ProcessDynamicEventCreation(endpointRepo datastore.EndpointRepository, even
 
 		if eventDelivery.Status != datastore.DiscardedEventStatus {
 			payload := EventDelivery{
-				Endpoint:      endpoint,
-				Project:       project,
-				Subscription:  s,
-				EventDelivery: eventDelivery,
+				EventDeliveryID: eventDelivery.UID,
+				ProjectID:       eventDelivery.ProjectID,
 			}
 
 			data, err := msgpack.EncodeMsgPack(payload)

--- a/worker/task/process_event_creation.go
+++ b/worker/task/process_event_creation.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
+
 	"github.com/frain-dev/convoy/pkg/msgpack"
 	"github.com/frain-dev/convoy/util"
-	"time"
 
 	"github.com/frain-dev/convoy"
 	"github.com/frain-dev/convoy/cache"
@@ -179,10 +180,8 @@ func ProcessEventCreation(endpointRepo datastore.EndpointRepository, eventRepo d
 
 			if eventDelivery.Status != datastore.DiscardedEventStatus {
 				payload := EventDelivery{
-					Subscription:  &s,
-					Project:       project,
-					Endpoint:      s.Endpoint,
-					EventDelivery: eventDelivery,
+					EventDeliveryID: eventDelivery.UID,
+					ProjectID:       eventDelivery.ProjectID,
 				}
 
 				data, err := msgpack.EncodeMsgPack(payload)

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/frain-dev/convoy/pkg/msgpack"
 	"time"
+
+	"github.com/frain-dev/convoy/pkg/msgpack"
 
 	"github.com/frain-dev/convoy/pkg/httpheader"
 
@@ -41,11 +42,6 @@ type SignatureValues struct {
 type EventDelivery struct {
 	EventDeliveryID string
 	ProjectID       string
-
-	Endpoint      *datastore.Endpoint
-	Project       *datastore.Project
-	Subscription  *datastore.Subscription
-	EventDelivery *datastore.EventDelivery
 }
 
 func ProcessEventDelivery(endpointRepo datastore.EndpointRepository, eventDeliveryRepo datastore.EventDeliveryRepository, projectRepo datastore.ProjectRepository, subRepo datastore.SubscriptionRepository, notificationQueue queue.Queuer) func(context.Context, *asynq.Task) error {
@@ -65,38 +61,26 @@ func ProcessEventDelivery(endpointRepo datastore.EndpointRepository, eventDelive
 			return &EndpointError{Err: err, delay: defaultDelay}
 		}
 
-		project := data.Project
-		endpoint := data.Endpoint
-		subscription := data.Subscription
-		eventDelivery := data.EventDelivery
-
-		if eventDelivery == nil {
-			eventDelivery, err = eventDeliveryRepo.FindEventDeliveryByID(ctx, data.ProjectID, data.EventDeliveryID)
-			if err != nil {
-				return &EndpointError{Err: err, delay: defaultDelay}
-			}
+		eventDelivery, err := eventDeliveryRepo.FindEventDeliveryByID(ctx, data.ProjectID, data.EventDeliveryID)
+		if err != nil {
+			return &EndpointError{Err: err, delay: defaultDelay}
 		}
+
 		delayDuration := retrystrategies.NewRetryStrategyFromMetadata(*eventDelivery.Metadata).NextDuration(eventDelivery.Metadata.NumTrials)
 
-		if endpoint == nil {
-			endpoint, err = endpointRepo.FindEndpointByID(ctx, eventDelivery.EndpointID, eventDelivery.ProjectID)
-			if err != nil {
-				return &EndpointError{Err: err, delay: delayDuration}
-			}
+		endpoint, err := endpointRepo.FindEndpointByID(ctx, eventDelivery.EndpointID, eventDelivery.ProjectID)
+		if err != nil {
+			return &EndpointError{Err: err, delay: delayDuration}
 		}
 
-		if subscription == nil {
-			subscription, err = subRepo.FindSubscriptionByID(ctx, eventDelivery.ProjectID, eventDelivery.SubscriptionID)
-			if err != nil {
-				return &EndpointError{Err: err, delay: delayDuration}
-			}
+		subscription, err := subRepo.FindSubscriptionByID(ctx, eventDelivery.ProjectID, eventDelivery.SubscriptionID)
+		if err != nil {
+			return &EndpointError{Err: err, delay: delayDuration}
 		}
 
-		if project == nil {
-			project, err = projectRepo.FetchProjectByID(ctx, endpoint.ProjectID)
-			if err != nil {
-				return &EndpointError{Err: err, delay: delayDuration}
-			}
+		project, err := projectRepo.FetchProjectByID(ctx, eventDelivery.ProjectID)
+		if err != nil {
+			return &EndpointError{Err: err, delay: delayDuration}
 		}
 
 		switch eventDelivery.Status {


### PR DESCRIPTION
We're picking the exact same eventdelivery json put on redis this first time the event was queued. This means things like delivery attempts don’t get reflceted if the sending fails the first time for some reason. This PR fixes that