### PR TITLE
fix: allow activation of both inactive and paused endpoints

### DIFF
--- a/services/activate_endpoint.go
+++ b/services/activate_endpoint.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/frain-dev/convoy/datastore"
 	"github.com/frain-dev/convoy/pkg/log"
@@ -20,8 +21,8 @@ func (s *ActivateEndpointService) Run(ctx context.Context) (*datastore.Endpoint,
 		return nil, &ServiceError{ErrMsg: "failed to find endpoint", Err: err}
 	}
 
-	if endpoint.Status != datastore.InactiveEndpointStatus {
-		return nil, &ServiceError{ErrMsg: "the endpoint must be inactive"}
+	if endpoint.Status != datastore.InactiveEndpointStatus && endpoint.Status != datastore.PausedEndpointStatus {
+		return nil, &ServiceError{ErrMsg: fmt.Sprintf("current endpoint status - %s, does not support activation", endpoint.Status)}
 	}
 
 	err = s.EndpointRepo.UpdateEndpointStatus(ctx, s.ProjectID, endpoint.UID, datastore.ActiveEndpointStatus)


### PR DESCRIPTION
- Updated ActivateEndpointService to accept both InactiveEndpointStatus and PausedEndpointStatus
- Fixed issue where unpausing paused endpoints via portal links showed error 'the endpoint must be inactive'
- Updated error message to match pattern used in PauseEndpointService
- Added fmt import for formatted error messages

This allows users to activate endpoints from both inactive and paused states, resolving the issue when accessing via portal links and activating from project page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Behavior change**
> 
> - `ActivateEndpointService.Run` now allows activation when `endpoint.Status` is `InactiveEndpointStatus` or `PausedEndpointStatus` (was only inactive).
> - Returns a formatted error indicating the current status when activation isn’t supported.
> 
> **Implementation**
> 
> - Updated condition and error message in `services/activate_endpoint.go`; added `fmt` import for formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffcb4746bb47f50d3283202677bc1993ad75a793. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->