### PR TITLE
fix: always assign RoleOrganisationAdmin, clear localStorage on logout, add VAT placeholder examples

### DIFF
--- a/services/create_organisation.go
+++ b/services/create_organisation.go
@@ -74,22 +74,7 @@ func (co *CreateOrganisationService) Run(ctx context.Context) (*datastore.Organi
 		return nil, &ServiceError{ErrMsg: "failed to create organisation", Err: err}
 	}
 
-	// Check if this is the first user (no instance admins exist yet)
-	count, err := co.OrgMemberRepo.CountInstanceAdminUsers(ctx)
-	if err != nil {
-		log.FromContext(ctx).WithError(err).Error("failed to count instance admin users")
-		return nil, &ServiceError{ErrMsg: "failed to create organisation", Err: err}
-	}
-
-	// Only assign RoleInstanceAdmin to the first user, otherwise assign RoleOrganisationAdmin
-	var roleType auth.RoleType
-	if count == 0 {
-		roleType = auth.RoleInstanceAdmin
-	} else {
-		roleType = auth.RoleOrganisationAdmin
-	}
-
-	_, err = NewOrganisationMemberService(co.OrgMemberRepo, co.Licenser).CreateOrganisationMember(ctx, org, co.User, &auth.Role{Type: roleType})
+	_, err = NewOrganisationMemberService(co.OrgMemberRepo, co.Licenser).CreateOrganisationMember(ctx, org, co.User, &auth.Role{Type: auth.RoleOrganisationAdmin})
 	if err != nil {
 		log.FromContext(ctx).WithError(err).Error("failed to create super_user member for organisation owner")
 	}

