### PR TITLE
Postgres connection string encoded credentials

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -109,7 +110,8 @@ func (dc DatabaseConfiguration) BuildDsn() string {
 
 	authPart := ""
 	if dc.Username != "" || dc.Password != "" {
-		authPart = fmt.Sprintf("%s:%s@", dc.Username, dc.Password)
+		authPrefix := url.UserPassword(dc.Username, dc.Password)
+		authPart = fmt.Sprintf("%s@", authPrefix)
 	}
 
 	dbPart := ""

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"net/url"
 	"os"
 	"strconv"
 	"testing"
@@ -438,6 +440,67 @@ func TestOverride(t *testing.T) {
 				require.Equal(t, tc.expectedConfig.Redis, c.Redis)
 			default:
 			}
+		})
+	}
+}
+
+func Test_DatabaseConfigurationBuildDsn(t *testing.T) {
+	tests := []struct {
+		name        string
+		dbConfig    DatabaseConfiguration
+		expectedDsn string
+	}{
+		{
+			name: "handles happy path Postgres config",
+			dbConfig: DatabaseConfiguration{
+				Type:               PostgresDatabaseProvider,
+				Scheme:             "postgres",
+				Host:               "localhost",
+				Username:           "postgres",
+				Password:           "postgres",
+				Database:           "convoy",
+				Options:            "sslmode=disable&connect_timeout=30",
+				Port:               5432,
+				SetConnMaxLifetime: 3600,
+			},
+			expectedDsn: "postgres://postgres:postgres@localhost:5432/convoy?sslmode=disable&connect_timeout=30",
+		},
+		{
+			name: "escapes special characters in the password",
+			dbConfig: DatabaseConfiguration{
+				Type:               PostgresDatabaseProvider,
+				Scheme:             "postgres",
+				Host:               "localhost",
+				Username:           "asdf12345",
+				Password:           "Password1234@#%^/?:",
+				Database:           "convoy",
+				Options:            "sslmode=disable&connect_timeout=30",
+				Port:               5432,
+				SetConnMaxLifetime: 3600,
+			},
+			expectedDsn: "postgres://asdf12345:Password1234%40%23%25%5E%2F%3F%3A@localhost:5432/convoy?sslmode=disable&connect_timeout=30",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actualDsn := tc.dbConfig.BuildDsn()
+			require.Equal(t, tc.expectedDsn, actualDsn)
+
+			u, err := url.Parse(actualDsn)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.dbConfig.Scheme, u.Scheme)
+			require.Equal(t, tc.dbConfig.Host, u.Hostname())
+			require.Equal(t, tc.dbConfig.Username, u.User.Username())
+			actualPassword, passwordSet := u.User.Password()
+			require.True(t, passwordSet)
+			require.Equal(t, tc.dbConfig.Password, actualPassword)
+			expectedPath := fmt.Sprintf("/%s", tc.dbConfig.Database)
+			require.Equal(t, expectedPath, u.Path)
+
+			parsedPort, e := strconv.ParseInt(u.Port(), 10, 64)
+			require.NoError(t, e)
+			require.Equal(t, int64(tc.dbConfig.Port), parsedPort)
 		})
 	}
 }


### PR DESCRIPTION
# Overview

This PR reworks the Postgres connection string builder to percent-encode the password portion of the string. I discovered while spinning up an environment that the connection string does not handle special characters in the password. I spotted this while using auto-generated passwords which I pull directly from a secrets manager into the convoy environment variables.

Previously convoy placed the raw password into a postgres URI: `postgres://username:raw_password@hostname:port/dbname?any_params`. If the password has any special characters, like `@` or `:` for example, it would fail further downstream in the app code / library code when it tried to process the postgres URI and found URI delimiters in the password. The errors seen vary depending on which special characters are used. The library code might think the hostname and/or port section starts early for example.

Per https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING we can expect these URIs to largely follow RFC 3986 which tells us to percent encode special characters. Percent encoding should eliminate this type of connection string construction error for passwords.

It's possible there are other parts of the URI that could run into issues with special characters but I kept this PR scoped to the password since that's the only problematic piece in my environment.

_Note: Anyone who manually percent-encoded a postgres password to get things running previously would consider this a breaking change._