### PR TITLE
fix(dataplane): assert non-nil configurations for HmacOptions

### DIFF
--- a/api/ingest.go
+++ b/api/ingest.go
@@ -94,7 +94,14 @@ func (a *ApplicationHandler) IngestEvent(w http.ResponseWriter, r *http.Request)
 				Secret:   verifierConfig.HMac.Secret,
 				Encoding: string(verifierConfig.HMac.Encoding),
 			}
-			v = verifier.NewHmacVerifier(opts)
+			v, err = verifier.NewHmacVerifier(opts)
+			if err != nil {
+				a.A.Logger.Error("failed to initialize HMAC verifier", "error", err)
+
+				_ = render.Render(w, r, util.NewErrorResponse("failed to initialize HMAC verifier", http.StatusInternalServerError))
+
+				return
+			}
 
 		case datastore.BasicAuthVerifier:
 			v = verifier.NewBasicAuthVerifier(

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -25,6 +25,11 @@ var (
 	ErrInvalidHeaderStructure             = errors.New("invalid header structure")
 	ErrInvalidAuthLength                  = errors.New("invalid basic auth length")
 	ErrInvalidEncoding                    = errors.New("invalid header encoding")
+	ErrMissingHmacOptions                 = errors.New("missing HMAC options")
+	ErrMissingHeader                      = errors.New("header cannot be empty")
+	ErrMissingHash                        = errors.New("hash algorithm cannot be empty")
+	ErrMissingSecret                      = errors.New("secret cannot be empty")
+	ErrMissingEncoding                    = errors.New("encoding cannot be empty")
 )
 
 type Verifier interface {
@@ -43,10 +48,24 @@ type HmacVerifier struct {
 	opts *HmacOptions
 }
 
-func NewHmacVerifier(opts *HmacOptions) *HmacVerifier {
-	// TODO(subomi): assert that they're all non-nil values.
+func NewHmacVerifier(opts *HmacOptions) (*HmacVerifier, error) {
+	if opts == nil {
+		return nil, ErrMissingHmacOptions
+	}
+	if opts.Header == "" && opts.GetSignature == nil {
+		return nil, ErrMissingHeader
+	}
+	if opts.Hash == "" {
+		return nil, ErrMissingHash
+	}
+	if opts.Secret == "" {
+		return nil, ErrMissingSecret
+	}
+	if opts.Encoding == "" {
+		return nil, ErrMissingEncoding
+	}
 
-	return &HmacVerifier{opts}
+	return &HmacVerifier{opts}, nil
 }
 
 func (hV *HmacVerifier) VerifyRequest(r *http.Request, payload []byte) error {

--- a/pkg/verifier/verifier_test.go
+++ b/pkg/verifier/verifier_test.go
@@ -158,11 +158,12 @@ func Test_HmacVerifier_VerifyRequest(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Arrange.
-			v := NewHmacVerifier(tc.opts)
+			v, err := NewHmacVerifier(tc.opts)
+			require.NoError(t, err)
 			req := tc.requestFn(t)
 
 			// Assert.
-			err := v.VerifyRequest(req, tc.payload)
+			err = v.VerifyRequest(req, tc.payload)
 
 			// Act.
 			require.ErrorIs(t, err, tc.expectedError)


### PR DESCRIPTION
### What is being changed?
This PR resolves an outstanding `TODO(subomi): assert that they're all non-nil values` inside `pkg/verifier/verifier.go`.
- Refactored `NewHmacVerifier()` to validate `HmacOptions` and return an `error` if essential HMAC configuration parameters are missing or nil.
- Handled the newly surfaced error in `api/ingest.go` to gracefully return a `500 Internal Server Error` instead of swallowing a bad configuration.
- Updated the tests within `pkg/verifier/verifier_test.go` to properly handle the updated function signature.


### Why is it being changed?
Returning a pointer to `HmacVerifier` without properly validating the options leaves the application vulnerable to either nil pointer dereferences or silent security failures (e.g., verifying hashes using blank strings and secrets). This ensures our ingest process catches invalid webhook configurations early.

### Checklist
- [x] Tested locally (`make test`)
- [x] Code is formatted correctly
- [x] Narrowly focused on a single concern