### PR TITLE
bg: fix panic when request body is a string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 .idea
+.vscode
 
 /api/ui/build/*
 !/api/ui/build/go_test_stub.txt

--- a/pkg/flatten/flat.go
+++ b/pkg/flatten/flat.go
@@ -133,6 +133,7 @@ func flatten(prefix string, nested interface{}) (map[string]interface{}, error) 
 			f[k] = v
 		}
 	case nil:
+	case string:
 	default:
 		if prefix != "" {
 			f[prefix] = n

--- a/pkg/flatten/flat_test.go
+++ b/pkg/flatten/flat_test.go
@@ -4,10 +4,10 @@ import (
 	_ "embed"
 	"encoding/json"
 	"errors"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/nsf/jsondiff"
+	"github.com/stretchr/testify/require"
 )
 
 //go:embed gh_event.json
@@ -77,6 +77,11 @@ func TestFlattenMap(t *testing.T) {
 		{
 			name:  "nothing",
 			given: nil,
+			want:  map[string]interface{}{},
+		},
+		{
+			name:  "string",
+			given: "random_string",
 			want:  map[string]interface{}{},
 		},
 	}


### PR DESCRIPTION
```
change adds support for string request body in the flatten method.
```
![Screenshot 2024-05-03 at 16 09 14](https://github.com/frain-dev/convoy/assets/24735571/292afc9e-43b0-4566-ac49-bcadf9310f1c)

