### PR TITLE
fix(controlplane): guard against empty billing owner emails

### DIFF
--- a/api/handlers/billing.go
+++ b/api/handlers/billing.go
@@ -23,6 +23,7 @@ import (
 )
 
 var ErrHostRequiredForBilling = errors.New("organisation host (assigned domain) is required for billing. Please set the assigned domain in the configuration")
+var ErrOwnerEmailRequiredForBilling = errors.New("organisation owner email is required for billing")
 
 type BillingHandler struct {
 	*Handler
@@ -58,7 +59,8 @@ func (h *BillingHandler) ensureOrganisationInBilling(w http.ResponseWriter, r *h
 
 	ownerEmail := h.getOwnerEmail(r.Context(), orgID)
 	if ownerEmail == "" {
-		h.A.Logger.Warnf("Failed to fetch owner email for organisation %s, using empty billing_email", orgID)
+		_ = render.Render(w, r, util.NewErrorResponse(ErrOwnerEmailRequiredForBilling.Error(), http.StatusUnprocessableEntity))
+		return true
 	}
 
 	orgData := billing.BillingOrganisation{

--- a/api/handlers/billing.go
+++ b/api/handlers/billing.go
@@ -121,7 +121,7 @@ func (h *BillingHandler) getOwnerEmail(ctx context.Context, orgID string) string
 		return ""
 	}
 
-	return owner.Email
+	return strings.TrimSpace(owner.Email)
 }
 
 func (h *BillingHandler) updateBillingEmailIfEmpty(orgID string) {

--- a/services/create_organisation.go
+++ b/services/create_organisation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/dchest/uniuri"
@@ -122,10 +123,17 @@ func RunBillingOrganisationSync(
 	if logger == nil {
 		panic("RunBillingOrganisationSync: logger is required and must not be nil")
 	}
+
+	trimmedEmail := strings.TrimSpace(userEmail)
+	if trimmedEmail == "" {
+		logger.Error("create_organisation: owner email is empty, skipping billing sync", "org_id", org.UID)
+		return
+	}
+
 	orgData := billing.BillingOrganisation{
 		Name:         org.Name,
 		ExternalID:   org.UID,
-		BillingEmail: userEmail,
+		BillingEmail: trimmedEmail,
 		Host:         billingHost,
 	}
 	resp, createErr := billingClient.CreateOrganisation(ctx, orgData)

--- a/services/create_organisation_test.go
+++ b/services/create_organisation_test.go
@@ -17,6 +17,14 @@ import (
 	log "github.com/frain-dev/convoy/pkg/logger"
 )
 
+type panicOnCreateBillingClient struct {
+	*billing.MockBillingClient
+}
+
+func (panicOnCreateBillingClient) CreateOrganisation(context.Context, billing.BillingOrganisation) (*billing.Response[billing.BillingOrganisation], error) {
+	panic("CreateOrganisation must not be called when owner email is empty")
+}
+
 func provideCreateOrganisationService(ctrl *gomock.Controller, newOrg *datastore.OrganisationRequest, user *datastore.User) *CreateOrganisationService {
 	return &CreateOrganisationService{
 		OrgRepo:       mocks.NewMockOrganisationRepository(ctrl),
@@ -214,5 +222,15 @@ func TestRunBillingOrganisationSync(t *testing.T) {
 		// CreateOrganisationLicenseKey and GetOrganisationLicenseKey left empty
 
 		RunBillingOrganisationSync(ctx, mockBilling, org, cfg, userEmail, billingHost, mockOrgRepo, log.New("convoy", log.LevelInfo))
+	})
+
+	t.Run("skips_billing_sync_when_owner_email_is_empty", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockOrgRepo := mocks.NewMockOrganisationRepository(ctrl)
+		mockBilling := panicOnCreateBillingClient{MockBillingClient: &billing.MockBillingClient{}}
+
+		RunBillingOrganisationSync(ctx, &mockBilling, org, cfg, "", billingHost, mockOrgRepo, log.New("convoy", log.LevelInfo))
 	})
 }


### PR DESCRIPTION
## Summary
- stop Convoy billing sync from sending blank owner emails by short-circuiting when the resolved owner email is empty
- return a clear `422` response when billing bootstrap cannot resolve organisation owner email
- add a focused service test that ensures billing create is not called when owner email is empty

## Test plan
- [x] `go test ./services -run TestRunBillingOrganisationSync`
- [x] `go test ./api/handlers -run \"TestGetInternalOrganisationID_BillingDisabled_DoesNotCallBilling|TestIsBillingOrgNotFound\"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing bootstrap/sync paths and changes API behavior to hard-fail with `422` when owner email is missing, which could affect onboarding flows if data is incomplete.
> 
> **Overview**
> Prevents Convoy from creating/syncing billing organisations with a blank `billing_email` by **requiring a non-empty, trimmed owner email**.
> 
> `BillingHandler.ensureOrganisationInBilling` now returns a clear `422 Unprocessable Entity` when the organisation owner email can’t be resolved, and `RunBillingOrganisationSync` short-circuits (and trims whitespace) so the billing client is never called with an empty email.
> 
> Adds a focused service test that asserts billing `CreateOrganisation` is not invoked when the owner email is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3221363fbaf9ed9e582af1b8e5f7f0e7b306e36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->