### PR TITLE
fix: fixed bugs with the ingest & worker cli

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -51,7 +51,6 @@ func AddServerCommand(a *cli.App) *cobra.Command {
 	var newRelicConfigEnabled bool
 
 	var port uint32
-	var smtpPort uint32
 	var retryLimit uint64
 	var workerPort uint32
 	var retryInterval uint64
@@ -112,7 +111,6 @@ func AddServerCommand(a *cli.App) *cobra.Command {
 	cmd.Flags().BoolVar(&newRelicTracerEnabled, "new-relic-tracer-enabled", false, "Enable new-relic distributed tracer")
 
 	cmd.Flags().Uint32Var(&port, "port", 0, "Server port")
-	cmd.Flags().Uint32Var(&smtpPort, "smtp-port", 0, "Server port")
 	cmd.Flags().Uint32Var(&workerPort, "worker-port", 0, "Worker port")
 	cmd.Flags().Uint64Var(&retryLimit, "retry-limit", 0, "Endpoint retry limit")
 	cmd.Flags().Uint64Var(&maxResponseSize, "max-response-size", 0, "Max response size")
@@ -384,76 +382,6 @@ func buildServerCliConfiguration(cmd *cobra.Command) (*config.Configuration, err
 
 	if !util.IsStringEmpty(proxy) {
 		c.Server.HTTP.HttpProxy = proxy
-	}
-
-	// CONVOY_SMTP_PROVIDER
-	smtpProvider, err := cmd.Flags().GetString("smtp-provider")
-	if err != nil {
-		return nil, err
-	}
-
-	if !util.IsStringEmpty(smtpProvider) {
-		c.SMTP.Provider = smtpProvider
-	}
-
-	// CONVOY_SMTP_URL
-	smtpUrl, err := cmd.Flags().GetString("smtp-url")
-	if err != nil {
-		return nil, err
-	}
-
-	if !util.IsStringEmpty(smtpUrl) {
-		c.SMTP.URL = smtpUrl
-	}
-
-	// CONVOY_SMTP_USERNAME
-	smtpUsername, err := cmd.Flags().GetString("smtp-username")
-	if err != nil {
-		return nil, err
-	}
-
-	if !util.IsStringEmpty(smtpUsername) {
-		c.SMTP.Username = smtpUsername
-	}
-
-	// CONVOY_SMTP_PASSWORD
-	smtpPassword, err := cmd.Flags().GetString("smtp-password")
-	if err != nil {
-		return nil, err
-	}
-
-	if !util.IsStringEmpty(smtpPassword) {
-		c.SMTP.Password = smtpPassword
-	}
-
-	// CONVOY_SMTP_FROM
-	smtpFrom, err := cmd.Flags().GetString("smtp-from")
-	if err != nil {
-		return nil, err
-	}
-
-	if !util.IsStringEmpty(smtpFrom) {
-		c.SMTP.From = smtpFrom
-	}
-
-	// CONVOY_SMTP_REPLY_TO
-	smtpReplyTo, err := cmd.Flags().GetString("smtp-reply-to")
-	if err != nil {
-		return nil, err
-	}
-
-	if !util.IsStringEmpty(smtpReplyTo) {
-		c.SMTP.ReplyTo = smtpReplyTo
-	}
-
-	// CONVOY_SMTP_PORT
-	smtpPort, err := cmd.Flags().GetUint32("smtp-port")
-	if err != nil {
-		return nil, err
-	}
-
-	if smtpPort != 0 {
-		c.SMTP.Port = smtpPort
 	}
 
 	// CONVOY_MAX_RESPONSE_SIZE

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -41,6 +41,7 @@ func AddWorkerCommand(a *cli.App) *cobra.Command {
 	var smtpFrom string
 	var smtpProvider string
 	var smtpUrl string
+	var smtpPort uint32
 
 	cmd := &cobra.Command{
 		Use:   "worker",
@@ -189,6 +190,7 @@ func AddWorkerCommand(a *cli.App) *cobra.Command {
 	cmd.Flags().StringVar(&smtpReplyTo, "smtp-reply-to", "", "Email address to reply to")
 	cmd.Flags().StringVar(&smtpProvider, "smtp-provider", "", "SMTP provider")
 	cmd.Flags().StringVar(&smtpUrl, "smtp-url", "", "SMTP provider URL")
+	cmd.Flags().Uint32Var(&smtpPort, "smtp-port", 0, "SMTP Port")
 
 	cmd.Flags().Uint32Var(&workerPort, "worker-port", 5006, "Worker port")
 	cmd.Flags().StringVar(&logLevel, "log-level", "", "scheduler log level")
@@ -263,6 +265,76 @@ func buildWorkerCliConfiguration(cmd *cobra.Command) (*config.Configuration, err
 		}
 
 		c.Tracer.NewRelic.DistributedTracerEnabled = newReplicTracerEnabled
+	}
+
+	// CONVOY_SMTP_PROVIDER
+	smtpProvider, err := cmd.Flags().GetString("smtp-provider")
+	if err != nil {
+		return nil, err
+	}
+
+	if !util.IsStringEmpty(smtpProvider) {
+		c.SMTP.Provider = smtpProvider
+	}
+
+	// CONVOY_SMTP_URL
+	smtpUrl, err := cmd.Flags().GetString("smtp-url")
+	if err != nil {
+		return nil, err
+	}
+
+	if !util.IsStringEmpty(smtpUrl) {
+		c.SMTP.URL = smtpUrl
+	}
+
+	// CONVOY_SMTP_USERNAME
+	smtpUsername, err := cmd.Flags().GetString("smtp-username")
+	if err != nil {
+		return nil, err
+	}
+
+	if !util.IsStringEmpty(smtpUsername) {
+		c.SMTP.Username = smtpUsername
+	}
+
+	// CONVOY_SMTP_PASSWORD
+	smtpPassword, err := cmd.Flags().GetString("smtp-password")
+	if err != nil {
+		return nil, err
+	}
+
+	if !util.IsStringEmpty(smtpPassword) {
+		c.SMTP.Password = smtpPassword
+	}
+
+	// CONVOY_SMTP_FROM
+	smtpFrom, err := cmd.Flags().GetString("smtp-from")
+	if err != nil {
+		return nil, err
+	}
+
+	if !util.IsStringEmpty(smtpFrom) {
+		c.SMTP.From = smtpFrom
+	}
+
+	// CONVOY_SMTP_REPLY_TO
+	smtpReplyTo, err := cmd.Flags().GetString("smtp-reply-to")
+	if err != nil {
+		return nil, err
+	}
+
+	if !util.IsStringEmpty(smtpReplyTo) {
+		c.SMTP.ReplyTo = smtpReplyTo
+	}
+
+	// CONVOY_SMTP_PORT
+	smtpPort, err := cmd.Flags().GetUint32("smtp-port")
+	if err != nil {
+		return nil, err
+	}
+
+	if smtpPort != 0 {
+		c.SMTP.Port = smtpPort
 	}
 
 	return c, nil

--- a/config/config.go
+++ b/config/config.go
@@ -121,6 +121,7 @@ type HTTPServerConfiguration struct {
 	SSLCertFile string `json:"ssl_cert_file" envconfig:"CONVOY_SSL_CERT_FILE"`
 	SSLKeyFile  string `json:"ssl_key_file" envconfig:"CONVOY_SSL_KEY_FILE"`
 	Port        uint32 `json:"port" envconfig:"PORT"`
+	IngestPort  uint32 `json:"ingest_port" envconfig:"INGEST_PORT"`
 	WorkerPort  uint32 `json:"worker_port" envconfig:"WORKER_PORT"`
 	SocketPort  uint32 `json:"socket_port" envconfig:"SOCKET_PORT"`
 	DomainPort  uint32 `json:"domain_port" envconfig:"DOMAIN_PORT"`

--- a/docker-compose.dep.yml
+++ b/docker-compose.dep.yml
@@ -26,16 +26,3 @@ services:
           - ./redis_data:/data
         ports:
           - "6379:6379"
-
-    typesense:
-        image: typesense/typesense:0.22.2
-        restart: always
-        environment:
-          TYPESENSE_DATA_DIR: /data/typesense
-          TYPESENSE_ENABLE_CORS: "true"
-          TYPESENSE_API_KEY: "convoy"
-        volumes:
-          - ./typesense_data:/data/typesense
-        ports:
-          - "8108:8108"
-


### PR DESCRIPTION
This PR includes the following fixes.

- Added the `ingestPort` config to enable the `ingest` cli to use a different separate from the server's port. 
- Added the `logLevel` flag to enable us independently set the `ingest` cli's log level.
- Moved parsing `smtp` cli flags from server to the `worker`.