### PR TITLE
add: eventId in ingest response

### DIFF
--- a/api/ingest.go
+++ b/api/ingest.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"errors"
+
 	"github.com/frain-dev/convoy/pkg/msgpack"
 
 	"io"
@@ -214,7 +215,12 @@ func (a *ApplicationHandler) IngestEvent(w http.ResponseWriter, r *http.Request)
 	if event.IsDuplicateEvent {
 		_ = render.Render(w, r, util.NewServerResponse("Duplicate event received, but will not be sent", len(payload), http.StatusOK))
 	} else {
-		_ = render.Render(w, r, util.NewServerResponse("Event received", len(payload), http.StatusOK))
+		responseData := map[string]interface {
+		}{
+			"eventId": event.UID,
+			"size":    len(payload),
+		}
+		_ = render.Render(w, r, util.NewServerResponse("Event received", responseData, http.StatusOK))
 	}
 }
 

--- a/pkg/log/std.go
+++ b/pkg/log/std.go
@@ -66,6 +66,10 @@ func WithError(err error) *logrus.Entry {
 	return stdLogger.entry.WithError(err)
 }
 
+func WithEventid(uid string) *logrus.Entry {
+	return stdLogger.entry.WithField("event_id", uid)
+}
+
 func WithLogger() *logrus.Logger {
 	return stdLogger.logger
 }


### PR DESCRIPTION
This provides a parital fix to #1931 

the ingest response now contains `eventId` param, which can be used to:
1. Inspect the workers to see what has happened with event 
2. use in event api to see the past dispatches

Additional logging are added to filters, to see when an event didn't matched body/header filters.
Logging also have `event-id` keyword in JSON dict, to filter the logs out