### PR TITLE
fix: circuit breaker email notifications not being sent

### DIFF
--- a/cmd/worker/notifications.go
+++ b/cmd/worker/notifications.go
@@ -6,6 +6,7 @@ import (
 	"github.com/frain-dev/convoy"
 	"github.com/frain-dev/convoy/datastore"
 	"github.com/frain-dev/convoy/internal/email"
+	notification "github.com/frain-dev/convoy/internal/notifications"
 	"github.com/frain-dev/convoy/pkg/log"
 	"github.com/frain-dev/convoy/pkg/msgpack"
 	"github.com/frain-dev/convoy/queue"
@@ -70,7 +71,14 @@ func EnqueueCircuitBreakerEmails(q queue.Queuer, lo *log.Logger, project *datast
 }
 
 func enqueueEmail(q queue.Queuer, emailMsg *email.Message) error {
-	bytes, err := msgpack.EncodeMsgPack(emailMsg)
+	// Wrap email message in notification.Notification struct
+	// ProcessNotifications expects this structure with NotificationType and Payload
+	notif := &notification.Notification{
+		NotificationType: notification.EmailNotificationType,
+		Payload:          emailMsg,
+	}
+
+	bytes, err := msgpack.EncodeMsgPack(notif)
 	if err != nil {
 		return err
 	}

--- a/worker/task/process_notifications.go
+++ b/worker/task/process_notifications.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/frain-dev/convoy/pkg/msgpack"
 	"strconv"
 	"time"
+
+	"github.com/frain-dev/convoy/pkg/msgpack"
 
 	"github.com/frain-dev/convoy"
 	"github.com/frain-dev/convoy/internal/email"
@@ -29,8 +30,55 @@ func ProcessNotifications(sc smtp.SmtpClient) func(context.Context, *asynq.Task)
 		if err != nil {
 			err := json.Unmarshal(t.Payload(), &n)
 			if err != nil {
+				// If unmarshal fails, try parsing as raw email.Message (backward compatibility)
+				np := &email.Message{}
+				err := msgpack.DecodeMsgPack(t.Payload(), np)
+				if err != nil {
+					err := json.Unmarshal(t.Payload(), np)
+					if err != nil {
+						return ErrInvalidNotificationPayload
+					}
+				}
+				// Successfully parsed as email, process it
+				if np.Email != "" {
+					newEmail := email.NewEmail(sc)
+					err = newEmail.Build(string(np.TemplateName), np.Params)
+					if err != nil {
+						return err
+					}
+					return newEmail.Send(np.Email, np.Subject)
+				}
 				return ErrInvalidNotificationPayload
 			}
+		}
+
+		// If NotificationType is empty and Payload is nil/empty, try parsing original payload as raw email.Message
+		payloadEmpty := n.Payload == nil
+		if !payloadEmpty {
+			// Check if payload is an empty map/interface
+			if payloadMap, ok := n.Payload.(map[string]interface{}); ok && len(payloadMap) == 0 {
+				payloadEmpty = true
+			}
+		}
+		if n.NotificationType == "" && payloadEmpty {
+			np := &email.Message{}
+			err := msgpack.DecodeMsgPack(t.Payload(), np)
+			if err != nil {
+				err := json.Unmarshal(t.Payload(), np)
+				if err != nil {
+					return ErrInvalidNotificationPayload
+				}
+			}
+			// Successfully parsed as email, process it
+			if np.Email != "" {
+				newEmail := email.NewEmail(sc)
+				err = newEmail.Build(string(np.TemplateName), np.Params)
+				if err != nil {
+					return err
+				}
+				return newEmail.Send(np.Email, np.Subject)
+			}
+			return ErrInvalidNotificationPayload
 		}
 
 		bufP, err := json.Marshal(n.Payload)
@@ -78,6 +126,19 @@ func ProcessNotifications(sc smtp.SmtpClient) func(context.Context, *asynq.Task)
 			return nil
 
 		default:
+			// Default to email if notification type is empty/invalid but payload can be parsed as email
+			np := &email.Message{}
+			err := json.Unmarshal(bufP, np)
+			if err == nil && np.Email != "" {
+				// Successfully parsed as email, process it
+				newEmail := email.NewEmail(sc)
+				err = newEmail.Build(string(np.TemplateName), np.Params)
+				if err != nil {
+					return err
+				}
+				return newEmail.Send(np.Email, np.Subject)
+			}
+
 			return ErrInvalidNotificationType
 		}
 	}

--- a/worker/task/process_notifications_test.go
+++ b/worker/task/process_notifications_test.go
@@ -111,6 +111,55 @@ func TestProcessNotifications(t *testing.T) {
 			clientFn:      nil,
 			expectedError: nil,
 		},
+		{
+			name: "should_pass_when_email_payload_is_valid_but_type_is_missing",
+			payload: `
+				{
+					"notification_type": "",
+					"payload": {
+						"email": "user@default.com",
+						"subject": "Endpoint Disabled - Circuit Breaker Triggered",
+						"template_name": "endpoint.update",
+						"params": {
+							"name": "test-endpoint",
+							"target_url": "https://example.com",
+							"failure_msg": "Circuit breaker threshold exceeded",
+							"endpoint_status": "inactive"
+						}
+					}
+				}
+			`,
+			clientFn: func(sc *mocks.MockSmtpClient) {
+				// Should be called once when fix is applied
+				sc.EXPECT().
+					SendEmail(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil).Times(1)
+			},
+			expectedError: nil,
+		},
+		{
+			name: "should_pass_when_raw_email_message_is_sent",
+			payload: `
+				{
+					"email": "user@default.com",
+					"subject": "Endpoint Disabled - Circuit Breaker Triggered",
+					"template_name": "endpoint.update",
+					"params": {
+						"name": "test-endpoint",
+						"target_url": "https://example.com",
+						"failure_msg": "Circuit breaker threshold exceeded",
+						"endpoint_status": "inactive"
+					}
+				}
+			`,
+			clientFn: func(sc *mocks.MockSmtpClient) {
+				// Should be called once when fix is applied
+				sc.EXPECT().
+					SendEmail(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil).Times(1)
+			},
+			expectedError: nil,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
- Fix circuit breaker emails failing with 'invalid notification type' error
- Wrap email messages in notification.Notification struct when enqueueing from circuit breaker
- Add fallback logic to parse and process email payload when notification type is missing
- Add backward compatibility for raw email.Message payloads
- Add test cases to verify emails are sent correctly