### PR TITLE
Upsert event types

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,7 +108,7 @@ var DefaultConfiguration = Configuration{
 		},
 	},
 	Dispatcher: DispatcherConfiguration{
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: false,
 		AllowList:          []string{"0.0.0.0/0", "::/0"},
 		BlockList:          []string{"127.0.0.0/8", "::1/128"},
 	},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -179,7 +179,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 				Dispatcher: DispatcherConfiguration{
-					InsecureSkipVerify: true,
+					InsecureSkipVerify: false,
 					AllowList:          []string{"0.0.0.0/0", "::/0"},
 					BlockList:          []string{"127.0.0.0/8", "::1/128"},
 				},
@@ -271,7 +271,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 				Dispatcher: DispatcherConfiguration{
-					InsecureSkipVerify: true,
+					InsecureSkipVerify: false,
 					AllowList:          []string{"0.0.0.0/0", "::/0"},
 					BlockList:          []string{"127.0.0.0/8", "::1/128"},
 				},
@@ -362,7 +362,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 				},
 				Dispatcher: DispatcherConfiguration{
-					InsecureSkipVerify: true,
+					InsecureSkipVerify: false,
 					AllowList:          []string{"0.0.0.0/0", "::/0"},
 					BlockList:          []string{"127.0.0.0/8", "::1/128"},
 				},

--- a/database/postgres/subscription.go
+++ b/database/postgres/subscription.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/oklog/ulid/v2"
 	"math"
 	"time"
 
@@ -259,6 +260,9 @@ const (
 	deleted_at = NOW()
 	WHERE id = $1 AND project_id = $2;
 	`
+
+	upsertSubscriptionEventTypes = `
+	INSERT INTO convoy.event_types (id, name, project_id, description, category) VALUES (:id, :name, :project_id, :description, :category) on conflict do nothing;`
 )
 
 var (
@@ -481,7 +485,18 @@ func (s *subscriptionRepo) CreateSubscription(ctx context.Context, projectID str
 
 	fc.Filter.IsFlattened = true // this is just a flag so we can identify old records
 
-	result, err := s.db.ExecContext(
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func(tx *sqlx.Tx) {
+		innerErr := tx.Rollback()
+		if innerErr != nil {
+			err = innerErr
+		}
+	}(tx)
+
+	result, err := tx.ExecContext(
 		ctx, createSubscription, subscription.UID,
 		subscription.Name, subscription.Type, subscription.ProjectID,
 		endpointID, deviceID, sourceID,
@@ -503,11 +518,33 @@ func (s *subscriptionRepo) CreateSubscription(ctx context.Context, projectID str
 	}
 
 	_subscription := &datastore.Subscription{}
-	err = s.db.QueryRowxContext(ctx, fmt.Sprintf(fetchSubscriptionByID, "s.id", "s.project_id"), subscription.UID, projectID).StructScan(_subscription)
+	err = tx.QueryRowxContext(ctx, fmt.Sprintf(fetchSubscriptionByID, "s.id", "s.project_id"), subscription.UID, projectID).StructScan(_subscription)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return datastore.ErrSubscriptionNotFound
 		}
+		return err
+	}
+
+	eventTypesSlice := make([]*datastore.ProjectEventType, len(subscription.FilterConfig.EventTypes))
+	for i := range subscription.FilterConfig.EventTypes {
+		eventTypesSlice[i] = &datastore.ProjectEventType{
+			UID:         ulid.Make().String(),
+			Name:        subscription.FilterConfig.EventTypes[i],
+			ProjectId:   subscription.ProjectID,
+			Description: "",
+			Category:    "",
+		}
+	}
+
+	// create event types for each subscription
+	_, err = tx.NamedExecContext(ctx, upsertSubscriptionEventTypes, eventTypesSlice)
+	if err != nil {
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
 		return err
 	}
 
@@ -520,7 +557,7 @@ func (s *subscriptionRepo) CreateSubscription(ctx context.Context, projectID str
 		return err
 	}
 
-	return nil
+	return err
 }
 
 func (s *subscriptionRepo) UpdateSubscription(ctx context.Context, projectID string, subscription *datastore.Subscription) error {
@@ -546,6 +583,17 @@ func (s *subscriptionRepo) UpdateSubscription(ctx context.Context, projectID str
 
 	fc.Filter.IsFlattened = true // this is just a flag so we can identify old records
 
+	tx, err := s.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func(tx *sqlx.Tx) {
+		innerErr := tx.Rollback()
+		if innerErr != nil {
+			err = innerErr
+		}
+	}(tx)
+
 	result, err := s.db.ExecContext(
 		ctx, updateSubscription, subscription.UID, projectID,
 		subscription.Name, subscription.EndpointID, sourceID,
@@ -567,11 +615,33 @@ func (s *subscriptionRepo) UpdateSubscription(ctx context.Context, projectID str
 	}
 
 	_subscription := &datastore.Subscription{}
-	err = s.db.QueryRowxContext(ctx, fmt.Sprintf(fetchSubscriptionByID, "s.id", "s.project_id"), subscription.UID, projectID).StructScan(_subscription)
+	err = tx.QueryRowxContext(ctx, fmt.Sprintf(fetchSubscriptionByID, "s.id", "s.project_id"), subscription.UID, projectID).StructScan(_subscription)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return datastore.ErrSubscriptionNotFound
 		}
+		return err
+	}
+
+	eventTypesSlice := make([]*datastore.ProjectEventType, len(subscription.FilterConfig.EventTypes))
+	for i := range subscription.FilterConfig.EventTypes {
+		eventTypesSlice[i] = &datastore.ProjectEventType{
+			UID:         ulid.Make().String(),
+			Name:        subscription.FilterConfig.EventTypes[i],
+			ProjectId:   subscription.ProjectID,
+			Description: "",
+			Category:    "",
+		}
+	}
+
+	// create event types for each subscription
+	_, err = tx.NamedExecContext(ctx, upsertSubscriptionEventTypes, eventTypesSlice)
+	if err != nil {
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
 		return err
 	}
 
@@ -584,7 +654,7 @@ func (s *subscriptionRepo) UpdateSubscription(ctx context.Context, projectID str
 		return err
 	}
 
-	return nil
+	return err
 }
 
 func (s *subscriptionRepo) LoadSubscriptionsPaged(ctx context.Context, projectID string, filter *datastore.FilterBy, pageable datastore.Pageable) ([]datastore.Subscription, datastore.PaginationData, error) {

--- a/net/dispatcher.go
+++ b/net/dispatcher.go
@@ -169,7 +169,8 @@ func BlockListOption(blockList []string) DispatcherOption {
 	}
 }
 
-// InsecureSkipVerifyOption allow self-signed certificates if set to false which is susceptible to MITM attacks.
+// InsecureSkipVerifyOption allow self-signed certificates
+// to be used if set to true but is susceptible to Man In The Middle attacks.
 func InsecureSkipVerifyOption(insecureSkipVerify bool) DispatcherOption {
 	return func(d *Dispatcher) error {
 		if insecureSkipVerify {

--- a/sql/1733488138.sql
+++ b/sql/1733488138.sql
@@ -1,0 +1,6 @@
+-- +migrate Up
+create unique index if not exists idx_event_types_name_project_id
+    on convoy.event_types (project_id, name);
+
+-- +migrate Down
+drop index if exists convoy.idx_event_types_name_project_id;


### PR DESCRIPTION
This PR facilitates the creation of new event types created via the API (used by the client libraries) whenever a subscription is created or updated. This ensures that the list of event types available to a customer on the customer portals is up to date.