### PR TITLE
fix: fixing the permission denied when create a volume in current dir

### DIFF
--- a/configs/local/docker-compose.yml
+++ b/configs/local/docker-compose.yml
@@ -69,13 +69,13 @@ services:
           POSTGRES_PASSWORD: convoy
           PGDATA: /data/postgres
         volumes:
-          - ./postgres_data:/data/postgres
+          - postgres_data:/data/postgres
 
     redis_server:
         image: redis:alpine
         restart: always
         volumes:
-          - ./redis_data:/data
+          - redis_data:/data
 
     typesense:
         image: typesense/typesense:0.24.0
@@ -85,4 +85,8 @@ services:
             TYPESENSE_ENABLE_CORS: "true"
             TYPESENSE_API_KEY: "convoy"
         volumes:
-            - ./typesense_data:/data/typesense
+            - typesense_data:/data/typesense
+volumes:
+    postgres_data:
+    typesense_data:
+    redis_data:


### PR DESCRIPTION
## Context:
We are stucking when running the entire docker compose manifest in localhost, we've got the following message:

```shell
➜  local git:(main) docker compose logs postgres redis_server typesense
postgres-1 |chown: /data/postgres: Permission denied
redis_server-1 |chown: /data/postgres: Permission denied
typesense-1 |chown: /data/postgres: Permission denied
```

## Solution:
I propose split up the volumes from each component to volumes session, ex:
```yaml
volumes:
    postgres_data:
    typesense_data:
    redis_data:
```

## Reference:
- https://docs.docker.com/storage/volumes/#use-a-volume-with-docker-compose