### PR TITLE
fix: create organisation does not reflect app-wide

### DIFF
--- a/web/ui/dashboard-react/src/app/projects/index.tsx
+++ b/web/ui/dashboard-react/src/app/projects/index.tsx
@@ -1,17 +1,18 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { createFileRoute } from '@tanstack/react-router';
 
 import { ConvoyLoader } from '@/components/convoy-loader';
 import { CreateOrganisation } from '@/components/create-organisation';
+
+import { useOrganisationContext } from '@/contexts/organisation';
 
 import { ensureCanAccessPrivatePages } from '@/lib/auth';
 import * as projectsService from '@/services/projects.service';
 import * as orgsService from '@/services/organisations.service';
 
 import type { Project } from '@/models/project.model';
-import type { Organisation } from '@/models/organisation.model';
 
-export const Route = createFileRoute('/projects/_layout/')({
+export const Route = createFileRoute('/projects/')({
 	beforeLoad({ context }) {
 		ensureCanAccessPrivatePages(context.auth?.getTokens().isLoggedIn);
 	},
@@ -20,26 +21,20 @@ export const Route = createFileRoute('/projects/_layout/')({
 
 function RouteComponent() {
 	const [isLoadingOrganisations, setIsLoadingOrganisations] = useState(false);
-	const [organisations, setOrganisations] = useState<Organisation[]>([]);
+	const { setOrganisations, organisations } = useOrganisationContext();
 
 	// TODO use a hook for organisations and projects
 	const [currentProject /* setCurrentProject */] = useState<Project | null>(
 		projectsService.getCachedProject(),
 	);
 
-	useEffect(() => {
-		getOrganisations();
-
-		return () => {
-			// clear all requests on unmount component
-		};
-	}, []);
-
 	function getOrganisations() {
 		setIsLoadingOrganisations(true);
 		orgsService
 			.getOrganisations({ refresh: true })
-			.then(({ content }) => setOrganisations(content))
+			.then(({ content }) => {
+				setOrganisations(content);
+			})
 			// TODO use toast component to show UI error on all catch(error) where necessary
 			.catch(console.error)
 			.finally(() => {
@@ -53,7 +48,6 @@ function RouteComponent() {
 		return (
 			<CreateOrganisation
 				onOrgCreated={() => {
-					console.log('org created');
 					getOrganisations();
 				}}
 			/>

--- a/web/ui/dashboard-react/src/app/projects/route.tsx
+++ b/web/ui/dashboard-react/src/app/projects/route.tsx
@@ -2,6 +2,7 @@ import { ensureCanAccessPrivatePages } from '@/lib/auth';
 import { Outlet, createFileRoute } from '@tanstack/react-router';
 
 import { DashboardLayout } from '@/components/dashboard';
+import { OrganisationProvider } from '@/contexts/organisation';
 
 export const Route = createFileRoute('/projects')({
 	beforeLoad({ context }) {
@@ -12,8 +13,10 @@ export const Route = createFileRoute('/projects')({
 
 function ProjectsLayout() {
 	return (
-		<DashboardLayout>
-			<Outlet />
-		</DashboardLayout>
+		<OrganisationProvider>
+			<DashboardLayout>
+				<Outlet />
+			</DashboardLayout>
+		</OrganisationProvider>
 	);
 }

--- a/web/ui/dashboard-react/src/app/projects/route.tsx
+++ b/web/ui/dashboard-react/src/app/projects/route.tsx
@@ -13,6 +13,7 @@ export const Route = createFileRoute('/projects')({
 
 function ProjectsLayout() {
 	return (
+		// TODO use Zustand instead because this provider here will cause the whole nodes to rerender and that's not performant
 		<OrganisationProvider>
 			<DashboardLayout>
 				<Outlet />

--- a/web/ui/dashboard-react/src/app/projects/route.tsx
+++ b/web/ui/dashboard-react/src/app/projects/route.tsx
@@ -3,7 +3,7 @@ import { Outlet, createFileRoute } from '@tanstack/react-router';
 
 import { DashboardLayout } from '@/components/dashboard';
 
-export const Route = createFileRoute('/projects/_layout')({
+export const Route = createFileRoute('/projects')({
 	beforeLoad({ context }) {
 		ensureCanAccessPrivatePages(context.auth?.getTokens().isLoggedIn);
 	},

--- a/web/ui/dashboard-react/src/components/dashboard.tsx
+++ b/web/ui/dashboard-react/src/components/dashboard.tsx
@@ -72,7 +72,6 @@ import userProfileIcon from '../../assets/svg/user-icon.svg';
 
 import type { Project } from '@/models/project.model';
 import type { ComponentProps, ReactNode } from 'react';
-import { OrganisationProvider } from '@/contexts/organisation';
 
 function HeaderLeftLogo() {
 	const { toggleSidebar } = useSidebar();
@@ -170,9 +169,7 @@ function HeaderRightOrganisation() {
 		orgsService
 			.getOrganisations({ refresh: true })
 			.then(({ content }) => {
-				console.log('setting orgs');
 				setOrganisations(content);
-				console.log('done setting orgs');
 			})
 			.catch(console.error)
 			.finally(() => {
@@ -302,10 +299,8 @@ function HeaderRight() {
 	return (
 		<nav>
 			<ul className="flex items-center justify-end">
-				<OrganisationProvider>
-					<HeaderRightOrganisation />
-					<HeaderRightProfile />
-				</OrganisationProvider>
+				<HeaderRightOrganisation />
+				<HeaderRightProfile />
 			</ul>
 		</nav>
 	);
@@ -584,9 +579,7 @@ export function DashboardSidebar({ ...props }: ComponentProps<typeof Sidebar>) {
 								<SidebarGroup>
 									<SidebarGroupContent className="flex flex-col justify-center items-center">
 										<Button
-											disabled={
-												!currentOrganisation /*  || !canCreateProject */
-											}
+											disabled={!currentOrganisation || !canCreateProject}
 											variant={'ghost'}
 											className={cn(
 												'w-full hover:bg-neutral-3 ',
@@ -648,9 +641,7 @@ export function DashboardLayout(props: { children: ReactNode }) {
 			<SidebarProvider className="flex flex-col">
 				<DashboardHeader />
 				<div className="flex items-center h-full">
-					<OrganisationProvider>
-						<DashboardSidebar />
-					</OrganisationProvider>
+					<DashboardSidebar />
 					<SidebarInset className="flex h-full">{props.children}</SidebarInset>
 				</div>
 			</SidebarProvider>

--- a/web/ui/dashboard-react/src/contexts/organisation.tsx
+++ b/web/ui/dashboard-react/src/contexts/organisation.tsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+import { CONVOY_ORG_KEY } from '@/lib/constants';
+
+import type { Organisation } from '@/models/organisation.model';
+import type { ReactNode, SetStateAction, Dispatch } from 'react';
+
+function getCachedOrganisation(): Organisation | null {
+	let org = localStorage.getItem(CONVOY_ORG_KEY);
+	return org ? JSON.parse(org) : null;
+}
+
+export type OrganisationContext = {
+	organisations: Organisation[];
+	setOrganisations: Dispatch<SetStateAction<Organisation[]>>;
+	currentOrganisation: Organisation | null;
+	setCurrentOrganisation: Dispatch<SetStateAction<Organisation | null>>;
+};
+
+const OrganisationContext = createContext<OrganisationContext>({
+	currentOrganisation: getCachedOrganisation(),
+	organisations: [],
+	setCurrentOrganisation: () => null,
+	setOrganisations: () => [],
+});
+OrganisationContext.displayName = 'OrganisationContext';
+
+export const useOrganisationContext = () => useContext(OrganisationContext);
+
+export function OrganisationProvider({ children }: { children: ReactNode }) {
+	const [organisations, setOrganisations] = useState<Organisation[]>([]);
+	const [currentOrganisation, setCurrentOrganisation] = useState(
+		getCachedOrganisation(),
+	);
+
+	useEffect(() => {
+		if (!organisations.length) {
+			console.log('no orgs', children)
+			setCurrentOrganisation(null);
+			return localStorage.removeItem(CONVOY_ORG_KEY);
+		}
+
+			console.log('orgs exist', children)
+			setCurrentOrganisation(organisations[0]);
+		localStorage.setItem(CONVOY_ORG_KEY, JSON.stringify(organisations[0]));
+	}, [organisations]);
+
+	return (
+		<OrganisationContext.Provider
+			value={{
+				currentOrganisation,
+				organisations,
+				setCurrentOrganisation,
+				setOrganisations,
+			}}
+		>
+			{children}
+		</OrganisationContext.Provider>
+	);
+}
+
+// TODO use Zustand for state management

--- a/web/ui/dashboard-react/src/contexts/organisation.tsx
+++ b/web/ui/dashboard-react/src/contexts/organisation.tsx
@@ -35,13 +35,11 @@ export function OrganisationProvider({ children }: { children: ReactNode }) {
 
 	useEffect(() => {
 		if (!organisations.length) {
-			console.log('no orgs', children)
 			setCurrentOrganisation(null);
 			return localStorage.removeItem(CONVOY_ORG_KEY);
 		}
 
-			console.log('orgs exist', children)
-			setCurrentOrganisation(organisations[0]);
+		setCurrentOrganisation(organisations[0]);
 		localStorage.setItem(CONVOY_ORG_KEY, JSON.stringify(organisations[0]));
 	}, [organisations]);
 

--- a/web/ui/dashboard-react/src/hooks/use-auth.tsx
+++ b/web/ui/dashboard-react/src/hooks/use-auth.tsx
@@ -7,7 +7,7 @@ type AuthDetailsTokenJson = {
 	refresh_token: string;
 };
 
-export const useAuth = () => {
+export function useAuth() {
 	function getCachedAuthTokens() {
 		const authDetails = localStorage.getItem(CONVOY_AUTH_TOKENS_KEY);
 
@@ -25,7 +25,6 @@ export const useAuth = () => {
 	}
 
 	function getCachedAuthProfile(): null | CachedAuth {
-		console.log('getting auth profile');
 		const authProfile = localStorage.getItem(CONVOY_AUTH_KEY);
 
 		if (authProfile && authProfile !== 'undefined')
@@ -38,6 +37,6 @@ export const useAuth = () => {
 		getTokens: getCachedAuthTokens,
 		getCurrentUser: getCachedAuthProfile,
 	};
-};
+}
 
 export type AuthContext = ReturnType<typeof useAuth>;

--- a/web/ui/dashboard-react/src/routes.gen.ts
+++ b/web/ui/dashboard-react/src/routes.gen.ts
@@ -8,8 +8,6 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { createFileRoute } from '@tanstack/react-router'
-
 // Import Routes
 
 import { Route as rootRoute } from './app/__root'
@@ -18,24 +16,14 @@ import { Route as SignupImport } from './app/signup'
 import { Route as LoginImport } from './app/login'
 import { Route as GetStartedImport } from './app/get-started'
 import { Route as ForgotPasswordImport } from './app/forgot-password'
+import { Route as ProjectsRouteImport } from './app/projects/route'
 import { Route as IndexImport } from './app/index'
+import { Route as ProjectsIndexImport } from './app/projects/index'
 import { Route as OrganisationsIndexImport } from './app/organisations/index'
-import { Route as ProjectsLayoutImport } from './app/projects/_layout'
-import { Route as ProjectsLayoutIndexImport } from './app/projects/_layout/index'
 import { Route as OrganisationsOrganisationIdIndexImport } from './app/organisations/$organisationId/index'
 import { Route as OrganisationsOrganisationIdSettingsImport } from './app/organisations/$organisationId/settings'
 
-// Create Virtual Routes
-
-const ProjectsImport = createFileRoute('/projects')()
-
 // Create/Update Routes
-
-const ProjectsRoute = ProjectsImport.update({
-  id: '/projects',
-  path: '/projects',
-  getParentRoute: () => rootRoute,
-} as any)
 
 const UserSettingsRoute = UserSettingsImport.update({
   id: '/user-settings',
@@ -67,27 +55,28 @@ const ForgotPasswordRoute = ForgotPasswordImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
+const ProjectsRouteRoute = ProjectsRouteImport.update({
+  id: '/projects',
+  path: '/projects',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const IndexRoute = IndexImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRoute,
 } as any)
 
+const ProjectsIndexRoute = ProjectsIndexImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ProjectsRouteRoute,
+} as any)
+
 const OrganisationsIndexRoute = OrganisationsIndexImport.update({
   id: '/organisations/',
   path: '/organisations/',
   getParentRoute: () => rootRoute,
-} as any)
-
-const ProjectsLayoutRoute = ProjectsLayoutImport.update({
-  id: '/_layout',
-  getParentRoute: () => ProjectsRoute,
-} as any)
-
-const ProjectsLayoutIndexRoute = ProjectsLayoutIndexImport.update({
-  id: '/',
-  path: '/',
-  getParentRoute: () => ProjectsLayoutRoute,
 } as any)
 
 const OrganisationsOrganisationIdIndexRoute =
@@ -113,6 +102,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexImport
+      parentRoute: typeof rootRoute
+    }
+    '/projects': {
+      id: '/projects'
+      path: '/projects'
+      fullPath: '/projects'
+      preLoaderRoute: typeof ProjectsRouteImport
       parentRoute: typeof rootRoute
     }
     '/forgot-password': {
@@ -150,26 +146,19 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof UserSettingsImport
       parentRoute: typeof rootRoute
     }
-    '/projects': {
-      id: '/projects'
-      path: '/projects'
-      fullPath: '/projects'
-      preLoaderRoute: typeof ProjectsImport
-      parentRoute: typeof rootRoute
-    }
-    '/projects/_layout': {
-      id: '/projects/_layout'
-      path: '/projects'
-      fullPath: '/projects'
-      preLoaderRoute: typeof ProjectsLayoutImport
-      parentRoute: typeof ProjectsRoute
-    }
     '/organisations/': {
       id: '/organisations/'
       path: '/organisations'
       fullPath: '/organisations'
       preLoaderRoute: typeof OrganisationsIndexImport
       parentRoute: typeof rootRoute
+    }
+    '/projects/': {
+      id: '/projects/'
+      path: '/'
+      fullPath: '/projects/'
+      preLoaderRoute: typeof ProjectsIndexImport
+      parentRoute: typeof ProjectsRouteImport
     }
     '/organisations/$organisationId/settings': {
       id: '/organisations/$organisationId/settings'
@@ -185,54 +174,35 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof OrganisationsOrganisationIdIndexImport
       parentRoute: typeof rootRoute
     }
-    '/projects/_layout/': {
-      id: '/projects/_layout/'
-      path: '/'
-      fullPath: '/projects/'
-      preLoaderRoute: typeof ProjectsLayoutIndexImport
-      parentRoute: typeof ProjectsLayoutImport
-    }
   }
 }
 
 // Create and export the route tree
 
-interface ProjectsLayoutRouteChildren {
-  ProjectsLayoutIndexRoute: typeof ProjectsLayoutIndexRoute
+interface ProjectsRouteRouteChildren {
+  ProjectsIndexRoute: typeof ProjectsIndexRoute
 }
 
-const ProjectsLayoutRouteChildren: ProjectsLayoutRouteChildren = {
-  ProjectsLayoutIndexRoute: ProjectsLayoutIndexRoute,
+const ProjectsRouteRouteChildren: ProjectsRouteRouteChildren = {
+  ProjectsIndexRoute: ProjectsIndexRoute,
 }
 
-const ProjectsLayoutRouteWithChildren = ProjectsLayoutRoute._addFileChildren(
-  ProjectsLayoutRouteChildren,
-)
-
-interface ProjectsRouteChildren {
-  ProjectsLayoutRoute: typeof ProjectsLayoutRouteWithChildren
-}
-
-const ProjectsRouteChildren: ProjectsRouteChildren = {
-  ProjectsLayoutRoute: ProjectsLayoutRouteWithChildren,
-}
-
-const ProjectsRouteWithChildren = ProjectsRoute._addFileChildren(
-  ProjectsRouteChildren,
+const ProjectsRouteRouteWithChildren = ProjectsRouteRoute._addFileChildren(
+  ProjectsRouteRouteChildren,
 )
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/projects': typeof ProjectsRouteRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
   '/get-started': typeof GetStartedRoute
   '/login': typeof LoginRoute
   '/signup': typeof SignupRoute
   '/user-settings': typeof UserSettingsRoute
-  '/projects': typeof ProjectsLayoutRouteWithChildren
   '/organisations': typeof OrganisationsIndexRoute
+  '/projects/': typeof ProjectsIndexRoute
   '/organisations/$organisationId/settings': typeof OrganisationsOrganisationIdSettingsRoute
   '/organisations/$organisationId': typeof OrganisationsOrganisationIdIndexRoute
-  '/projects/': typeof ProjectsLayoutIndexRoute
 }
 
 export interface FileRoutesByTo {
@@ -242,8 +212,8 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/signup': typeof SignupRoute
   '/user-settings': typeof UserSettingsRoute
-  '/projects': typeof ProjectsLayoutIndexRoute
   '/organisations': typeof OrganisationsIndexRoute
+  '/projects': typeof ProjectsIndexRoute
   '/organisations/$organisationId/settings': typeof OrganisationsOrganisationIdSettingsRoute
   '/organisations/$organisationId': typeof OrganisationsOrganisationIdIndexRoute
 }
@@ -251,33 +221,32 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
+  '/projects': typeof ProjectsRouteRouteWithChildren
   '/forgot-password': typeof ForgotPasswordRoute
   '/get-started': typeof GetStartedRoute
   '/login': typeof LoginRoute
   '/signup': typeof SignupRoute
   '/user-settings': typeof UserSettingsRoute
-  '/projects': typeof ProjectsRouteWithChildren
-  '/projects/_layout': typeof ProjectsLayoutRouteWithChildren
   '/organisations/': typeof OrganisationsIndexRoute
+  '/projects/': typeof ProjectsIndexRoute
   '/organisations/$organisationId/settings': typeof OrganisationsOrganisationIdSettingsRoute
   '/organisations/$organisationId/': typeof OrganisationsOrganisationIdIndexRoute
-  '/projects/_layout/': typeof ProjectsLayoutIndexRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/projects'
     | '/forgot-password'
     | '/get-started'
     | '/login'
     | '/signup'
     | '/user-settings'
-    | '/projects'
     | '/organisations'
+    | '/projects/'
     | '/organisations/$organisationId/settings'
     | '/organisations/$organisationId'
-    | '/projects/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -286,35 +255,34 @@ export interface FileRouteTypes {
     | '/login'
     | '/signup'
     | '/user-settings'
-    | '/projects'
     | '/organisations'
+    | '/projects'
     | '/organisations/$organisationId/settings'
     | '/organisations/$organisationId'
   id:
     | '__root__'
     | '/'
+    | '/projects'
     | '/forgot-password'
     | '/get-started'
     | '/login'
     | '/signup'
     | '/user-settings'
-    | '/projects'
-    | '/projects/_layout'
     | '/organisations/'
+    | '/projects/'
     | '/organisations/$organisationId/settings'
     | '/organisations/$organisationId/'
-    | '/projects/_layout/'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  ProjectsRouteRoute: typeof ProjectsRouteRouteWithChildren
   ForgotPasswordRoute: typeof ForgotPasswordRoute
   GetStartedRoute: typeof GetStartedRoute
   LoginRoute: typeof LoginRoute
   SignupRoute: typeof SignupRoute
   UserSettingsRoute: typeof UserSettingsRoute
-  ProjectsRoute: typeof ProjectsRouteWithChildren
   OrganisationsIndexRoute: typeof OrganisationsIndexRoute
   OrganisationsOrganisationIdSettingsRoute: typeof OrganisationsOrganisationIdSettingsRoute
   OrganisationsOrganisationIdIndexRoute: typeof OrganisationsOrganisationIdIndexRoute
@@ -322,12 +290,12 @@ export interface RootRouteChildren {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  ProjectsRouteRoute: ProjectsRouteRouteWithChildren,
   ForgotPasswordRoute: ForgotPasswordRoute,
   GetStartedRoute: GetStartedRoute,
   LoginRoute: LoginRoute,
   SignupRoute: SignupRoute,
   UserSettingsRoute: UserSettingsRoute,
-  ProjectsRoute: ProjectsRouteWithChildren,
   OrganisationsIndexRoute: OrganisationsIndexRoute,
   OrganisationsOrganisationIdSettingsRoute:
     OrganisationsOrganisationIdSettingsRoute,
@@ -345,12 +313,12 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/",
+        "/projects",
         "/forgot-password",
         "/get-started",
         "/login",
         "/signup",
         "/user-settings",
-        "/projects",
         "/organisations/",
         "/organisations/$organisationId/settings",
         "/organisations/$organisationId/"
@@ -358,6 +326,12 @@ export const routeTree = rootRoute
     },
     "/": {
       "filePath": "index.tsx"
+    },
+    "/projects": {
+      "filePath": "projects/route.tsx",
+      "children": [
+        "/projects/"
+      ]
     },
     "/forgot-password": {
       "filePath": "forgot-password.tsx"
@@ -374,31 +348,18 @@ export const routeTree = rootRoute
     "/user-settings": {
       "filePath": "user-settings.tsx"
     },
-    "/projects": {
-      "filePath": "projects",
-      "children": [
-        "/projects/_layout"
-      ]
-    },
-    "/projects/_layout": {
-      "filePath": "projects/_layout.tsx",
-      "parent": "/projects",
-      "children": [
-        "/projects/_layout/"
-      ]
-    },
     "/organisations/": {
       "filePath": "organisations/index.tsx"
+    },
+    "/projects/": {
+      "filePath": "projects/index.tsx",
+      "parent": "/projects"
     },
     "/organisations/$organisationId/settings": {
       "filePath": "organisations/$organisationId/settings.tsx"
     },
     "/organisations/$organisationId/": {
       "filePath": "organisations/$organisationId/index.tsx"
-    },
-    "/projects/_layout/": {
-      "filePath": "projects/_layout/index.tsx",
-      "parent": "/projects/_layout"
     }
   }
 }

--- a/web/ui/dashboard-react/src/services/hubspot.service.ts
+++ b/web/ui/dashboard-react/src/services/hubspot.service.ts
@@ -21,11 +21,11 @@ export async function sendWelcomeEmail(
 		return data;
 	} catch (err) {
 		if (axios.isAxiosError(err)) {
-			console.log('hubspot error message: ', err.message);
+			console.error('hubspot error message: ', err.message);
 			return err.message;
 		}
 
-		console.log('hubspot unexpected error: ', err);
+		console.error('hubspot unexpected error: ', err);
 		throw new Error('An hubspot unexpected error occurred');
 	}
 }

--- a/web/ui/dashboard-react/src/services/organisations.service.ts
+++ b/web/ui/dashboard-react/src/services/organisations.service.ts
@@ -1,5 +1,4 @@
 import { request } from './http.service';
-import { CONVOY_ORG_KEY } from '@/lib/constants';
 
 import type { Organisation } from '@/models/organisation.model';
 
@@ -15,32 +14,24 @@ type Pagination = {
 
 let organisations: Array<Organisation> = [];
 
-export function getCachedOrganisation(): Organisation | null {
-	let org = localStorage.getItem(CONVOY_ORG_KEY);
-	return org ? JSON.parse(org) : null;
-}
+// export function getCachedOrganisation(): Organisation | null {
+// 	let org = localStorage.getItem(CONVOY_ORG_KEY);
+// 	return org ? JSON.parse(org) : null;
+// }
 
-export function setDefaultCachedOrganisation(organisations: Organisation[]) {
-	if (!organisations.length) return localStorage.removeItem(CONVOY_ORG_KEY);
+// export function setDefaultCachedOrganisation(organisations: Organisation[]) {
+// 	if (!organisations.length) return localStorage.removeItem(CONVOY_ORG_KEY);
 
-	const existingOrg = organisations.find(
-		org => org.uid == getCachedOrganisation()?.uid,
-	);
+// 	return localStorage.setItem(CONVOY_ORG_KEY, JSON.stringify(organisations[0]));
+// }
 
-	if (!existingOrg)
-		return localStorage.setItem(
-			CONVOY_ORG_KEY,
-			JSON.stringify(organisations[0]),
-		);
-}
+// export function getDefaultCachedOrganisation() {
+// 	const cached = localStorage.getItem(CONVOY_ORG_KEY);
+// 	if (!cached) return null;
 
-export function getDefaultCachedOrganisation() {
-	const cached = localStorage.getItem(CONVOY_ORG_KEY);
-	if (!cached) return null;
-
-	const cachedOrg = JSON.parse(cached);
-	return cachedOrg as Organisation;
-}
+// 	const cachedOrg = JSON.parse(cached);
+// 	return cachedOrg as Organisation;
+// }
 
 type PaginatedOrganisationResult = {
 	content: Array<Organisation>;
@@ -72,7 +63,7 @@ export async function getOrganisations(
 		method: 'get',
 	});
 
-	setDefaultCachedOrganisation(res.data.content);
+	organisations = res.data.content
 
 	return res.data;
 }
@@ -89,11 +80,6 @@ export async function addOrganisation(
 		url: '/organisations',
 		body: reqDetails,
 	});
-
-	const cachedOrg = getDefaultCachedOrganisation();
-	if (!cachedOrg) {
-		// TODO set as cached org when data shcema is determined
-	}
 
 	return res.data;
 }


### PR DESCRIPTION
### Bug
When an organisation is created, other components are not updated.

### Fix
This PR uses React's Context API (for now) to propagate the update 

### Points to note
- Plans are in order to use a state management library instead of React's Context API because React's Context API is not performant, rendering-wise.
- This PR also changes the way that layout routes are set up, choosing to use the `route.tsx` pattern rather than the `_layout` folder pattern