### PR TITLE
fix release draft creation

### DIFF
--- a/.publisher.yml
+++ b/.publisher.yml
@@ -100,5 +100,5 @@ release:
     owner: frain-dev
     name: Convoy
   prerelease: auto
-  draft: true
+  draft: false
   name_template: "{{ .ProjectName }}-v{{ .Version }}"


### PR DESCRIPTION
```
change prevents the creation of a draft release anytime a version is pushed.
```