### PR TITLE
refactor(infra): extract inline CI workflow scripts into scripts/ci/

### DIFF
--- a/.github/workflows/lint-migrations.yml
+++ b/.github/workflows/lint-migrations.yml
@@ -30,21 +30,7 @@ jobs:
 
       - name: Get changed SQL files
         id: changed-files
-        run: |
-          # Get list of changed SQL files in this PR
-          CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT origin/${{ github.base_ref }}...HEAD -- 'sql/*.sql' || echo "")
-
-          if [ -z "$CHANGED_FILES" ]; then
-            echo "No SQL files changed"
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-          else
-            echo "Changed SQL files:"
-            echo "$CHANGED_FILES"
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            # Convert newlines to spaces for squawk
-            FILES_LIST=$(echo "$CHANGED_FILES" | tr '\n' ' ')
-            echo "files=$FILES_LIST" >> $GITHUB_OUTPUT
-          fi
+        run: ./scripts/ci/get-changed-sql-files.sh "${{ github.base_ref }}"
 
       - name: Validate migration structure
         if: steps.changed-files.outputs.has_changes == 'true'

--- a/.github/workflows/monthly-release-pr.yml
+++ b/.github/workflows/monthly-release-pr.yml
@@ -50,63 +50,19 @@ jobs:
       - name: Build release plan
         id: release-plan
         if: ${{ steps.check-day.outputs.should_run == 'true' }}
-        run: |
-          CURRENT_YEAR="$(date -u +%Y)"
-          CURRENT_MONTH_PADDED="$(date -u +%m)"
-          PREVIOUS_MONTH_DATE="$(date -u -d "$(date -u +%Y-%m-01) -1 day" +%Y-%m-%d)"
-          RELEASE_YEAR_FULL="$(date -u -d "${PREVIOUS_MONTH_DATE}" +%Y)"
-          RELEASE_YEAR="$(date -u -d "${PREVIOUS_MONTH_DATE}" +%y)"
-          RELEASE_MONTH="$(date -u -d "${PREVIOUS_MONTH_DATE}" +%-m)"
-          RELEASE_MONTH_PADDED="$(date -u -d "${PREVIOUS_MONTH_DATE}" +%m)"
-          RELEASE_VERSION="$(./scripts/calver.sh "${RELEASE_YEAR}" "${RELEASE_MONTH}")"
-          CURRENT_CUTOFF_TAG="release-cutoff-${CURRENT_YEAR}-${CURRENT_MONTH_PADDED}"
-          RELEASE_CUTOFF_TAG="release-cutoff-${RELEASE_YEAR_FULL}-${RELEASE_MONTH_PADDED}"
-          RELEASE_LINE="${RELEASE_YEAR}.${RELEASE_MONTH}"
-
-          echo "version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "release_line=${RELEASE_LINE}" >> "$GITHUB_OUTPUT"
-          echo "current_cutoff_tag=${CURRENT_CUTOFF_TAG}" >> "$GITHUB_OUTPUT"
-          echo "release_cutoff_tag=${RELEASE_CUTOFF_TAG}" >> "$GITHUB_OUTPUT"
+        run: ./scripts/ci/build-release-plan.sh
 
       - name: Create current month cutoff tag
         if: ${{ steps.check-day.outputs.should_run == 'true' }}
-        run: |
-          CURRENT_CUTOFF_TAG="${{ steps.release-plan.outputs.current_cutoff_tag }}"
-          CURRENT_SHA="$(git rev-parse HEAD)"
-
-          if git rev-parse --verify "refs/tags/${CURRENT_CUTOFF_TAG}" >/dev/null 2>&1; then
-            echo "Cutoff tag ${CURRENT_CUTOFF_TAG} already exists."
-            exit 0
-          fi
-
-          git tag "${CURRENT_CUTOFF_TAG}" "${CURRENT_SHA}"
-          git push origin "refs/tags/${CURRENT_CUTOFF_TAG}"
+        run: ./scripts/ci/create-cutoff-tag.sh "${{ steps.release-plan.outputs.current_cutoff_tag }}"
 
       - name: Resolve release target
         id: release-target
         if: ${{ steps.check-day.outputs.should_run == 'true' }}
