### PR TITLE
fix(controlplane): prevent password reset token replay

### DIFF
--- a/services/reset_password.go
+++ b/services/reset_password.go
@@ -45,6 +45,8 @@ func (u *ResetPasswordService) Run(ctx context.Context) (*datastore.User, error)
 	}
 
 	user.Password = string(p.Hash)
+	user.ResetPasswordToken = ""
+	user.ResetPasswordExpiresAt = time.Time{}
 	err = u.UserRepo.UpdateUser(ctx, user)
 	if err != nil {
 		u.Logger.ErrorContext(ctx, "an error occurred while updating user", "error", err)

--- a/services/reset_password_test.go
+++ b/services/reset_password_test.go
@@ -61,8 +61,8 @@ func TestResetPasswordService_Run(t *testing.T) {
 			wantUser: &datastore.User{
 				UID:                    "1234",
 				Email:                  "test@email.com",
-				ResetPasswordToken:     "123456789",
-				ResetPasswordExpiresAt: resetEx,
+				ResetPasswordToken:     "",
+				ResetPasswordExpiresAt: time.Time{},
 			},
 		},
 		{
@@ -155,4 +155,49 @@ func TestResetPasswordService_Run(t *testing.T) {
 			require.Equal(t, tt.wantUser, user)
 		})
 	}
+}
+
+func TestResetPasswordService_Run_RejectsTokenReplayAfterSuccessfulReset(t *testing.T) {
+	ctx := context.Background()
+	resetEx := time.Now().Add(time.Hour)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	u := provideResetPasswordService(ctrl, "replay-token", &models.ResetPassword{
+		Password:             "password1",
+		PasswordConfirmation: "password1",
+	})
+
+	us, _ := u.UserRepo.(*mocks.MockUserRepository)
+	storedUser := &datastore.User{
+		UID:                    "1234",
+		Email:                  "test@email.com",
+		ResetPasswordToken:     "replay-token",
+		ResetPasswordExpiresAt: resetEx,
+	}
+
+	us.EXPECT().FindUserByToken(gomock.Any(), "replay-token").Times(2).DoAndReturn(
+		func(_ context.Context, token string) (*datastore.User, error) {
+			if storedUser.ResetPasswordToken == token && time.Now().Before(storedUser.ResetPasswordExpiresAt) {
+				return storedUser, nil
+			}
+
+			return nil, datastore.ErrUserNotFound
+		},
+	)
+
+	us.EXPECT().UpdateUser(gomock.Any(), gomock.AssignableToTypeOf(&datastore.User{})).Times(1).DoAndReturn(
+		func(_ context.Context, updatedUser *datastore.User) error {
+			storedUser = updatedUser
+			return nil
+		},
+	)
+
+	_, err := u.Run(ctx)
+	require.NoError(t, err)
+
+	_, err = u.Run(ctx)
+	require.Error(t, err)
+	require.Equal(t, "invalid password reset token", err.(*ServiceError).Error())
 }


### PR DESCRIPTION
Invalidate reset tokens immediately after a successful password reset and add a regression test that proves a consumed token cannot be reused within its original TTL window.