### PR TITLE
added delivery mode to subscriptions

### DIFF
--- a/api/models/subscription.go
+++ b/api/models/subscription.go
@@ -37,6 +37,9 @@ type CreateSubscription struct {
 
 	// Rate limit configuration
 	RateLimitConfig *RateLimitConfiguration `json:"rate_limit_config,omitempty"`
+
+	// Delivery mode configuration
+	DeliveryMode datastore.DeliveryMode `json:"delivery_mode,omitempty"`
 }
 
 func (cs *CreateSubscription) Validate() error {
@@ -71,6 +74,9 @@ type UpdateSubscription struct {
 
 	// Rate limit configuration
 	RateLimitConfig *RateLimitConfiguration `json:"rate_limit_config,omitempty"`
+
+	// Delivery mode configuration
+	DeliveryMode datastore.DeliveryMode `json:"delivery_mode,omitempty"`
 }
 
 func (us *UpdateSubscription) Validate() error {

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -281,7 +281,8 @@ func StartWorker(ctx context.Context, a *cli.App, cfg config.Configuration, inte
 		attemptRepo,
 		circuitBreakerManager,
 		featureFlag,
-		a.TracerBackend),
+		a.TracerBackend,
+		subRepo),
 		newTelemetry)
 
 	consumer.RegisterHandlers(convoy.CreateEventProcessor, task.ProcessEventCreation(

--- a/datastore/models.go
+++ b/datastore/models.go
@@ -8,11 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/crypto/bcrypt"
 	"math"
 	"net/http"
 	"strings"
 	"time"
+
+	"golang.org/x/crypto/bcrypt"
 
 	cb "github.com/frain-dev/convoy/pkg/circuit_breaker"
 
@@ -781,6 +782,12 @@ type (
 	EventStatus         string
 	EventDeliveryStatus string
 	HttpHeader          map[string]string
+	DeliveryMode        string
+)
+
+const (
+	AtLeastOnceDeliveryMode DeliveryMode = "at_least_once"
+	AtMostOnceDeliveryMode  DeliveryMode = "at_most_once"
 )
 
 func (h *HttpHeader) Scan(value interface{}) error {
@@ -1068,6 +1075,8 @@ type Subscription struct {
 	RetryConfig     *RetryConfiguration     `json:"retry_config,omitempty" db:"retry_config"`
 	FilterConfig    *FilterConfiguration    `json:"filter_config,omitempty" db:"filter_config"`
 	RateLimitConfig *RateLimitConfiguration `json:"rate_limit_config,omitempty" db:"rate_limit_config"`
+
+	DeliveryMode DeliveryMode `json:"delivery_mode,omitempty" db:"delivery_mode"`
 
 	CreatedAt time.Time `json:"created_at,omitempty" db:"created_at" swaggertype:"string"`
 	UpdatedAt time.Time `json:"updated_at,omitempty" db:"updated_at" swaggertype:"string"`

--- a/services/create_subscription.go
+++ b/services/create_subscription.go
@@ -63,12 +63,13 @@ func (s *CreateSubscriptionService) Run(ctx context.Context) (*datastore.Subscri
 	}
 
 	subscription := &datastore.Subscription{
-		UID:        ulid.Make().String(),
-		ProjectID:  s.Project.UID,
-		Name:       s.NewSubscription.Name,
-		Type:       datastore.SubscriptionTypeAPI,
-		SourceID:   s.NewSubscription.SourceID,
-		EndpointID: s.NewSubscription.EndpointID,
+		UID:          ulid.Make().String(),
+		ProjectID:    s.Project.UID,
+		Name:         s.NewSubscription.Name,
+		Type:         datastore.SubscriptionTypeAPI,
+		SourceID:     s.NewSubscription.SourceID,
+		EndpointID:   s.NewSubscription.EndpointID,
+		DeliveryMode: s.NewSubscription.DeliveryMode,
 
 		AlertConfig:     s.NewSubscription.AlertConfig.Transform(),
 		RateLimitConfig: s.NewSubscription.RateLimitConfig.Transform(),

--- a/services/update_subscription.go
+++ b/services/update_subscription.go
@@ -93,6 +93,10 @@ func (s *UpdateSubscriptionService) Run(ctx context.Context) (*datastore.Subscri
 		subscription.Function = null.StringFrom(s.Update.Function)
 	}
 
+	if !util.IsStringEmpty(string(s.Update.DeliveryMode)) {
+		subscription.DeliveryMode = s.Update.DeliveryMode
+	}
+
 	if s.Update.AlertConfig != nil && s.Update.AlertConfig.Count > 0 {
 		if subscription.AlertConfig == nil {
 			subscription.AlertConfig = &datastore.AlertConfiguration{}

--- a/sql/1746876410.sql
+++ b/sql/1746876410.sql
@@ -1,0 +1,8 @@
+-- +migrate Up
+ALTER TABLE convoy.subscriptions ADD COLUMN IF NOT EXISTS delivery_mode VARCHAR(255) NOT NULL DEFAULT 'at_least_once';
+
+-- Add comment to explain the column
+COMMENT ON COLUMN convoy.subscriptions.delivery_mode IS 'Specifies the delivery mode for the subscription. Can be either at_least_once or at_most_once';
+
+-- +migrate Down
+ALTER TABLE convoy.subscriptions DROP COLUMN IF EXISTS delivery_mode; 


### PR DESCRIPTION
# Add At-Most-Once Delivery Mode

## Description
Adds support for two delivery modes in webhook deliveries:

1. **At-Least-Once** (default)
   - Guarantees delivery by retrying on all errors
   - Best for critical events that must be delivered
   - Example: Payment notifications, order confirmations

2. **At-Most-Once**
   - Delivers exactly once, no retries on network errors
   - Best for non-critical events where duplicates are problematic
   - Example: Analytics events, audit logs

## Usage
Set delivery mode in your subscription creation/update API request. If not specified, `at_least_once` is used by default:

```json
{
  "name": "my-subscription",
  "endpoint_id": "end_123",
  "delivery_mode": "at_most_once",  // or "at_least_once" (default)
  "retry_config": {
    "type": "linear",
    "retry_count": 3,
    "duration": 60
  }
}