-        run: |
-          RELEASE_CUTOFF_TAG="${{ steps.release-plan.outputs.release_cutoff_tag }}"
-          VERSION="${{ steps.release-plan.outputs.version }}"
-
-          if ! git rev-parse --verify "refs/tags/${RELEASE_CUTOFF_TAG}" >/dev/null 2>&1; then
-            echo "No prior cutoff tag ${RELEASE_CUTOFF_TAG}; bootstrap month only."
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if git rev-parse --verify "refs/tags/v${VERSION}" >/dev/null 2>&1; then
-            echo "Release tag v${VERSION} already exists; skipping."
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          TARGET_SHA="$(git rev-list -n 1 "${RELEASE_CUTOFF_TAG}")"
-          PREVIOUS_STABLE_TAG="$(git tag --merged "${TARGET_SHA}" --list 'v*' --sort=-version:refname | sed -n '1p')"
-
-          echo "target_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
-          echo "previous_stable_tag=${PREVIOUS_STABLE_TAG}" >> "$GITHUB_OUTPUT"
-          echo "should_run=true" >> "$GITHUB_OUTPUT"
+        run: >-
+          ./scripts/ci/resolve-release-target.sh
+          "${{ steps.release-plan.outputs.release_cutoff_tag }}"
+          "${{ steps.release-plan.outputs.version }}"
 
       - name: Install git-cliff
         if: ${{ steps.release-target.outputs.should_run == 'true' }}
@@ -129,18 +85,14 @@ jobs:
 
       - name: Write release manifest
         if: ${{ steps.release-target.outputs.should_run == 'true' }}
