### PR TITLE
ci(release):  generate SPDX SBOM for published Docker images and upload as a workflow artifact

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -176,3 +176,42 @@ jobs:
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:main-${{ needs.set-image-tag.outputs.image_tag }} \
             ${{ env.IMAGE_NAME }}:main-${{ needs.set-image-tag.outputs.image_tag }}-amd64 \
             ${{ env.IMAGE_NAME }}:main-${{ needs.set-image-tag.outputs.image_tag }}-arm64
+
+  sbom:
+    name: SBOM Generation
+    runs-on: ubuntu-latest
+    needs: [build-and-push-default, set-image-tag]
+    permissions:
+      contents: read
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ env.DOCKER_HUB_USERNAME }}
+          password: ${{ env.DOCKER_HUB_TOKEN }}
+
+      - name: Resolve image reference
+        id: image
+        run: |
+          if [ "${{ needs.set-image-tag.outputs.release_kind }}" = "tag" ]; then
+            echo "ref=${{ env.IMAGE_NAME }}:${{ needs.set-image-tag.outputs.image_tag }}" >> "$GITHUB_OUTPUT"
+            echo "slug=${{ needs.set-image-tag.outputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ env.IMAGE_NAME }}:main-${{ needs.set-image-tag.outputs.image_tag }}" >> "$GITHUB_OUTPUT"
+            echo "slug=main-${{ needs.set-image-tag.outputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ steps.image.outputs.ref }}
+          format: spdx-json
+          output-file: convoy.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-spdx-${{ steps.image.outputs.slug }}
+          path: convoy.spdx.json

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -195,3 +195,42 @@ jobs:
           docker buildx imagetools create -t ${{ env.IMAGE_NAME }}:main-${{ needs.set-image-tag.outputs.image_tag }} \
             ${{ env.IMAGE_NAME }}:main-${{ needs.set-image-tag.outputs.image_tag }}-amd64 \
             ${{ env.IMAGE_NAME }}:main-${{ needs.set-image-tag.outputs.image_tag }}-arm64
+
+  sbom:
+    name: SBOM Generation
+    runs-on: ubuntu-latest
+    needs: [build-and-push-default, set-image-tag]
+    permissions:
+      contents: read
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ env.DOCKER_HUB_USERNAME }}
+          password: ${{ env.DOCKER_HUB_TOKEN }}
+
+      - name: Resolve image reference
+        id: image
+        run: |
+          if [ "${{ needs.set-image-tag.outputs.release_kind }}" = "tag" ]; then
+            echo "ref=${{ env.IMAGE_NAME }}:${{ needs.set-image-tag.outputs.image_tag }}" >> "$GITHUB_OUTPUT"
+            echo "slug=${{ needs.set-image-tag.outputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=${{ env.IMAGE_NAME }}:main-${{ needs.set-image-tag.outputs.image_tag }}" >> "$GITHUB_OUTPUT"
+            echo "slug=main-${{ needs.set-image-tag.outputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate SPDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ steps.image.outputs.ref }}
+          format: spdx-json
+          output-file: convoy.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-spdx-${{ steps.image.outputs.slug }}
+          path: convoy.spdx.json

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -199,9 +199,13 @@ jobs:
   # Scan the published Docker Hub image after the manifest exists, then upload
   # convoy.spdx.json as a workflow artifact. This does not attach the SBOM as an
   # OCI layer or attestation on the image.
+  # continue-on-error: the image is already live. A scan failure must not mark
+  # this workflow failed, or bump-convoy-cloud-staging and trivy-defectdojo skip
+  # because they require conclusion == success.
   sbom:
     name: SBOM Generation
     runs-on: ubuntu-latest
+    continue-on-error: true
     needs: [build-and-push-default, set-image-tag]
     permissions:
       contents: read

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -202,6 +202,7 @@ jobs:
     needs: [build-and-push-default, set-image-tag]
     permissions:
       contents: read
+      actions: write
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
@@ -221,6 +222,7 @@ jobs:
           fi
 
       - name: Generate SPDX SBOM
+        # v0.24.0 is the current SPDX generator (Syft 1.42.3). Pin the tag SHA so the scanner cannot float.
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ steps.image.outputs.ref }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -196,6 +196,9 @@ jobs:
             ${{ env.IMAGE_NAME }}:main-${{ needs.set-image-tag.outputs.image_tag }}-amd64 \
             ${{ env.IMAGE_NAME }}:main-${{ needs.set-image-tag.outputs.image_tag }}-arm64
 
+  # Scan the published Docker Hub image after the manifest exists, then upload
+  # convoy.spdx.json as a workflow artifact. This does not attach the SBOM as an
+  # OCI layer or attestation on the image.
   sbom:
     name: SBOM Generation
     runs-on: ubuntu-latest


### PR DESCRIPTION
```
change adds an SBOM job to the image workflow after images are pushed.
SBOM is generated for each image and attached to the workflow artifacts. 
This makes it easier to trace exactly which packages and dependencies are included in a built image,
helping with vulnerability scanning, auditing, and supply chain verification.
```