### PR TITLE
Add Subcription Filter Benchmarks

### DIFF
--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -941,7 +941,7 @@ func jsonEqual(got, want interface{}) bool {
 	return diff == jsondiff.FullMatch
 }
 
-func BenchmarkCompareNestedArrayOperator(t *testing.B) {
+func BenchmarkCompareNestedArrayOperator(b *testing.B) {
 	payload := map[string]interface{}{
 		"data": []interface{}{
 			map[string]interface{}{
@@ -969,26 +969,26 @@ func BenchmarkCompareNestedArrayOperator(t *testing.B) {
 		"swag":                   "hoodies",
 	}
 
-	t.ResetTimer()
-	t.ReportAllocs()
+	b.ResetTimer()
+	b.ReportAllocs()
 
-	for i := 0; i < t.N; i++ {
+	for i := 0; i < b.N; i++ {
 		p, err := flatten.Flatten(payload)
-		require.NoError(t, err)
+		require.NoError(b, err)
 
 		f, err := flatten.Flatten(filter)
-		require.NoError(t, err)
+		require.NoError(b, err)
 
 		matched, err := Compare(p, f)
-		require.NoError(t, err)
+		require.NoError(b, err)
 
 		if !matched {
-			t.Errorf("mismatch:\ngot:  %+v\nwant: %+v", matched, true)
+			b.Errorf("mismatch:\ngot:  %+v\nwant: %+v", matched, true)
 		}
 	}
 }
 
-func BenchmarkCompareAndOr(t *testing.B) {
+func BenchmarkCompareAndOr(b *testing.B) {
 	payload := map[string]interface{}{
 		"cities": []interface{}{
 			"lagos",
@@ -1026,26 +1026,26 @@ func BenchmarkCompareAndOr(t *testing.B) {
 		},
 	}
 
-	t.ResetTimer()
-	t.ReportAllocs()
+	b.ResetTimer()
+	b.ReportAllocs()
 
-	for i := 0; i < t.N; i++ {
+	for i := 0; i < b.N; i++ {
 		p, err := flatten.Flatten(payload)
-		require.NoError(t, err)
+		require.NoError(b, err)
 
 		f, err := flatten.Flatten(filter)
-		require.NoError(t, err)
+		require.NoError(b, err)
 
 		matched, err := Compare(p, f)
-		require.NoError(t, err)
+		require.NoError(b, err)
 
 		if !matched {
-			t.Errorf("mismatch:\ngot:  %+v\nwant: %+v", matched, true)
+			b.Errorf("mismatch:\ngot:  %+v\nwant: %+v", matched, true)
 		}
 	}
 }
 
-func BenchmarkCompareRegex(t *testing.B) {
+func BenchmarkCompareRegex(b *testing.B) {
 	payload := map[string]interface{}{
 		"event": "https://admin:admin@mfs-registry-stg.g4.app.cloud.comcast.net/eureka/apps/MFSAGENT/mfsagent:e1432431e46cf610d06e2dbcda13b069?status=UP&lastDirtyTimestamp=1643797857108",
 	}
@@ -1056,21 +1056,21 @@ func BenchmarkCompareRegex(t *testing.B) {
 		},
 	}
 
-	t.ResetTimer()
-	t.ReportAllocs()
+	b.ResetTimer()
+	b.ReportAllocs()
 
-	for i := 0; i < t.N; i++ {
+	for i := 0; i < b.N; i++ {
 		p, err := flatten.Flatten(payload)
-		require.NoError(t, err)
+		require.NoError(b, err)
 
 		f, err := flatten.Flatten(filter)
-		require.NoError(t, err)
+		require.NoError(b, err)
 
 		matched, err := Compare(p, f)
-		require.NoError(t, err)
+		require.NoError(b, err)
 
 		if !matched {
-			t.Errorf("mismatch:\ngot:  %+v\nwant: %+v", matched, true)
+			b.Errorf("mismatch:\ngot:  %+v\nwant: %+v", matched, true)
 		}
 	}
 }

--- a/pkg/flatten/flat_test.go
+++ b/pkg/flatten/flat_test.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"errors"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/nsf/jsondiff"
@@ -964,7 +965,7 @@ func TestFlattenWithOrAndOperator(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			got, err := Flatten(test.given)
 			if test.wantErr {
-				if test.err != err {
+				if !errors.Is(err, test.err) {
 					t.Errorf("failed to flatten: %+v", err)
 				}
 			}
@@ -1143,12 +1144,12 @@ func TestFlattenArray(t *testing.T) {
 
 func TestFlattenLargeJSON(t *testing.T) {
 	var given, want interface{}
-	err := json.Unmarshal([]byte(ghEvent), &given)
+	err := json.Unmarshal(ghEvent, &given)
 	if err != nil {
 		t.Errorf("failed to unmarshal JSON: %v", err)
 	}
 
-	err = json.Unmarshal([]byte(ghEventFlat), &want)
+	err = json.Unmarshal(ghEventFlat, &want)
 	if err != nil {
 		t.Errorf("failed to unmarshal JSON: %v", err)
 	}
@@ -1171,4 +1172,220 @@ func jsonEqual(got, want interface{}) bool {
 
 	diff, _ := jsondiff.Compare(a, b, &jsondiff.Options{})
 	return diff == jsondiff.FullMatch
+}
+
+func BenchmarkFlattenArray(b *testing.B) {
+	test := `
+        [
+            {
+              "hallo": {
+                  "lorem": [20, 2],
+                  "ipsum": {
+                      "dolor": ["1", "10"]
+                  }
+              }
+            },
+            {
+              "game": {
+                  "name": "Elden Ring",
+                  "authors": {
+                      "first_name": "George",
+                      "last_name": "Martin"
+                  }
+              }
+            },
+            {
+              "person": {
+                  "ages": [100, -1],
+                  "names": {
+                      "parts": ["ray", "mond"]
+                  }
+              }
+            }
+        ]`
+
+	want := map[string]interface{}{
+		"0.hallo.lorem":             []interface{}{float64(20), float64(2)},
+		"0.hallo.ipsum.dolor":       []interface{}{"1", "10"},
+		"1.game.authors.first_name": "George",
+		"1.game.authors.last_name":  "Martin",
+		"1.game.name":               "Elden Ring",
+		"2.person.ages":             []interface{}{float64(100), float64(-1)},
+		"2.person.names.parts":      []interface{}{"ray", "mond"},
+	}
+
+	var given interface{}
+	err := json.Unmarshal([]byte(test), &given)
+	if err != nil {
+		require.NoError(b, err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		got, err := Flatten(given)
+		require.NoError(b, err)
+
+		if !jsonEqual(got, want) {
+			b.Errorf("mismatch:\ngot:  %+v\nwant: %+v", got, want)
+		}
+	}
+}
+
+func BenchmarkFlattenMap(b *testing.B) {
+	test := map[string]interface{}{
+		"$and": []map[string]interface{}{
+			{
+				"$or": []map[string]interface{}{
+					{
+						"person": map[string]interface{}{
+							"age": map[string]interface{}{
+								"$in": []int{10, 11, 12},
+							},
+						},
+					},
+					{
+						"places": map[string]interface{}{
+							"temperatures": 39.9,
+						},
+					},
+				},
+			},
+			{
+				"city": "lagos",
+			},
+		},
+	}
+
+	want := map[string]interface{}{
+		"$and": []map[string]interface{}{
+			{
+				"$or": []map[string]interface{}{
+					{
+						"person.age": map[string]interface{}{
+							"$in": []int{10, 11, 12},
+						},
+					},
+					{
+						"places.temperatures": 39.9,
+					},
+				},
+			},
+			{
+				"city": "lagos",
+			},
+		},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		got, err := Flatten(test)
+		require.NoError(b, err)
+
+		if !jsonEqual(got, want) {
+			b.Errorf("mismatch:\ngot:  %+v\nwant: %+v", got, want)
+		}
+	}
+}
+
+func BenchmarkFlattenLargeJson(b *testing.B) {
+	var given, want interface{}
+	err := json.Unmarshal(ghEvent, &given)
+	if err != nil {
+		b.Errorf("failed to unmarshal JSON: %v", err)
+	}
+
+	err = json.Unmarshal(ghEventFlat, &want)
+	if err != nil {
+		b.Errorf("failed to unmarshal JSON: %v", err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		got, err := Flatten(given)
+		require.NoError(b, err)
+
+		if !jsonEqual(got, want) {
+			expectedJson, _ := json.MarshalIndent(got, "", " ")
+			b.Errorf("%v\n", string(expectedJson))
+		}
+	}
+}
+
+func BenchmarkFlattenOperators(b *testing.B) {
+	given := map[string]interface{}{
+		"filter": map[string]interface{}{
+			"person": map[string]interface{}{
+				"age": map[string]interface{}{
+					"$eq": float64(5),
+				},
+			},
+		},
+	}
+	want := map[string]interface{}{
+		"filter.person.age": map[string]interface{}{
+			"$eq": float64(5),
+		},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		got, err := Flatten(given)
+		require.NoError(b, err)
+
+		if !jsonEqual(got, want) {
+			expectedJson, _ := json.MarshalIndent(got, "", " ")
+			b.Errorf("%v\n", string(expectedJson))
+		}
+	}
+}
+
+func BenchmarkFlattenWithPrefix(b *testing.B) {
+	test := `{
+				"hello": {
+					"lorem": {
+						"ipsum": "again",
+						"dolor": "sit"
+					}
+				},
+				"world": {
+					"lorem": {
+						"ipsum": "again",
+						"dolor": "sit"
+					}
+				}
+			}`
+
+	want := map[string]interface{}{
+		"data.hello.lorem.ipsum": "again",
+		"data.hello.lorem.dolor": "sit",
+		"data.world.lorem.ipsum": "again",
+		"data.world.lorem.dolor": "sit",
+	}
+
+	var given interface{}
+	err := json.Unmarshal([]byte(test), &given)
+	if err != nil {
+		require.NoError(b, err)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		got, err := FlattenWithPrefix("data", given)
+		require.NoError(b, err)
+
+		if !jsonEqual(got, want) {
+			expectedJson, _ := json.MarshalIndent(got, "", " ")
+			b.Errorf("%v\n", string(expectedJson))
+		}
+	}
 }


### PR DESCRIPTION
Benchmarks for the flatten and compare packages used for subscription filters

```txt
BenchmarkFlattenArray
BenchmarkFlattenArray-12         	   52860	     22313 ns/op	   16025 B/op	     306 allocs/op
BenchmarkFlattenMap
BenchmarkFlattenMap-12           	   72457	     16310 ns/op	   15968 B/op	     265 allocs/op
BenchmarkFlattenLargeJson
BenchmarkFlattenLargeJson-12     	    1099	   1086014 ns/op	  848443 B/op	    7112 allocs/op
BenchmarkFlattenOperators
BenchmarkFlattenOperators-12     	  216832	      5461 ns/op	    6102 B/op	      84 allocs/op
BenchmarkFlattenWithPrefix
BenchmarkFlattenWithPrefix-12    	  109190	     11172 ns/op	    9858 B/op	     153 allocs/op


BenchmarkCompareNestedArrayOperator
BenchmarkCompareNestedArrayOperator-12    	  131340	      8217 ns/op	    9015 B/op	     103 allocs/op
BenchmarkCompareAndOr
BenchmarkCompareAndOr-12                  	  229128	      5217 ns/op	    6300 B/op	      43 allocs/op
BenchmarkCompareRegex
BenchmarkCompareRegex-12                  	   97258	     12038 ns/op	   14675 B/op	     104 allocs/op
```
I only picked the most complex variants. The slowest one is flattening a large (17KB) JSON file (it’s a Github webhook sample), which takes ~1 ms.