### PR TITLE
fix: inconsistent organisation and project states

### DIFF
--- a/web/ui/dashboard-react/src/app/projects/route.tsx
+++ b/web/ui/dashboard-react/src/app/projects/route.tsx
@@ -7,7 +7,6 @@ export const Route = createFileRoute('/projects')({
 	beforeLoad({ context }) {
 		ensureCanAccessPrivatePages(context.auth?.getTokens().isLoggedIn);
 	},
-	// TODO use Zustand instead because this provider here will cause the whole nodes to rerender and that's not performant
 	component: ProjectsLayout,
 });
 

--- a/web/ui/dashboard-react/src/app/projects_/new.tsx
+++ b/web/ui/dashboard-react/src/app/projects_/new.tsx
@@ -1013,21 +1013,24 @@ function CreateNewProject() {
 			</section>
 			<Dialog open={hasCreatedProject}>
 				<DialogTrigger></DialogTrigger>
-				<DialogContent className="sm:max-w-[432px] rounded-lg">
+				<DialogContent
+					className="sm:max-w-[432px] rounded-lg"
+					aria-describedby={undefined}
+				>
 					<DialogHeader>
 						<DialogTitle className="flex flex-col justify-center items-center">
 							<img src={successAnimation} alt="warning" className="w-28" />
-							<h3 className="text-sm font-semibold">
+							<span className="text-sm font-semibold">
 								Project Created Successfully
-							</h3>
+							</span>
 						</DialogTitle>
-						<DialogDescription className="flex flex-col items-center gap-y-3">
+						<div className="flex flex-col items-center gap-y-3">
 							<div className="flex flex-col justify-center items-center font-normal text-neutral-11 text-xs/5">
-								<p>Your API Key has also been created.</p>
-								<p>Please copy this key and save it somewhere safe.</p>
+								<span>Your API Key has also been created.</span>
+								<span>Please copy this key and save it somewhere safe.</span>
 							</div>
 
-							<div className="flex items-center justify-between w-[400px] h-[50px] border border-neutral-a3 bg-[#F7F9FC] px-4 rounded-md">
+							<div className="flex items-center justify-between w-[400px] h-[50px] border border-neutral-a3 bg-[#F7F9FC] pr-2 pl-3 rounded-md">
 								<span className="text-xs text-neutral-11 font-normal truncate">
 									{projectkey}
 								</span>
@@ -1035,19 +1038,18 @@ function CreateNewProject() {
 									type="button"
 									variant="ghost"
 									size="sm"
-									className="asbolute right-[1%] top-0 h-full py-2 hover:bg-transparent"
+									className="asbolute right-[1%] top-0 h-full py-2 hover:bg-transparent pr-1 pl-0"
 									onClick={() => {
 										window.navigator.clipboard.writeText(projectkey).then();
 										// TODO show toast message on copy successful
 									}}
 								>
 									<CopyIcon className="opacity-50" aria-hidden="true" />
-									<span className="sr-only">copy projectkey</span>
+									<span className="sr-only">copy project key</span>
 								</Button>
 							</div>
-						</DialogDescription>
+						</div>
 					</DialogHeader>
-					<div className="flex flex-col items-center"></div>
 					<DialogFooter className="flex justify-center items-center">
 						<DialogClose asChild>
 							<Button

--- a/web/ui/dashboard-react/src/app/settings.tsx
+++ b/web/ui/dashboard-react/src/app/settings.tsx
@@ -77,7 +77,6 @@ function SettingsPage() {
 	const [isDeletingOrg, setIsDeletingOrg] = useState(false);
 	const { org, setPaginatedOrgs, setOrg, paginatedOrgs } =
 		useOrganisationStore();
-
 	const organisationForm = useForm<z.infer<typeof OrganisationFormSchema>>({
 		resolver: zodResolver(OrganisationFormSchema),
 		defaultValues: {
@@ -90,7 +89,7 @@ function SettingsPage() {
 	useEffect(() => {
 		organisationForm.setValue('orgId', org?.uid || '');
 		organisationForm.setValue('orgName', org?.name || '');
-	}, [org]);
+	}, [org?.uid]);
 
 	async function updateOrganisation(
 		values: z.infer<typeof OrganisationFormSchema>,

--- a/web/ui/dashboard-react/src/services/http.service.ts
+++ b/web/ui/dashboard-react/src/services/http.service.ts
@@ -3,10 +3,9 @@ import { router } from '../lib/router';
 import { isProductionMode } from '@/lib/env';
 
 import * as authService from '@/services/auth.service';
-import * as projectsService from '@/services/projects.service';
 
 import type { HttpResponse } from '@/models/global.model';
-import { useOrganisationStore } from '@/store';
+import { useOrganisationStore, useProjectStore } from '@/store';
 
 const APIURL = `${isProductionMode ? location.origin : 'http://localhost:5005'}/ui`;
 const APP_PORTAL_APIURL = `${isProductionMode ? location.origin : 'http://localhost:5005'}/portal-api`;
@@ -61,19 +60,22 @@ export function buildRequestQuery(
 export function buildRequestPath(
 	level?: 'org' | 'org_project',
 	deps: {
-		getCachedProject: typeof projectsService.getCachedProject;
+		getCachedProjectId: () => string;
 		getCachedOrganisationId: () => string;
 	} = {
-		getCachedProject: projectsService.getCachedProject,
+		getCachedProjectId: () => {
+			const { project } = useProjectStore.getState();
+			return project?.uid || '';
+		},
 		getCachedOrganisationId: () => {
-			const {org} = useOrganisationStore.getState()
-			return org?.uid || ''
+			const { org } = useOrganisationStore.getState();
+			return org?.uid || '';
 		},
 	},
 ): string {
 	if (!level) return '';
 	const orgId = deps.getCachedOrganisationId();
-	const projectId = deps.getCachedProject()?.uid;
+	const projectId = deps.getCachedProjectId();
 
 	if (level == 'org' && orgId) return `/organisations/${orgId}`;
 

--- a/web/ui/dashboard-react/src/services/projects.service.ts
+++ b/web/ui/dashboard-react/src/services/projects.service.ts
@@ -1,11 +1,6 @@
 import { request } from '@/services/http.service';
-import { CONVOY_CURRENT_PROJECT } from '@/lib/constants';
 
 import type { Project, CreateProjectResponse } from '@/models/project.model';
-
-// TODO use state management
-let projects: Array<Project> = [];
-let projectDetails: Project | null = null;
 
 type CreateProjectParams = {
 	name: string;
@@ -46,11 +41,8 @@ export async function createProject(
 }
 
 export async function getProjects(
-	reqDetails: { refresh?: boolean },
 	deps: { httpReq: typeof request } = { httpReq: request },
 ) {
-	if (projects.length && !reqDetails.refresh) return projects;
-
 	const res = await deps.httpReq<Array<Project>>({
 		url: '/projects',
 		method: 'get',
@@ -61,29 +53,14 @@ export async function getProjects(
 }
 
 export async function getProject(
-	reqDetails: { refresh?: boolean; projectId: string },
+	projectId: string,
 	deps: { httpReq: typeof request } = { httpReq: request },
 ) {
-	if (projectDetails && !reqDetails.refresh) return projectDetails;
-
 	const res = await deps.httpReq<Project>({
-		url: `/projects/${reqDetails.projectId}`,
+		url: `/projects/${projectId}`,
 		method: 'get',
 		level: 'org',
 	});
 
-	projectDetails = res.data;
-
-	return res;
-}
-
-export function getCachedProject(): Project | null {
-	const cachedProject = localStorage.getItem(CONVOY_CURRENT_PROJECT);
-	return cachedProject && cachedProject != 'undefined'
-		? JSON.parse(cachedProject)
-		: null;
-}
-
-export function setCachedProject(project: Project | null) {
-	localStorage.setItem(CONVOY_CURRENT_PROJECT, JSON.stringify(project));
+	return res.data;
 }

--- a/web/ui/dashboard-react/src/store/index.ts
+++ b/web/ui/dashboard-react/src/store/index.ts
@@ -1,8 +1,13 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
-import { CONVOY_LICENSES_KEY, CONVOY_ORG_KEY } from '@/lib/constants';
+import {
+	CONVOY_LICENSES_KEY,
+	CONVOY_ORG_KEY,
+	CONVOY_CURRENT_PROJECT,
+} from '@/lib/constants';
 
+import type { Project } from '@/models/project.model';
 import type { PaginatedResult } from '@/models/global.model';
 import type { LicenseKey } from '@/services/licenses.service';
 import type { Organisation } from '@/models/organisation.model';
@@ -55,6 +60,30 @@ export const useOrganisationStore = create<OrganisationStore>()(
 		}),
 		{
 			name: CONVOY_ORG_KEY,
+			storage: createJSONStorage(() => sessionStorage),
+		},
+	),
+);
+
+type ProjectStore = {
+	/** The current project in use */
+	project: Project | null;
+	projects: Array<Project>;
+	/** Set the current project in use */
+	setProject: (p: Project | null) => void;
+	setProjects: (projects: Array<Project>) => void;
+};
+
+export const useProjectStore = create<ProjectStore>()(
+	persist(
+		set => ({
+			project: null,
+			projects: [],
+			setProject: project => set({ project }),
+			setProjects: projects => set({ projects }),
+		}),
+		{
+			name: CONVOY_CURRENT_PROJECT,
 			storage: createJSONStorage(() => sessionStorage),
 		},
 	),


### PR DESCRIPTION
The React application has been having inconsistencies in maintaining the states when the current organisation changes or when the project changes.
Modifications in this PR ensures that when an organisation is selected, only projects for that organisation is shown.
It also maintains the organisation state and project state after page reloads and navigation from page to page.
Lastly, it fixes HTML errors that prop up when the dialog component in the /projects/new route appears.