### PR TITLE
Limit number of events created

### DIFF
--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -185,8 +185,6 @@ func AddWorkerCommand(a *cli.App) *cobra.Command {
 				render.JSON(w, r, "Convoy")
 			})
 
-			go task.QueueStuckEventDeliveries(ctx, eventDeliveryRepo, a.Queue)
-
 			srv := &http.Server{
 				Handler: router,
 				Addr:    fmt.Sprintf(":%d", workerPort),


### PR DESCRIPTION
Create events for the same number of endpoints and not the number of subscriptions