### PR TITLE
feat: Add support for inbound webhooks that use `urlencoded` content type

### DIFF
--- a/api/ingest.go
+++ b/api/ingest.go
@@ -244,6 +244,7 @@ func (a *ApplicationHandler) IngestEvent(w http.ResponseWriter, r *http.Request)
 const (
 	applicationJsonContentType   = "application/json"
 	multipartFormDataContentType = "multipart/form-data"
+	urlEncodedContentType        = "application/x-www-form-urlencoded"
 )
 
 func extractPayloadFromIngestEventReq(r *http.Request, maxIngestSize uint64) ([]byte, error) {
@@ -265,7 +266,7 @@ func extractPayloadFromIngestEventReq(r *http.Request, maxIngestSize uint64) ([]
 	}
 
 	switch contentType {
-	case multipartFormDataContentType:
+	case multipartFormDataContentType, urlEncodedContentType:
 		if err := r.ParseMultipartForm(int64(maxIngestSize)); err != nil {
 			return nil, err
 		}
@@ -279,7 +280,6 @@ func extractPayloadFromIngestEventReq(r *http.Request, maxIngestSize uint64) ([]
 			}
 		}
 		return json.Marshal(data)
-
 	default:
 		// To avoid introducing a breaking change, we are keeping the old behaviour of assuming
 		// the content type is JSON if the content type is not specified/unsupported.

--- a/api/ingest_test.go
+++ b/api/ingest_test.go
@@ -63,8 +63,7 @@ func Test_extractPayloadFromIngestEventReq(t *testing.T) {
 
 		payload, err := extractPayloadFromIngestEventReq(req, 1024)
 		require.NoError(t, err)
-		fmt.Println(string(payload))
-		require.Equal(t, []byte(`{"key1": "value1", "key2": "value2"}`), payload)
+		require.Equal(t, []byte(`{"key1":"value1","key2":"value2"}`), payload)
 	})
 
 	t.Run("unsupported content type", func(t *testing.T) {

--- a/api/ingest_test.go
+++ b/api/ingest_test.go
@@ -63,6 +63,7 @@ func Test_extractPayloadFromIngestEventReq(t *testing.T) {
 
 		payload, err := extractPayloadFromIngestEventReq(req, 1024)
 		require.NoError(t, err)
+		fmt.Println(string(payload))
 		require.Equal(t, []byte(`{"key1": "value1", "key2": "value2"}`), payload)
 	})
 

--- a/api/ingest_test.go
+++ b/api/ingest_test.go
@@ -33,7 +33,7 @@ func Test_extractPayloadFromIngestEventReq(t *testing.T) {
 		require.NoError(t, writer.Close())
 
 		req := httptest.NewRequest(http.MethodPost, "/", body)
-		req.Header.Set("Content-Type", fmt.Sprintf("%s; boundary=$s", multipartFormDataContentType, writer.Boundary()))
+		req.Header.Set("Content-Type", fmt.Sprintf("%s; boundary=%s", multipartFormDataContentType, writer.Boundary()))
 
 		payload, err := extractPayloadFromIngestEventReq(req, 1024)
 		require.NoError(t, err)

--- a/api/ingest_test.go
+++ b/api/ingest_test.go
@@ -56,14 +56,14 @@ func Test_extractPayloadFromIngestEventReq(t *testing.T) {
 	})
 
 	t.Run("urlencoded content type", func(t *testing.T) {
-		body := strings.NewReader("value1=key1&value2=key2")
+		body := strings.NewReader("key1=value1&key2=value2")
 
 		req := httptest.NewRequest(http.MethodPost, "/", body)
 		req.Header.Set("Content-Type", urlEncodedContentType)
 
 		payload, err := extractPayloadFromIngestEventReq(req, 1024)
 		require.NoError(t, err)
-		require.Equal(t, body, payload)
+		require.Equal(t, []byte(`{"key1": "value1", "key2": "value2"}`), payload)
 	})
 
 	t.Run("unsupported content type", func(t *testing.T) {
@@ -74,6 +74,6 @@ func Test_extractPayloadFromIngestEventReq(t *testing.T) {
 
 		payload, err := extractPayloadFromIngestEventReq(req, 1024)
 		require.NoError(t, err)
-		require.Equal(t, []byte(`{"key": "value"}`), payload)
+		require.Equal(t, jsonBody, payload)
 	})
 }


### PR DESCRIPTION
Closes #2117

This adds support for content type `url-encoded`when ingesting webhooks.