### PR TITLE
fix: add ORDER BY clause to event deliveries query

### DIFF
--- a/database/postgres/event_delivery.go
+++ b/database/postgres/event_delivery.go
@@ -155,6 +155,8 @@ const (
         %s
     GROUP BY
         "data.group_only", "data.index";
+	ORDER BY
+        "data.group_only"
     `
 
 	fetchEventDeliveries = `


### PR DESCRIPTION
Fix #2236