### PR TITLE
Move smtp cli flags to worker cli

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -34,13 +34,6 @@ func AddServerCommand(a *cli.App) *cobra.Command {
 	var retryStrategy string
 	var signatureHash string
 	var signatureHeader string
-	var smtpProvider string
-	var smtpUrl string
-	var smtpSSL bool
-	var smtpUsername string
-	var smtpPassword string
-	var smtpReplyTo string
-	var smtpFrom string
 	var newRelicApp string
 	var newRelicKey string
 	var typesenseApiKey string
@@ -104,13 +97,6 @@ func AddServerCommand(a *cli.App) *cobra.Command {
 	cmd.Flags().StringVar(&retryStrategy, "retry-strategy", "", "Endpoint retry strategy")
 	cmd.Flags().StringVar(&signatureHash, "signature-hash", "", "Application signature hash")
 	cmd.Flags().StringVar(&signatureHeader, "signature-header", "", "Application signature header")
-	cmd.Flags().StringVar(&smtpProvider, "smtp-provider", "", "SMTP provider")
-	cmd.Flags().StringVar(&smtpUrl, "smtp-url", "", "SMTP provider URL")
-	cmd.Flags().BoolVar(&smtpSSL, "smtp-ssl", false, "SMTP SSL")
-	cmd.Flags().StringVar(&smtpUsername, "smtp-username", "", "SMTP authentication username")
-	cmd.Flags().StringVar(&smtpPassword, "smtp-password", "", "SMTP authentication password")
-	cmd.Flags().StringVar(&smtpFrom, "smtp-from", "", "Sender email address")
-	cmd.Flags().StringVar(&smtpReplyTo, "smtp-reply-to", "", "Email address to reply to")
 	cmd.Flags().StringVar(&newRelicApp, "new-relic-app", "", "NewRelic application name")
 	cmd.Flags().StringVar(&newRelicKey, "new-relic-key", "", "NewRelic application license key")
 	cmd.Flags().StringVar(&searcher, "searcher", "", "Searcher")

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -34,6 +34,14 @@ func AddWorkerCommand(a *cli.App) *cobra.Command {
 	var newRelicTracerEnabled bool
 	var newRelicConfigEnabled bool
 
+	var smtpSSL bool
+	var smtpUsername string
+	var smtpPassword string
+	var smtpReplyTo string
+	var smtpFrom string
+	var smtpProvider string
+	var smtpUrl string
+
 	cmd := &cobra.Command{
 		Use:   "worker",
 		Short: "Start worker instance",
@@ -173,6 +181,14 @@ func AddWorkerCommand(a *cli.App) *cobra.Command {
 			return ctx.Err()
 		},
 	}
+
+	cmd.Flags().BoolVar(&smtpSSL, "smtp-ssl", false, "Enable SMTP SSL")
+	cmd.Flags().StringVar(&smtpUsername, "smtp-username", "", "SMTP authentication username")
+	cmd.Flags().StringVar(&smtpPassword, "smtp-password", "", "SMTP authentication password")
+	cmd.Flags().StringVar(&smtpFrom, "smtp-from", "", "Sender email address")
+	cmd.Flags().StringVar(&smtpReplyTo, "smtp-reply-to", "", "Email address to reply to")
+	cmd.Flags().StringVar(&smtpProvider, "smtp-provider", "", "SMTP provider")
+	cmd.Flags().StringVar(&smtpUrl, "smtp-url", "", "SMTP provider URL")
 
 	cmd.Flags().Uint32Var(&workerPort, "worker-port", 5006, "Worker port")
 	cmd.Flags().StringVar(&logLevel, "log-level", "", "scheduler log level")


### PR DESCRIPTION
The server does not send emails, it only queues them. This set of CLI flags should be defined on the worker, this is potentially A BREAKING CHANGE.