### PR TITLE
skip the ping check for now

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:1
-FROM node:14 as node-env
+FROM node:14 AS node-env
 WORKDIR /app
 COPY ./web/ui/dashboard .
 RUN git config --global url."https://".insteadOf git://
 RUN npm install
 RUN npm run build
 
-FROM golang:1.23 as build-env
+FROM golang:1.23 AS build-env
 WORKDIR /go/src/frain-dev/convoy
 
 COPY ./go.mod /go/src/frain-dev/convoy

--- a/services/create_endpoint.go
+++ b/services/create_endpoint.go
@@ -7,7 +7,7 @@ import (
 	"github.com/frain-dev/convoy/config"
 	"github.com/frain-dev/convoy/internal/pkg/fflag"
 	"github.com/frain-dev/convoy/internal/pkg/keys"
-	"github.com/frain-dev/convoy/net"
+	// "github.com/frain-dev/convoy/net"
 	"net/http"
 	"net/url"
 	"time"
@@ -147,17 +147,17 @@ func (a *CreateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 			return "", errors.New("only https endpoints allowed")
 		}
 	case "https":
-		cfg, innerErr := config.Get()
-		if innerErr != nil {
-			return "", innerErr
-		}
-
-		caCertTLSCfg, innerErr := config.GetCaCert()
-		if innerErr != nil {
-			return "", innerErr
-		}
-
 		// // TODO: this does a GET, but the endpoint needs a POST!
+		// cfg, innerErr := config.Get()
+		// if innerErr != nil {
+		// 	return "", innerErr
+		// }
+		//
+		// caCertTLSCfg, innerErr := config.GetCaCert()
+		// if innerErr != nil {
+		// 	return "", innerErr
+		// }
+		//
 		// dispatcher, innerErr := net.NewDispatcher(
 		// 	a.Licenser,
 		// 	a.FeatureFlag,

--- a/services/create_endpoint.go
+++ b/services/create_endpoint.go
@@ -3,7 +3,7 @@ package services
 import (
 	"context"
 	"errors"
-	// "fmt"
+	"fmt"
 	"github.com/frain-dev/convoy/config"
 	"github.com/frain-dev/convoy/internal/pkg/fflag"
 	"github.com/frain-dev/convoy/internal/pkg/keys"
@@ -173,8 +173,7 @@ func (a *CreateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 		// TODO: this does a GET, but the endpoint needs a POST!
 		pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
 		if pingErr != nil {
-			// TODO: log this
-			fmt.Errorf("failed to ping tls endpoint: %v", pingErr)
+			log.Warn(fmt.Errorf("failed to ping tls endpoint: %v", pingErr))
 		}
 	default:
 		return "", errors.New("invalid endpoint scheme")

--- a/services/create_endpoint.go
+++ b/services/create_endpoint.go
@@ -7,7 +7,7 @@ import (
 	"github.com/frain-dev/convoy/config"
 	"github.com/frain-dev/convoy/internal/pkg/fflag"
 	"github.com/frain-dev/convoy/internal/pkg/keys"
-	// "github.com/frain-dev/convoy/net"
+	"github.com/frain-dev/convoy/net"
 	"net/http"
 	"net/url"
 	"time"
@@ -147,34 +147,35 @@ func (a *CreateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 			return "", errors.New("only https endpoints allowed")
 		}
 	case "https":
-		// // TODO: this does a GET, but the endpoint needs a POST!
-		// cfg, innerErr := config.Get()
-		// if innerErr != nil {
-		// 	return "", innerErr
-		// }
-		//
-		// caCertTLSCfg, innerErr := config.GetCaCert()
-		// if innerErr != nil {
-		// 	return "", innerErr
-		// }
-		//
-		// dispatcher, innerErr := net.NewDispatcher(
-		// 	a.Licenser,
-		// 	a.FeatureFlag,
-		// 	net.LoggerOption(a.Logger),
-		// 	net.ProxyOption(cfg.Server.HTTP.HttpProxy),
-		// 	net.AllowListOption(cfg.Dispatcher.AllowList),
-		// 	net.BlockListOption(cfg.Dispatcher.BlockList),
-		// 	net.TLSConfigOption(cfg.Dispatcher.InsecureSkipVerify, a.Licenser, caCertTLSCfg),
-		// )
-		// if innerErr != nil {
-		// 	return "", innerErr
-		// }
-		//
-		// pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
-		// if pingErr != nil {
-		// 	return "", fmt.Errorf("failed to ping tls endpoint: %v", pingErr)
-		// }
+		cfg, innerErr := config.Get()
+		if innerErr != nil {
+			return "", innerErr
+		}
+
+		caCertTLSCfg, innerErr := config.GetCaCert()
+		if innerErr != nil {
+			return "", innerErr
+		}
+
+		dispatcher, innerErr := net.NewDispatcher(
+			a.Licenser,
+			a.FeatureFlag,
+			net.LoggerOption(a.Logger),
+			net.ProxyOption(cfg.Server.HTTP.HttpProxy),
+			net.AllowListOption(cfg.Dispatcher.AllowList),
+			net.BlockListOption(cfg.Dispatcher.BlockList),
+			net.TLSConfigOption(cfg.Dispatcher.InsecureSkipVerify, a.Licenser, caCertTLSCfg),
+		)
+		if innerErr != nil {
+			return "", innerErr
+		}
+
+		// TODO: this does a GET, but the endpoint needs a POST!
+		pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
+		if pingErr != nil {
+			// TODO: log this
+			fmt.Errorf("failed to ping tls endpoint: %v", pingErr)
+		}
 	default:
 		return "", errors.New("invalid endpoint scheme")
 	}

--- a/services/create_endpoint.go
+++ b/services/create_endpoint.go
@@ -3,7 +3,7 @@ package services
 import (
 	"context"
 	"errors"
-	"fmt"
+	// "fmt"
 	"github.com/frain-dev/convoy/config"
 	"github.com/frain-dev/convoy/internal/pkg/fflag"
 	"github.com/frain-dev/convoy/internal/pkg/keys"
@@ -157,20 +157,20 @@ func (a *CreateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 			return "", innerErr
 		}
 
-		dispatcher, innerErr := net.NewDispatcher(
-			a.Licenser,
-			a.FeatureFlag,
-			net.LoggerOption(a.Logger),
-			net.ProxyOption(cfg.Server.HTTP.HttpProxy),
-			net.AllowListOption(cfg.Dispatcher.AllowList),
-			net.BlockListOption(cfg.Dispatcher.BlockList),
-			net.TLSConfigOption(cfg.Dispatcher.InsecureSkipVerify, a.Licenser, caCertTLSCfg),
-		)
-		if innerErr != nil {
-			return "", innerErr
-		}
-
 		// // TODO: this does a GET, but the endpoint needs a POST!
+		// dispatcher, innerErr := net.NewDispatcher(
+		// 	a.Licenser,
+		// 	a.FeatureFlag,
+		// 	net.LoggerOption(a.Logger),
+		// 	net.ProxyOption(cfg.Server.HTTP.HttpProxy),
+		// 	net.AllowListOption(cfg.Dispatcher.AllowList),
+		// 	net.BlockListOption(cfg.Dispatcher.BlockList),
+		// 	net.TLSConfigOption(cfg.Dispatcher.InsecureSkipVerify, a.Licenser, caCertTLSCfg),
+		// )
+		// if innerErr != nil {
+		// 	return "", innerErr
+		// }
+		//
 		// pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
 		// if pingErr != nil {
 		// 	return "", fmt.Errorf("failed to ping tls endpoint: %v", pingErr)

--- a/services/create_endpoint.go
+++ b/services/create_endpoint.go
@@ -170,10 +170,11 @@ func (a *CreateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 			return "", innerErr
 		}
 
-		pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
-		if pingErr != nil {
-			return "", fmt.Errorf("failed to ping tls endpoint: %v", pingErr)
-		}
+		// // TODO: this does a GET, but the endpoint needs a POST!
+		// pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
+		// if pingErr != nil {
+		// 	return "", fmt.Errorf("failed to ping tls endpoint: %v", pingErr)
+		// }
 	default:
 		return "", errors.New("invalid endpoint scheme")
 	}

--- a/services/update_endpoint.go
+++ b/services/update_endpoint.go
@@ -102,10 +102,11 @@ func (a *UpdateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 			return "", innerErr
 		}
 
-		pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
-		if pingErr != nil {
-			return "", fmt.Errorf("failed to ping tls endpoint: %v", pingErr)
-		}
+		// // TODO: this does a GET, but the endpoint needs a POST!
+		// pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
+		// if pingErr != nil {
+		// 	return "", fmt.Errorf("failed to ping tls endpoint: %v", pingErr)
+		// }
 	default:
 		return "", errors.New("invalid endpoint scheme")
 	}

--- a/services/update_endpoint.go
+++ b/services/update_endpoint.go
@@ -6,7 +6,7 @@ import (
 	// "fmt"
 	"github.com/frain-dev/convoy/config"
 	"github.com/frain-dev/convoy/internal/pkg/fflag"
-	"github.com/frain-dev/convoy/net"
+	// "github.com/frain-dev/convoy/net"
 	"net/url"
 	"time"
 
@@ -79,16 +79,17 @@ func (a *UpdateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 			return "", errors.New("only https endpoints allowed")
 		}
 	case "https":
-		cfg, innerErr := config.Get()
-		if innerErr != nil {
-			return "", innerErr
-		}
-
-		caCertTLSCfg, innerErr := config.GetCaCert()
-		if innerErr != nil {
-			return "", innerErr
-		}
-
+		// // TODO: this does a GET, but the endpoint needs a POST!
+		// cfg, innerErr := config.Get()
+		// if innerErr != nil {
+		// 	return "", innerErr
+		// }
+		//
+		// caCertTLSCfg, innerErr := config.GetCaCert()
+		// if innerErr != nil {
+		// 	return "", innerErr
+		// }
+		//
 		// dispatcher, innerErr := net.NewDispatcher(
 		// 	a.Licenser,
 		// 	a.FeatureFlag,
@@ -102,7 +103,6 @@ func (a *UpdateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 		// 	return "", innerErr
 		// }
 		//
-		// // TODO: this does a GET, but the endpoint needs a POST!
 		// pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
 		// if pingErr != nil {
 		// 	return "", fmt.Errorf("failed to ping tls endpoint: %v", pingErr)

--- a/services/update_endpoint.go
+++ b/services/update_endpoint.go
@@ -3,10 +3,10 @@ package services
 import (
 	"context"
 	"errors"
-	// "fmt"
+	"fmt"
 	"github.com/frain-dev/convoy/config"
 	"github.com/frain-dev/convoy/internal/pkg/fflag"
-	// "github.com/frain-dev/convoy/net"
+	"github.com/frain-dev/convoy/net"
 	"net/url"
 	"time"
 
@@ -79,34 +79,35 @@ func (a *UpdateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 			return "", errors.New("only https endpoints allowed")
 		}
 	case "https":
-		// // TODO: this does a GET, but the endpoint needs a POST!
-		// cfg, innerErr := config.Get()
-		// if innerErr != nil {
-		// 	return "", innerErr
-		// }
-		//
-		// caCertTLSCfg, innerErr := config.GetCaCert()
-		// if innerErr != nil {
-		// 	return "", innerErr
-		// }
-		//
-		// dispatcher, innerErr := net.NewDispatcher(
-		// 	a.Licenser,
-		// 	a.FeatureFlag,
-		// 	net.LoggerOption(a.Logger),
-		// 	net.ProxyOption(cfg.Server.HTTP.HttpProxy),
-		// 	net.AllowListOption(cfg.Dispatcher.AllowList),
-		// 	net.BlockListOption(cfg.Dispatcher.BlockList),
-		// 	net.TLSConfigOption(cfg.Dispatcher.InsecureSkipVerify, a.Licenser, caCertTLSCfg),
-		// )
-		// if innerErr != nil {
-		// 	return "", innerErr
-		// }
-		//
-		// pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
-		// if pingErr != nil {
-		// 	return "", fmt.Errorf("failed to ping tls endpoint: %v", pingErr)
-		// }
+		cfg, innerErr := config.Get()
+		if innerErr != nil {
+			return "", innerErr
+		}
+
+		caCertTLSCfg, innerErr := config.GetCaCert()
+		if innerErr != nil {
+			return "", innerErr
+		}
+
+		dispatcher, innerErr := net.NewDispatcher(
+			a.Licenser,
+			a.FeatureFlag,
+			net.LoggerOption(a.Logger),
+			net.ProxyOption(cfg.Server.HTTP.HttpProxy),
+			net.AllowListOption(cfg.Dispatcher.AllowList),
+			net.BlockListOption(cfg.Dispatcher.BlockList),
+			net.TLSConfigOption(cfg.Dispatcher.InsecureSkipVerify, a.Licenser, caCertTLSCfg),
+		)
+		if innerErr != nil {
+			return "", innerErr
+		}
+
+		// TODO: this does a GET, but the endpoint needs a POST!
+		pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
+		if pingErr != nil {
+			// TODO: log this
+			fmt.Errorf("failed to ping tls endpoint: %v", pingErr)
+		}
 	default:
 		return "", errors.New("invalid endpoint scheme")
 	}

--- a/services/update_endpoint.go
+++ b/services/update_endpoint.go
@@ -3,7 +3,7 @@ package services
 import (
 	"context"
 	"errors"
-	"fmt"
+	// "fmt"
 	"github.com/frain-dev/convoy/config"
 	"github.com/frain-dev/convoy/internal/pkg/fflag"
 	"github.com/frain-dev/convoy/net"
@@ -89,19 +89,19 @@ func (a *UpdateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 			return "", innerErr
 		}
 
-		dispatcher, innerErr := net.NewDispatcher(
-			a.Licenser,
-			a.FeatureFlag,
-			net.LoggerOption(a.Logger),
-			net.ProxyOption(cfg.Server.HTTP.HttpProxy),
-			net.AllowListOption(cfg.Dispatcher.AllowList),
-			net.BlockListOption(cfg.Dispatcher.BlockList),
-			net.TLSConfigOption(cfg.Dispatcher.InsecureSkipVerify, a.Licenser, caCertTLSCfg),
-		)
-		if innerErr != nil {
-			return "", innerErr
-		}
-
+		// dispatcher, innerErr := net.NewDispatcher(
+		// 	a.Licenser,
+		// 	a.FeatureFlag,
+		// 	net.LoggerOption(a.Logger),
+		// 	net.ProxyOption(cfg.Server.HTTP.HttpProxy),
+		// 	net.AllowListOption(cfg.Dispatcher.AllowList),
+		// 	net.BlockListOption(cfg.Dispatcher.BlockList),
+		// 	net.TLSConfigOption(cfg.Dispatcher.InsecureSkipVerify, a.Licenser, caCertTLSCfg),
+		// )
+		// if innerErr != nil {
+		// 	return "", innerErr
+		// }
+		//
 		// // TODO: this does a GET, but the endpoint needs a POST!
 		// pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
 		// if pingErr != nil {

--- a/services/update_endpoint.go
+++ b/services/update_endpoint.go
@@ -105,8 +105,7 @@ func (a *UpdateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 		// TODO: this does a GET, but the endpoint needs a POST!
 		pingErr = dispatcher.Ping(ctx, a.E.URL, 10*time.Second)
 		if pingErr != nil {
-			// TODO: log this
-			fmt.Errorf("failed to ping tls endpoint: %v", pingErr)
+			log.Warn(fmt.Errorf("failed to ping tls endpoint: %v", pingErr))
 		}
 	default:
 		return "", errors.New("invalid endpoint scheme")


### PR DESCRIPTION
It would be better to have this be a config option, but until the ping checks the right route (POST instead of GET), I think disabling it for now and cutting a quick release is the best path forward.