--- a/services/create_organisation_test.go
+++ b/services/create_organisation_test.go
@@ -54,7 +54,6 @@ func TestCreateOrganisationService_Run(t *testing.T) {
 					Times(1).Return(nil)
 
 				om, _ := os.OrgMemberRepo.(*mocks.MockOrganisationMemberRepository)
-				om.EXPECT().CountInstanceAdminUsers(gomock.Any()).Times(1).Return(int64(0), nil)
 				om.EXPECT().CreateOrganisationMember(gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
 				licenser, _ := os.Licenser.(*mocks.MockLicenser)
@@ -77,7 +76,6 @@ func TestCreateOrganisationService_Run(t *testing.T) {
 					Times(1).Return(nil)
 
 				om, _ := os.OrgMemberRepo.(*mocks.MockOrganisationMemberRepository)
-				om.EXPECT().CountInstanceAdminUsers(gomock.Any()).Times(1).Return(int64(1), nil)
 				om.EXPECT().CreateOrganisationMember(gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
 				licenser, _ := os.Licenser.(*mocks.MockLicenser)
@@ -131,27 +129,6 @@ func TestCreateOrganisationService_Run(t *testing.T) {
 			},
 			wantErr:    true,
 			wantErrMsg: ErrOrgLimit.Error(),
-		},
-		{
-			name: "should_fail_to_count_instance_admin_users",
-			args: args{
-				ctx:    ctx,
-				newOrg: &models.Organisation{Name: "new_org"},
-				user:   &datastore.User{UID: "1234"},
-			},
-			dbFn: func(os *CreateOrganisationService) {
-				a, _ := os.OrgRepo.(*mocks.MockOrganisationRepository)
-				a.EXPECT().CreateOrganisation(gomock.Any(), gomock.Any()).
-					Times(1).Return(nil)
-
-				om, _ := os.OrgMemberRepo.(*mocks.MockOrganisationMemberRepository)
-				om.EXPECT().CountInstanceAdminUsers(gomock.Any()).Times(1).Return(int64(0), errors.New("db error"))
-
-				licenser, _ := os.Licenser.(*mocks.MockLicenser)
-				licenser.EXPECT().CreateOrg(gomock.Any()).Times(1).Return(true, nil)
-			},
-			wantErr:    true,
-			wantErrMsg: "failed to create organisation",
 		},
 	}
 	for _, tt := range tests {

--- a/services/register_user_test.go
+++ b/services/register_user_test.go
@@ -84,7 +84,6 @@ func TestRegisterUserService_Run(t *testing.T) {
 				us.EXPECT().CreateUser(gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
 				orgRepo.EXPECT().CreateOrganisation(gomock.Any(), gomock.Any()).Times(1).Return(nil)
-				orgMemberRepo.EXPECT().CountInstanceAdminUsers(gomock.Any()).Times(1).Return(int64(0), nil)
 				orgMemberRepo.EXPECT().CreateOrganisationMember(gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
 				queue.EXPECT().Write(gomock.Any(), gomock.Any(), gomock.Any())
@@ -176,7 +175,6 @@ func TestRegisterUserService_Run(t *testing.T) {
 				us.EXPECT().CreateUser(gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
 				orgRepo.EXPECT().CreateOrganisation(gomock.Any(), gomock.Any()).Times(1).Return(nil)
-				orgMemberRepo.EXPECT().CountInstanceAdminUsers(gomock.Any()).Times(1).Return(int64(0), nil)
 				orgMemberRepo.EXPECT().CreateOrganisationMember(gomock.Any(), gomock.Any()).Times(1).Return(nil)
 
 				queue.EXPECT().Write(gomock.Any(), gomock.Any(), gomock.Any())

--- a/sql/1764854033.sql
+++ b/sql/1764854033.sql
@@ -1,0 +1,19 @@
+-- +migrate Up
+-- Set all instance_admin roles to organisation_admin
+UPDATE convoy.organisation_members
+SET role_type = 'organisation_admin'
+WHERE role_type = 'instance_admin';
+
+-- +migrate Down
+-- Revert the first user's organisation_admin role back to instance_admin
+-- Note: This only reverts the first user (by created_at), not all users
+UPDATE convoy.organisation_members
+SET role_type = 'instance_admin'
+WHERE role_type = 'organisation_admin'
+AND id = (
+    SELECT id FROM convoy.organisation_members
+    WHERE role_type = 'organisation_admin'
+    ORDER BY created_at ASC
+    LIMIT 1
+);
+

--- a/web/ui/dashboard/src/app/private/pages/settings/billing/billing-page.component.html
+++ b/web/ui/dashboard/src/app/private/pages/settings/billing/billing-page.component.html
@@ -305,7 +305,7 @@
 
             <convoy-input-field>
               <label for="vatNumber" convoy-label required="true">VAT number</label>
-              <input type="text" id="vatNumber" convoy-input formControlName="vatNumber" placeholder="Enter VAT number" />
+              <input type="text" id="vatNumber" convoy-input formControlName="vatNumber" [placeholder]="vatPlaceholder" />
               <convoy-input-error *ngIf="vatForm.get('vatNumber')?.touched && vatForm.get('vatNumber')?.invalid">
               <span *ngIf="vatForm.get('vatNumber')?.errors?.['required']">Please enter VAT number</span>
               <span *ngIf="vatForm.get('vatNumber')?.errors?.['invalidVatNumber']">Please enter a valid VAT number format</span>

--- a/web/ui/dashboard/src/app/private/pages/settings/billing/billing-page.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/settings/billing/billing-page.component.ts
@@ -54,6 +54,8 @@ export class BillingPageComponent implements OnInit {
 
   countries: { code: string; name: string }[] = [];
   vatCountries: { code: string; name: string }[] = []; // Countries with tax ID types from billing service
+  taxIdTypes: any[] = []; // Store tax ID types with examples
+  vatPlaceholder = 'Enter VAT number'; // Dynamic placeholder based on selected country
   cities: string[] = [];
   isLoadingCountries = false;
   isLoadingVatCountries = false;
@@ -96,6 +98,10 @@ export class BillingPageComponent implements OnInit {
 
     this.billingAddressForm.get('country')?.valueChanges.subscribe(countryCode => {
       this.onCountryChange(countryCode);
+    });
+
+    this.vatForm.get('country')?.valueChanges.subscribe(countryCode => {
+      this.onVatCountryChange(countryCode);
     });
   }
 
@@ -178,6 +184,7 @@ export class BillingPageComponent implements OnInit {
     this.billingPaymentDetailsService.getTaxIDTypes().subscribe({
       next: (response) => {
         const taxIdTypes = response.data || [];
+        this.taxIdTypes = taxIdTypes; // Store tax ID types with examples
         this.vatCountries = [];
 
         taxIdTypes.forEach((taxType: any) => {
@@ -199,8 +206,34 @@ export class BillingPageComponent implements OnInit {
         console.error('Failed to load VAT countries:', error);
         this.isLoadingVatCountries = false;
         this.vatCountries = [];
+        this.taxIdTypes = [];
       }
     });
+  }
+
+  onVatCountryChange(countryCode: string) {
+    if (!countryCode) {
+      this.vatPlaceholder = 'Enter VAT number';
+      return;
+    }
+
+    // Find the tax ID type for the selected country
+    const countryCodeLower = countryCode.toLowerCase();
+    const taxIdType = this.taxIdTypes.find((taxType: any) => {
+      const type = taxType.type;
+      if (type) {
+        const typeCountryCode = type.split('_')[0].toLowerCase();
+        return typeCountryCode === countryCodeLower;
+      }
+      return false;
+    });
+
+    // Set placeholder to the example if found, otherwise default
+    if (taxIdType && taxIdType.example) {
+      this.vatPlaceholder = taxIdType.example;
+    } else {
+      this.vatPlaceholder = 'Enter VAT number';
+    }
   }
 
   onCountryChange(countryCode: string) {

--- a/web/ui/dashboard/src/app/private/private.component.ts
+++ b/web/ui/dashboard/src/app/private/private.component.ts
@@ -63,7 +63,7 @@ export class PrivateComponent implements OnInit {
 
 	async logout() {
 		await this.privateService.logout();
-		localStorage.removeItem('CONVOY_AUTH');
+		localStorage.clear();
 		this.router.navigateByUrl('/login');
 	}
 

--- a/web/ui/dashboard/src/app/public/google-oauth-setup/google-oauth-setup.component.ts
+++ b/web/ui/dashboard/src/app/public/google-oauth-setup/google-oauth-setup.component.ts
@@ -70,16 +70,27 @@ export class GoogleOAuthSetupComponent implements OnInit {
 			const response = await this.googleOAuthSetupService.completeSetup(idToken, businessName);
 
 			if (response.data) {
+				// Check if this is a different user
+				const lastUserId = localStorage.getItem('CONVOY_LAST_USER_ID');
+				let refresh = false;
+				if (lastUserId && lastUserId !== response.data.uid) {
+					localStorage.clear();
+					refresh = true;
+				}
+
 				this.generalService.showNotification({
 					message: 'Setup completed successfully! Welcome to Convoy.',
 					style: 'success'
 				});
+				localStorage.setItem('CONVOY_LAST_USER_ID', response.data.uid);
 				localStorage.setItem('CONVOY_AUTH', JSON.stringify(response.data));
 				localStorage.setItem('CONVOY_AUTH_TOKENS', JSON.stringify(response.data.token));
-				localStorage.setItem('CONVOY_LAST_USER_ID', response.data.uid);
 				localStorage.removeItem('GOOGLE_OAUTH_USER_INFO');
 				localStorage.removeItem('GOOGLE_OAUTH_ID_TOKEN');
 				await this.router.navigateByUrl('/');
+				if (refresh) {
+					window.location.reload();
+				}
 			}
 		} catch (error: any) {
 			this.generalService.showNotification({

--- a/web/ui/dashboard/src/app/public/login/login.component.ts
+++ b/web/ui/dashboard/src/app/public/login/login.component.ts
@@ -238,19 +238,29 @@ export class LoginComponent implements OnInit, AfterViewInit {
                         return;
                     }
 
-                    // Show success notification
+                    // Check if this is a different user
+					const lastUserId = localStorage.getItem('CONVOY_LAST_USER_ID');
+					let refresh = false;
+					if (lastUserId && lastUserId !== response.data.uid) {
+						localStorage.clear();
+						refresh = true;
+					}
+
+					// Show success notification
 					this.generalService.showNotification({
 						message: 'Google login successful! Welcome back.',
 						style: 'success'
 					});
 
+					localStorage.setItem('CONVOY_LAST_USER_ID', response.data.uid);
 					localStorage.setItem('CONVOY_AUTH', JSON.stringify(response.data));
 					localStorage.setItem('CONVOY_AUTH_TOKENS', JSON.stringify(response.data.token));
-					localStorage.setItem('CONVOY_LAST_USER_ID', response.data.uid);
 
-					// await this.getOrganisations();
+					await this.getOrganisations();
 					await this.router.navigateByUrl('/');
-					// window.location.reload();
+					if (refresh) {
+						window.location.reload();
+					}
                 }
             }
         } catch (error: any) {


### PR DESCRIPTION
- Remove instance admin check, always assign RoleOrganisationAdmin when creating organisations
- Add migration to convert all instance admins to org admins
- Clear all localStorage on logout to prevent seeing previous org data
- Clear localStorage when logging in as different user (regular and Google OAuth)
- Update VAT form to show example format as placeholder when country is selected
- Update login to check first org admin per organization when no instance admins exist
- Update error message to reflect organization administrator instead of instance administrator
- Update tests to remove CountInstanceAdminUsers expectations