### PR TITLE
fix: fix slice init length

### DIFF
--- a/worker/task/queue_stuck_event_deliveries.go
+++ b/worker/task/queue_stuck_event_deliveries.go
@@ -20,7 +20,7 @@ func QueueStuckEventDeliveries(ctx context.Context, edRepo datastore.EventDelive
 		}
 
 		ids := func() []string {
-			arr := make([]string, len(evs))
+			arr := make([]string, 0, len(evs))
 			for i := 0; i < len(evs); i++ {
 				arr = append(arr, evs[i].UID)
 			}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of len(evs) rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW