### PR TITLE
display user-settings page when there are no orgs

### DIFF
--- a/web/ui/dashboard/src/app/private/private.component.html
+++ b/web/ui/dashboard/src/app/private/private.component.html
@@ -83,7 +83,7 @@
 
 	<div class="mt-60px">
 		<div
-			*ngIf="!isLoadingOrganisations && !organisations?.length"
+			*ngIf="!shouldMountAppRouter()"
 			convoy-empty-state
 			imgSrc="/assets/img/organizations-empty-state.svg"
 			heading="Create an organisation to get started with Convoy"
@@ -97,7 +97,7 @@
 			</button>
 		</div>
 
-		<router-outlet *ngIf="organisations?.length"></router-outlet>
+		<router-outlet *ngIf="shouldMountAppRouter()"></router-outlet>
 	</div>
 
 	<!-- Convoy version -->

--- a/web/ui/dashboard/src/app/private/private.component.ts
+++ b/web/ui/dashboard/src/app/private/private.component.ts
@@ -71,6 +71,10 @@ export class PrivateComponent implements OnInit {
 		return authDetails ? JSON.parse(authDetails) : false;
 	}
 
+    shouldMountAppRouter(): boolean {
+        return !this.isLoadingOrganisations && (Boolean(this.organisations?.length) || this.router.url.startsWith('/user-settings'))
+    }
+
 	async getConfiguration() {
 		try {
 			const response = await this.privateService.getConfiguration();


### PR DESCRIPTION
Closes #1967

https://github.com/frain-dev/convoy/assets/25608335/4ac0b1cc-fde3-4d07-9932-f2bb21f1249b

I added a comment in the originating issue about how the logic for forcing users to create an organisation might not be in the best place. https://sourcegraph.com/github.com/frain-dev/convoy/-/blob/web/ui/dashboard/src/app/private/private.component.html?L100

Since the exception for displaying a page when there are no organisations only applies to the `/user-settings` route, then we can get away with it with this band-aid fix.

cc @subomi 