-        run: |
-          cat <<EOF > .github/release-manifest.json
-          {
-            "version": "${{ steps.release-plan.outputs.version }}",
-            "release_line": "${{ steps.release-plan.outputs.release_line }}",
-            "target_sha": "${{ steps.release-target.outputs.target_sha }}",
-            "cutoff_tag": "${{ steps.release-plan.outputs.release_cutoff_tag }}",
-            "next_cutoff_tag": "${{ steps.release-plan.outputs.current_cutoff_tag }}",
-            "previous_stable_tag": "${{ steps.release-target.outputs.previous_stable_tag }}",
-            "generated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          }
-          EOF
+        run: >-
+          ./scripts/ci/write-release-manifest.sh
+          "${{ steps.release-plan.outputs.version }}"
+          "${{ steps.release-plan.outputs.release_line }}"
+          "${{ steps.release-target.outputs.target_sha }}"
+          "${{ steps.release-plan.outputs.release_cutoff_tag }}"
+          "${{ steps.release-plan.outputs.current_cutoff_tag }}"
+          "${{ steps.release-target.outputs.previous_stable_tag }}"
 
       - name: Create release PR
         if: ${{ steps.release-target.outputs.should_run == 'true' }}
@@ -185,9 +137,9 @@ jobs:
       - name: Trigger tag-stable-release workflow
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run "tag-stable-release.yml" \
-            --ref main \
-            --repo "${{ github.repository }}" \
-            -f version="${{ steps.manifest.outputs.version }}" \
-            -f target_sha="${{ steps.manifest.outputs.target_sha }}"
+        run: >-
+          gh workflow run "tag-stable-release.yml"
+          --ref main
+          --repo "${{ github.repository }}"
+          -f version="${{ steps.manifest.outputs.version }}"
+          -f target_sha="${{ steps.manifest.outputs.target_sha }}"

--- a/.github/workflows/promote-patch-release.yml
+++ b/.github/workflows/promote-patch-release.yml
@@ -31,70 +31,15 @@ jobs:
 
       - name: Build promotion plan
         id: plan
-        run: |
-          RELEASE_LINE="${{ inputs.release_line }}"
-
-          if ! [[ "${RELEASE_LINE}" =~ ^([0-9]{2})\.([0-9]{1,2})$ ]]; then
-            echo "release_line must match YY.M, for example 26.3" >&2
-            exit 1
-          fi
-
-          RELEASE_YEAR="${BASH_REMATCH[1]}"
-          RELEASE_MONTH="${BASH_REMATCH[2]}"
-          RELEASE_MONTH=$((10#${RELEASE_MONTH}))
-          RELEASE_YEAR_FULL=$((2000 + 10#${RELEASE_YEAR}))
-          NEXT_MONTH=$((RELEASE_MONTH + 1))
-          NEXT_YEAR_FULL=${RELEASE_YEAR_FULL}
-
-          if [ "${NEXT_MONTH}" -gt 12 ]; then
-            NEXT_MONTH=1
-            NEXT_YEAR_FULL=$((RELEASE_YEAR_FULL + 1))
-          fi
-
-          NEXT_CUTOFF_TAG="$(printf 'release-cutoff-%04d-%02d' "${NEXT_YEAR_FULL}" "${NEXT_MONTH}")"
-          BASE_TAG="v${RELEASE_YEAR}.${RELEASE_MONTH}.0"
-          VERSION="$(./scripts/calver.sh "${RELEASE_YEAR}" "${RELEASE_MONTH}")"
-
-          echo "release_year=${RELEASE_YEAR}" >> "$GITHUB_OUTPUT"
-          echo "release_month=${RELEASE_MONTH}" >> "$GITHUB_OUTPUT"
-          echo "next_cutoff_tag=${NEXT_CUTOFF_TAG}" >> "$GITHUB_OUTPUT"
-          echo "base_tag=${BASE_TAG}" >> "$GITHUB_OUTPUT"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        run: ./scripts/ci/build-promotion-plan.sh "${{ inputs.release_line }}"
 
       - name: Validate candidate commit
         id: validate
-        run: |
-          CANDIDATE_SHA="${{ inputs.commit_sha }}"
-          NEXT_CUTOFF_TAG="${{ steps.plan.outputs.next_cutoff_tag }}"
-          BASE_TAG="${{ steps.plan.outputs.base_tag }}"
-
-          if ! git rev-parse --verify "${CANDIDATE_SHA}^{commit}" >/dev/null 2>&1; then
-            echo "Commit '${CANDIDATE_SHA}' does not exist." >&2
-            exit 1
-          fi
-
-          if ! git rev-parse --verify "refs/tags/${BASE_TAG}" >/dev/null 2>&1; then
-            echo "Base release tag ${BASE_TAG} does not exist yet." >&2
-            exit 1
-          fi
-
-          if ! git rev-parse --verify "refs/tags/${NEXT_CUTOFF_TAG}" >/dev/null 2>&1; then
-            echo "Next cutoff tag ${NEXT_CUTOFF_TAG} does not exist." >&2
-            exit 1
-          fi
-
-          if ! git merge-base --is-ancestor "${CANDIDATE_SHA}" "origin/main"; then
-            echo "Commit '${CANDIDATE_SHA}' is not reachable from origin/main." >&2
-            exit 1
-          fi
-
-          NEXT_CUTOFF_SHA="$(git rev-list -n 1 "${NEXT_CUTOFF_TAG}")"
-          if ! git merge-base --is-ancestor "${CANDIDATE_SHA}" "${NEXT_CUTOFF_SHA}"; then
-            echo "Commit '${CANDIDATE_SHA}' is newer than the next cutoff ${NEXT_CUTOFF_TAG}." >&2
-            exit 1
-          fi
-
-          echo "next_cutoff_sha=${NEXT_CUTOFF_SHA}" >> "$GITHUB_OUTPUT"
+        run: >-
+          ./scripts/ci/validate-candidate-commit.sh
+          "${{ inputs.commit_sha }}"
+          "${{ steps.plan.outputs.next_cutoff_tag }}"
+          "${{ steps.plan.outputs.base_tag }}"
 
       - name: Log promotion plan
         run: |

--- a/scripts/ci/build-promotion-plan.sh
+++ b/scripts/ci/build-promotion-plan.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Parse a release line (YY.M) and compute the promotion plan outputs.
+#
+# Usage:
+#   ./scripts/ci/build-promotion-plan.sh <release_line>
+#
+# Outputs (written to $GITHUB_OUTPUT):
+#   release_year, release_month, next_cutoff_tag, base_tag, version
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <release_line>" >&2
+  exit 1
+fi
+
+RELEASE_LINE="$1"
+
+if ! [[ "${RELEASE_LINE}" =~ ^([0-9]{2})\.([0-9]{1,2})$ ]]; then
+  echo "release_line must match YY.M, for example 26.3" >&2
+  exit 1
+fi
+
+RELEASE_YEAR="${BASH_REMATCH[1]}"
+RELEASE_MONTH=$((10#${BASH_REMATCH[2]}))
+RELEASE_YEAR_FULL=$((2000 + 10#${RELEASE_YEAR}))
+
+NEXT_MONTH=$((RELEASE_MONTH + 1))
+NEXT_YEAR_FULL=${RELEASE_YEAR_FULL}
+if [ "${NEXT_MONTH}" -gt 12 ]; then
+  NEXT_MONTH=1
+  NEXT_YEAR_FULL=$((RELEASE_YEAR_FULL + 1))
+fi
+
+NEXT_CUTOFF_TAG="$(printf 'release-cutoff-%04d-%02d' "${NEXT_YEAR_FULL}" "${NEXT_MONTH}")"
+BASE_TAG="v${RELEASE_YEAR}.${RELEASE_MONTH}.0"
+VERSION="$(./scripts/calver.sh "${RELEASE_YEAR}" "${RELEASE_MONTH}")"
+
+echo "release_year=${RELEASE_YEAR}" >> "$GITHUB_OUTPUT"
+echo "release_month=${RELEASE_MONTH}" >> "$GITHUB_OUTPUT"
+echo "next_cutoff_tag=${NEXT_CUTOFF_TAG}" >> "$GITHUB_OUTPUT"
+echo "base_tag=${BASE_TAG}" >> "$GITHUB_OUTPUT"
+echo "version=${VERSION}" >> "$GITHUB_OUTPUT"

--- a/scripts/ci/build-release-plan.sh
+++ b/scripts/ci/build-release-plan.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Compute the monthly release plan from the current UTC date.
+# Derives the release version for the previous month and the
+# corresponding cutoff tags.
+#
+# Usage:
+#   ./scripts/ci/build-release-plan.sh
+#
+# Outputs (written to $GITHUB_OUTPUT):
+#   version, release_line, current_cutoff_tag, release_cutoff_tag
+
+set -euo pipefail
+
+CURRENT_YEAR="$(date -u +%Y)"
+CURRENT_MONTH_PADDED="$(date -u +%m)"
+
+PREVIOUS_MONTH_DATE="$(date -u -d "$(date -u +%Y-%m-01) -1 day" +%Y-%m-%d)"
+RELEASE_YEAR_FULL="$(date -u -d "${PREVIOUS_MONTH_DATE}" +%Y)"
+RELEASE_YEAR="$(date -u -d "${PREVIOUS_MONTH_DATE}" +%y)"
+RELEASE_MONTH="$(date -u -d "${PREVIOUS_MONTH_DATE}" +%-m)"
+RELEASE_MONTH_PADDED="$(date -u -d "${PREVIOUS_MONTH_DATE}" +%m)"
+
+RELEASE_VERSION="$(./scripts/calver.sh "${RELEASE_YEAR}" "${RELEASE_MONTH}")"
+CURRENT_CUTOFF_TAG="release-cutoff-${CURRENT_YEAR}-${CURRENT_MONTH_PADDED}"
+RELEASE_CUTOFF_TAG="release-cutoff-${RELEASE_YEAR_FULL}-${RELEASE_MONTH_PADDED}"
+RELEASE_LINE="${RELEASE_YEAR}.${RELEASE_MONTH}"
+
+echo "version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+echo "release_line=${RELEASE_LINE}" >> "$GITHUB_OUTPUT"
+echo "current_cutoff_tag=${CURRENT_CUTOFF_TAG}" >> "$GITHUB_OUTPUT"
+echo "release_cutoff_tag=${RELEASE_CUTOFF_TAG}" >> "$GITHUB_OUTPUT"

--- a/scripts/ci/create-cutoff-tag.sh
+++ b/scripts/ci/create-cutoff-tag.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Create and push a release cutoff tag at HEAD if it does not already exist.
+#
+# Usage:
+#   ./scripts/ci/create-cutoff-tag.sh <cutoff_tag>
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <cutoff_tag>" >&2
+  exit 1
+fi
+
+CUTOFF_TAG="$1"
+CURRENT_SHA="$(git rev-parse HEAD)"
+
+if git rev-parse --verify "refs/tags/${CUTOFF_TAG}" >/dev/null 2>&1; then
+  echo "Cutoff tag ${CUTOFF_TAG} already exists."
+  exit 0
+fi
+
+git tag "${CUTOFF_TAG}" "${CURRENT_SHA}"
+git push origin "refs/tags/${CUTOFF_TAG}"

--- a/scripts/ci/get-changed-sql-files.sh
+++ b/scripts/ci/get-changed-sql-files.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Detect SQL migration files changed in a pull request.
+#
+# Usage:
+#   ./scripts/ci/get-changed-sql-files.sh <base_ref>
+#
+# Outputs (written to $GITHUB_OUTPUT):
+#   has_changes  ("true" or "false")
+#   files        (space-separated list of changed SQL files)
+
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 <base_ref>" >&2
+  exit 1
+fi
+
+BASE_REF="$1"
+CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRT "origin/${BASE_REF}...HEAD" -- 'sql/*.sql' || echo "")
+
+if [ -z "$CHANGED_FILES" ]; then
+  echo "No SQL files changed"
+  echo "has_changes=false" >> "$GITHUB_OUTPUT"
+else
+  echo "Changed SQL files:"
+  echo "$CHANGED_FILES"
+  echo "has_changes=true" >> "$GITHUB_OUTPUT"
+  FILES_LIST=$(echo "$CHANGED_FILES" | tr '\n' ' ')
+  echo "files=$FILES_LIST" >> "$GITHUB_OUTPUT"
+fi

--- a/scripts/ci/resolve-release-target.sh
+++ b/scripts/ci/resolve-release-target.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Resolve the target SHA for a release from its cutoff tag.
+# Exits early (should_run=false) when the cutoff tag is missing
+# or the release tag already exists.
+#
+# Usage:
+#   ./scripts/ci/resolve-release-target.sh <release_cutoff_tag> <version>
+#
+# Outputs (written to $GITHUB_OUTPUT):
+#   target_sha, previous_stable_tag, should_run
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <release_cutoff_tag> <version>" >&2
+  exit 1
+fi
+
+RELEASE_CUTOFF_TAG="$1"
+VERSION="$2"
+
+if ! git rev-parse --verify "refs/tags/${RELEASE_CUTOFF_TAG}" >/dev/null 2>&1; then
+  echo "No prior cutoff tag ${RELEASE_CUTOFF_TAG}; bootstrap month only."
+  echo "should_run=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+if git rev-parse --verify "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+  echo "Release tag v${VERSION} already exists; skipping."
+  echo "should_run=false" >> "$GITHUB_OUTPUT"
+  exit 0
+fi
+
+TARGET_SHA="$(git rev-list -n 1 "${RELEASE_CUTOFF_TAG}")"
+PREVIOUS_STABLE_TAG="$(git tag --merged "${TARGET_SHA}" --list 'v*' --sort=-version:refname | sed -n '1p')"
+
+echo "target_sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
+echo "previous_stable_tag=${PREVIOUS_STABLE_TAG}" >> "$GITHUB_OUTPUT"
+echo "should_run=true" >> "$GITHUB_OUTPUT"

--- a/scripts/ci/validate-candidate-commit.sh
+++ b/scripts/ci/validate-candidate-commit.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Validate that a candidate commit is eligible for a patch release:
+#   - exists in the repository
+#   - the base release tag and next cutoff tag both exist
+#   - is reachable from origin/main
+#   - is not newer than the next cutoff tag
+#
+# Usage:
+#   ./scripts/ci/validate-candidate-commit.sh <candidate_sha> <next_cutoff_tag> <base_tag>
+#
+# Outputs (written to $GITHUB_OUTPUT):
+#   next_cutoff_sha
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <candidate_sha> <next_cutoff_tag> <base_tag>" >&2
+  exit 1
+fi
+
+CANDIDATE_SHA="$1"
+NEXT_CUTOFF_TAG="$2"
+BASE_TAG="$3"
+
+if ! git rev-parse --verify "${CANDIDATE_SHA}^{commit}" >/dev/null 2>&1; then
+  echo "Commit '${CANDIDATE_SHA}' does not exist." >&2
+  exit 1
+fi
+
+if ! git rev-parse --verify "refs/tags/${BASE_TAG}" >/dev/null 2>&1; then
+  echo "Base release tag ${BASE_TAG} does not exist yet." >&2
+  exit 1
+fi
+
+if ! git rev-parse --verify "refs/tags/${NEXT_CUTOFF_TAG}" >/dev/null 2>&1; then
+  echo "Next cutoff tag ${NEXT_CUTOFF_TAG} does not exist." >&2
+  exit 1
+fi
+
+if ! git merge-base --is-ancestor "${CANDIDATE_SHA}" "origin/main"; then
+  echo "Commit '${CANDIDATE_SHA}' is not reachable from origin/main." >&2
+  exit 1
+fi
+
+NEXT_CUTOFF_SHA="$(git rev-list -n 1 "${NEXT_CUTOFF_TAG}")"
+if ! git merge-base --is-ancestor "${CANDIDATE_SHA}" "${NEXT_CUTOFF_SHA}"; then
+  echo "Commit '${CANDIDATE_SHA}' is newer than the next cutoff ${NEXT_CUTOFF_TAG}." >&2
+  exit 1
+fi
+
+echo "next_cutoff_sha=${NEXT_CUTOFF_SHA}" >> "$GITHUB_OUTPUT"

--- a/scripts/ci/write-release-manifest.sh
+++ b/scripts/ci/write-release-manifest.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Write the release manifest JSON used by the tag-stable-release trigger.
+#
+# Usage:
+#   ./scripts/ci/write-release-manifest.sh <version> <release_line> \
+#       <target_sha> <cutoff_tag> <next_cutoff_tag> <previous_stable_tag>
+#
+# Output:
+#   Writes .github/release-manifest.json
+
+set -euo pipefail
+
+if [ "$#" -ne 6 ]; then
+  echo "Usage: $0 <version> <release_line> <target_sha> <cutoff_tag> <next_cutoff_tag> <previous_stable_tag>" >&2
+  exit 1
+fi
+
+VERSION="$1"
+RELEASE_LINE="$2"
+TARGET_SHA="$3"
+CUTOFF_TAG="$4"
+NEXT_CUTOFF_TAG="$5"
+PREVIOUS_STABLE_TAG="$6"
+
+cat <<EOF > .github/release-manifest.json
+{
+  "version": "${VERSION}",
+  "release_line": "${RELEASE_LINE}",
+  "target_sha": "${TARGET_SHA}",
+  "cutoff_tag": "${CUTOFF_TAG}",
+  "next_cutoff_tag": "${NEXT_CUTOFF_TAG}",
+  "previous_stable_tag": "${PREVIOUS_STABLE_TAG}",
+  "generated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+}
+EOF


### PR DESCRIPTION
## Summary
- Extract 7 complex inline bash scripts from CI workflows (`promote-patch-release.yml`, `monthly-release-pr.yml`, `lint-migrations.yml`) into standalone files under `scripts/ci/`.
- Each script follows existing repo conventions (`set -euo pipefail`, usage guards, argument validation) matching `scripts/tag-release.sh` and `scripts/calver.sh`.
- Workflow files are now significantly shorter and scannable—steps that were 15–30 lines of inline bash are replaced with single-line script invocations.

## Test plan
- [ ] Verify `promote-patch-release.yml` dispatches correctly (inputs are forwarded to scripts)
- [ ] Verify `monthly-release-pr.yml` runs on schedule/manual trigger (check-day step still inline, post-checkout steps call scripts)
- [ ] Verify `lint-migrations.yml` detects changed SQL files on a PR with SQL changes
- [ ] Confirm all new scripts under `scripts/ci/` are executable


Made with [Cursor](https://cursor.com)