### PR TITLE
fixed portal link UI issues with subscriptions, endpoints and license check

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -450,6 +450,8 @@ func (a *ApplicationHandler) BuildControlPlaneRoutes() *chi.Mux {
 
 		portalLinkRouter.Get("/portal_link", handler.GetPortalLink)
 
+		portalLinkRouter.Get("/license/features", handler.GetLicenseFeatures)
+
 		portalLinkRouter.Route("/endpoints", func(endpointRouter chi.Router) {
 			endpointRouter.With(middleware.Pagination).Get("/", handler.GetEndpoints)
 			endpointRouter.Get("/{endpointID}", handler.GetEndpoint)
@@ -659,6 +661,8 @@ func (a *ApplicationHandler) BuildDataPlaneRoutes() *chi.Mux {
 		portalLinkRouter.Use(middleware.SetupCORS)
 		portalLinkRouter.Use(middleware.RequireValidPortalLinksLicense(handler.A.Licenser))
 		portalLinkRouter.Use(middleware.RequireAuth())
+
+		portalLinkRouter.Get("/license/features", handler.GetLicenseFeatures)
 
 		portalLinkRouter.Route("/events", func(eventRouter chi.Router) {
 			eventRouter.Post("/", handler.CreateEndpointEvent)

--- a/datastore/models.go
+++ b/datastore/models.go
@@ -1049,7 +1049,7 @@ type Subscription struct {
 	UID        string           `json:"uid" db:"id"`
 	Name       string           `json:"name" db:"name"`
 	Type       SubscriptionType `json:"type" db:"type"`
-	ProjectID  string           `json:"-" db:"project_id"`
+	ProjectID  string           `json:"project_id" db:"project_id"`
 	SourceID   string           `json:"-" db:"source_id"`
 	EndpointID string           `json:"-" db:"endpoint_id"`
 	DeviceID   string           `json:"-" db:"device_id"`

--- a/web/ui/dashboard/src/app/models/subscription.ts
+++ b/web/ui/dashboard/src/app/models/subscription.ts
@@ -11,6 +11,7 @@ export interface SUBSCRIPTION {
 	status: string;
 	type: 'outgoing' | 'incoming';
 	uid: string;
+	project_id: string;
 	updated_at: string;
 	endpoint_metadata?: ENDPOINT;
 	alert_config?: { count: number; threshold: string };

--- a/web/ui/dashboard/src/app/portal/subscriptions/subscriptions.component.ts
+++ b/web/ui/dashboard/src/app/portal/subscriptions/subscriptions.component.ts
@@ -81,8 +81,20 @@ export class SubscriptionsComponent implements OnInit {
         }
 		this.action = action;
 		this.showSubscriptionForm = true;
-        this.location.go(`/portal/subscriptions/${action === 'create' ? 'new' : this.activeSubscription?.uid}?token=${this.token}${this.activeSubscription?.project_id ? `&projectId=${this.activeSubscription.project_id}` : ''}${this.endpointId ? `&endpointId=${this.endpointId}` : ''}`);
-	}
+        let subscriptionPath = '/portal/subscriptions/';
+        if (action === 'create') {
+            subscriptionPath += 'new';
+        } else if (this.activeSubscription?.uid) {
+            subscriptionPath += this.activeSubscription.uid;
+        }
+
+        let queryParams = `?token=${this.token}`;
+        if (this.endpointId) {
+            queryParams += `&endpointId=${this.endpointId}`;
+        }
+
+        this.location.go(subscriptionPath + queryParams);
+    }
 
 	async deleteSubscripton() {
 		this.isDeletingSubscription = true;

--- a/web/ui/dashboard/src/app/portal/subscriptions/subscriptions.component.ts
+++ b/web/ui/dashboard/src/app/portal/subscriptions/subscriptions.component.ts
@@ -17,6 +17,7 @@ import { DropdownComponent, DropdownOptionDirective } from 'src/app/components/d
 import { PortalService } from '../portal.service';
 import { DialogDirective } from 'src/app/components/dialog/dialog.directive';
 import { TagComponent } from 'src/app/components/tag/tag.component';
+import { LicensesService } from '../../services/licenses/licenses.service';
 
 @Component({
 	selector: 'convoy-subscriptions',
@@ -43,10 +44,10 @@ export class SubscriptionsComponent implements OnInit {
 
 	token: string = this.route.snapshot.queryParams.token;
 
-	constructor(private privateService: PrivateService, private generalService: GeneralService, private location: Location, private route: ActivatedRoute, private portalService: PortalService) {}
+	constructor(private privateService: PrivateService, private generalService: GeneralService, private location: Location, private route: ActivatedRoute, private portalService: PortalService, public licenseService: LicensesService) {}
 
 	ngOnInit() {
-		Promise.all([this.getPortalDetails(), this.getSubscriptions()]);
+		Promise.all([this.getPortalDetails(), this.getSubscriptions(), this.licenseService.setLicenses()]);
 	}
 
 	async getPortalDetails() {
@@ -71,9 +72,16 @@ export class SubscriptionsComponent implements OnInit {
 	}
 
 	openSubsriptionForm(action: 'create' | 'update') {
+        let project = localStorage.getItem("CONVOY_PROJECT");
+        if (!project && this.activeSubscription?.project_id) {
+            localStorage.setItem(
+                'CONVOY_PROJECT',
+                JSON.stringify({ uid: this.activeSubscription?.project_id })
+            );
+        }
 		this.action = action;
 		this.showSubscriptionForm = true;
-		this.location.go(`/portal/subscriptions/${action === 'create' ? 'new' : this.activeSubscription?.uid}?token=${this.token}${this.activeSubscription || this.endpointId ? `&endpointId=${this.activeSubscription?.uid || this.endpointId}` : ''}`);
+        this.location.go(`/portal/subscriptions/${action === 'create' ? 'new' : this.activeSubscription?.uid}?token=${this.token}${this.activeSubscription?.project_id ? `&projectId=${this.activeSubscription.project_id}` : ''}${this.endpointId ? `&endpointId=${this.endpointId}` : ''}`);
 	}
 
 	async deleteSubscripton() {


### PR DESCRIPTION
This pull request effectively resolves issues when portal links are run in an iframe.

Within an iframe, the portal link page lacks the essential context a user receives upon logging in.

The following critical issues have been addressed:
- Editing subscriptions no longer generate unauthorized responses, banners, or errors.
- All fields now accurately reflect the licensing status, eliminating the incorrect display of the license lock for licensed instances.