### PR TITLE
feat: cherry pick v25.6.7 fixes

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -137,12 +137,6 @@ func startServerComponent(_ context.Context, a *cli.App) error {
 
 	flag := fflag.NewFFlag(cfg.EnableFeatureFlag)
 
-	lvl, err := log.ParseLevel(cfg.Logger.Level)
-	if err != nil {
-		return err
-	}
-	lo.SetLevel(lvl)
-
 	// start events handler
 	srv := server.NewServer(cfg.Server.HTTP.AgentPort, func() {})
 
@@ -193,15 +187,6 @@ func buildAgentCliConfiguration(cmd *cobra.Command) (*config.Configuration, erro
 
 	if port != 0 {
 		c.Server.HTTP.AgentPort = port
-	}
-
-	logLevel, err := cmd.Flags().GetString("log-level")
-	if err != nil {
-		return nil, err
-	}
-
-	if !util.IsStringEmpty(logLevel) {
-		c.Logger.Level = logLevel
 	}
 
 	// CONVOY_WORKER_POOL_SIZE

--- a/cmd/stream/stream.go
+++ b/cmd/stream/stream.go
@@ -84,12 +84,6 @@ func AddStreamCommand(a *cli.App) *cobra.Command {
 			lo := a.Logger.(*log.Logger)
 			lo.SetPrefix("stream server")
 
-			lvl, err := log.ParseLevel(cfg.Logger.Level)
-			if err != nil {
-				return err
-			}
-			lo.SetLevel(lvl)
-
 			h := socket.NewHub()
 			h.Start(context.Background())
 
@@ -112,7 +106,12 @@ func AddStreamCommand(a *cli.App) *cobra.Command {
 			}
 			q := redisQueue.NewQueue(opts)
 
-			consumer := worker.NewConsumer(ctx, 100, q, lo)
+			lvl, err := log.ParseLevel(cfg.Logger.Level)
+			if err != nil {
+				return err
+			}
+
+			consumer := worker.NewConsumer(ctx, 100, q, lo, lvl)
 			consumer.RegisterHandlers(convoy.StreamCliEventsProcessor, h.EventDeliveryCLiHandler(r), nil)
 
 			// start worker

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -238,21 +238,23 @@ func in(payload, filter interface{}) (bool, error) {
 		}
 	}
 
-	sort.SliceStable(p, func(i, j int) bool {
-		switch pi := p[i].(type) {
+	pCopy := make([]interface{}, len(p))
+	copy(pCopy, p)
+	sort.SliceStable(pCopy, func(i, j int) bool {
+		switch pi := pCopy[i].(type) {
 		case string:
-			return pi < p[j].(string)
+			return pi < pCopy[j].(string)
 		case float64:
-			return pi < p[j].(float64)
+			return pi < pCopy[j].(float64)
 		case int:
-			return pi < p[j].(int)
+			return pi < pCopy[j].(int)
 		}
 
 		return false
 	})
 
 	found := false
-	for _, v := range p {
+	for _, v := range pCopy {
 		if v == filter {
 			found = true
 		}

--- a/worker/consumer.go
+++ b/worker/consumer.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+
 	"github.com/frain-dev/convoy"
 	"github.com/frain-dev/convoy/internal/telemetry"
 	"github.com/frain-dev/convoy/pkg/log"
@@ -19,7 +20,7 @@ type Consumer struct {
 	log   log.StdLogger
 }
 
-func NewConsumer(ctx context.Context, consumerPoolSize int, q queue.Queuer, lo log.StdLogger) *Consumer {
+func NewConsumer(ctx context.Context, consumerPoolSize int, q queue.Queuer, lo log.StdLogger, level log.Level) *Consumer {
 	lo.Infof("The consumer pool size has been set to %d.", consumerPoolSize)
 
 	var opts asynq.RedisConnOpt
@@ -53,6 +54,7 @@ func NewConsumer(ctx context.Context, consumerPoolSize int, q queue.Queuer, lo l
 			},
 			RetryDelayFunc: task.GetRetryDelay,
 			Logger:         lo,
+			LogLevel:       getLogLevel(level),
 		},
 	)
 
@@ -107,4 +109,21 @@ func (c *Consumer) loggingMiddleware(h asynq.Handler, tel *telemetry.Telemetry) 
 
 		return nil
 	})
+}
+
+func getLogLevel(lvl log.Level) asynq.LogLevel {
+	switch lvl {
+	case log.DebugLevel:
+		return asynq.DebugLevel
+	case log.InfoLevel:
+		return asynq.InfoLevel
+	case log.WarnLevel:
+		return asynq.WarnLevel
+	case log.ErrorLevel:
+		return asynq.ErrorLevel
+	case log.FatalLevel:
+		return asynq.FatalLevel
+	default:
+		return asynq.InfoLevel
+	}
 }

--- a/worker/task/process_broadcast_event_creation.go
+++ b/worker/task/process_broadcast_event_creation.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/frain-dev/convoy/pkg/log"
 	"github.com/frain-dev/convoy/pkg/msgpack"
 	"gopkg.in/guregu/null.v4"
 
@@ -148,6 +149,10 @@ func (b *BroadcastEventChannel) MatchSubscriptions(ctx context.Context, metadata
 	subscriptions := make([]datastore.Subscription, 0, len(matchAllSubs)+len(eventTypeSubs))
 	subscriptions = append(subscriptions, eventTypeSubs...)
 	subscriptions = append(subscriptions, matchAllSubs...)
+
+	log.FromContext(ctx).WithFields(log.Fields{
+		"event.id": broadcastEvent.UID,
+	}).Debug("matching subscriptions using filter")
 
 	subscriptions, err = matchSubscriptionsUsingFilter(ctx, broadcastEvent, args.subRepo, args.filterRepo, args.licenser, subscriptions, true)
 	if err != nil {


### PR DESCRIPTION
This pull request brings `main` up to speed with all the changes from `v25.6.x` series, which include:

1. Correctly passing the logger to the workers. 
2. Removing the race condition from the `compare` package.
3. Debug log lines to the broadcast event processing pipeline.