### PR TITLE
chore(deps): add nighly CVE scans

### DIFF
--- a/.github/scripts/osv-nightly-report.sh
+++ b/.github/scripts/osv-nightly-report.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JSON="${1:?first arg: path to OSV JSON report}"
+OUT_MD="${2:?second arg: path to write Markdown summary}"
+OUT_SLACK_DETAILS="${3:-}"
+
+REPO="${GITHUB_REPOSITORY:-convoy}"
+RUN_ID="${GITHUB_RUN_ID:-}"
+SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+if [[ -n "$RUN_ID" ]]; then
+  RUN_URL="${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+else
+  RUN_URL="${SERVER_URL}/${REPO}"
+fi
+SHA_SHORT="${GITHUB_SHA:-}"
+[[ -n "$SHA_SHORT" ]] && SHA_SHORT="${SHA_SHORT:0:7}"
+
+PKG_WITH_VULNS=$(jq '[.results[] | .packages[] | select((.vulnerabilities | length) > 0)] | length' "$JSON")
+VULN_ROWS=$(jq '[.results[] | .packages[] | .vulnerabilities[]?] | length' "$JSON")
+UNIQUE_IDS=$(jq '[.results[] | .packages[] | .vulnerabilities[]? | .id] | unique | length' "$JSON")
+
+SEV_LINE=$(jq -r '
+  [.results[] | .packages[] | .vulnerabilities[]?
+    | (.database_specific.severity // "UNKNOWN")
+  ] | group_by(.) | map("\(.[0]): \(length)") | join(" · ")
+' "$JSON")
+
+read -r CRITICAL HIGH MEDIUM LOW UNKNOWN < <(
+  jq -r '
+    def normsev:
+      ((. // "UNKNOWN") | ascii_upcase) as $s
+      | if $s == "MODERATE" then "MEDIUM"
+        elif ($s == "CRITICAL" or $s == "HIGH" or $s == "MEDIUM" or $s == "LOW" or $s == "UNKNOWN") then $s
+        else "UNKNOWN"
+        end;
+    [.results[] | .packages[] | .vulnerabilities[]?
+      | (.database_specific.severity | normsev)
+    ]
+    | reduce .[] as $s (
+        {"CRITICAL":0,"HIGH":0,"MEDIUM":0,"LOW":0,"UNKNOWN":0};
+        .[$s] += 1
+      )
+    | "\(.CRITICAL) \(.HIGH) \(.MEDIUM) \(.LOW) \(.UNKNOWN)"
+  ' "$JSON"
+)
+
+BY_ECO=$(jq -r '
+  [.results[] | .packages[] | select((.vulnerabilities | length) > 0)
+    | .package.ecosystem] | group_by(.) | map("\(.[0]): \(length)") | join(" · ")
+' "$JSON")
+
+TOP_PKGS=$(jq -r '
+  [.results[] | .packages[] | select((.vulnerabilities | length) > 0)
+    | { eco: .package.ecosystem, name: .package.name, ver: .package.version, n: (.vulnerabilities | length) }
+  ] | sort_by(-.n) | .[:20]
+  | .[] | "| \(.eco) | `\(.name)` | \(.ver) | \(.n) |"
+' "$JSON")
+
+ALL_CVE_ROWS=$(jq -r '
+  [
+    .results[] as $r
+    | $r.packages[] as $p
+    | select(($p.vulnerabilities | length) > 0)
+    | $p.vulnerabilities[] as $v
+    | {
+        source: ($r.source.path | split("/") | .[-1]),
+        ecosystem: $p.package.ecosystem,
+        package: $p.package.name,
+        version: $p.package.version,
+        cve: ($v.id // "UNKNOWN"),
+        url: (
+          [
+            ($v.references // [])[]?
+            | .url
+            | select((. != null) and (. != "") and (contains(($v.id // ""))))
+          ]
+          | .[0]
+          // (
+          [
+            ($v.references // [])[]?
+            | select((.type // "") == "ADVISORY" or (.type // "") == "WEB")
+            | .url
+          ]
+          | map(select(. != null and . != ""))
+          | .[0]
+          )
+          // ("https://osv.dev/" + ($v.id // ""))
+        ),
+        severity: (
+          (($v.database_specific.severity // "UNKNOWN") | ascii_upcase) as $s
+          | if $s == "MODERATE" then "MEDIUM"
+            elif ($s == "CRITICAL" or $s == "HIGH" or $s == "MEDIUM" or $s == "LOW" or $s == "UNKNOWN") then $s
+            else "UNKNOWN"
+            end
+        ),
+        fixed: (
+          [
+            ($v.affected // [])[]?
+            | .ranges[]?
+            | .events[]?
+            | .fixed?
+          ]
+          | map(select(. != null and . != ""))
+          | .[0] // "--"
+        ),
+        aliases: (($v.aliases // []) | join(",")),
+        summary: (
+          ($v.summary // ($v.details // ""))
+          | gsub("\\r|\\n"; " ")
+          | gsub("\\|"; "/")
+          | if length > 110 then .[0:110] + "..." else . end
+        )
+      }
+  ]
+  | sort_by(.severity, .ecosystem, .package, .cve)
+  | .[]
+  | "\(.severity)\t\(.ecosystem)\t\(.package)\t\(.version)\t\(.fixed)\t\(.cve)\t\(.url)\t\(.aliases)\t\(.summary)\t\(.source)"
+' "$JSON")
+
+DETAILED_ROWS_MD=$(jq -r '
+  [
+    .results[] as $r
+    | $r.packages[] as $p
+    | select(($p.vulnerabilities | length) > 0)
+    | $p.vulnerabilities[] as $v
+    | {
+        severity: (
+          (($v.database_specific.severity // "UNKNOWN") | ascii_upcase) as $s
+          | if $s == "MODERATE" then "MEDIUM"
+            elif ($s == "CRITICAL" or $s == "HIGH" or $s == "MEDIUM" or $s == "LOW" or $s == "UNKNOWN") then $s
+            else "UNKNOWN"
+            end
+        ),
+        ecosystem: $p.package.ecosystem,
+        package: $p.package.name,
+        version: $p.package.version,
+        fixed: (
+          [
+            ($v.affected // [])[]?
+            | .ranges[]?
+            | .events[]?
+            | .fixed?
+          ]
+          | map(select(. != null and . != ""))
+          | .[0] // "--"
+        ),
+        advisory: ($v.id // "UNKNOWN"),
+        url: (
+          [
+            ($v.references // [])[]?
+            | .url
+            | select((. != null) and (. != "") and (contains(($v.id // ""))))
+          ]
+          | .[0]
+          // (
+          [
+            ($v.references // [])[]?
+            | select((.type // "") == "ADVISORY" or (.type // "") == "WEB")
+            | .url
+          ]
+          | map(select(. != null and . != ""))
+          | .[0]
+          )
+          // ("https://osv.dev/" + ($v.id // ""))
+        ),
+        aliases: (($v.aliases // []) | join(", ")),
+        summary: (
+          ($v.summary // ($v.details // ""))
+          | gsub("\\r|\\n"; " ")
+          | gsub("\\|"; "/")
+          | if length > 160 then .[0:160] + "..." else . end
+        )
+      }
+  ]
+  | sort_by(.severity, .ecosystem, .package, .advisory)
+  | .[]
+  | "| \(.severity) | \(.ecosystem) | `\(.package)` | \(.version) | \(.fixed) | `\(.advisory)` | [link](\(.url)) | \(.aliases) | \(.summary) |"
+' "$JSON")
+
+SOURCES=$(jq -r '.results[] | "- `\(.source.path | split("/") | .[-1])`"' "$JSON")
+
+{
+  echo "# OSV vulnerability report"
+  echo
+  echo "**Repository:** \`${REPO}\`  "
+  echo "**Commit:** \`${SHA_SHORT:-n/a}\`  "
+  echo "**Workflow run:** ${RUN_URL}"
+  echo
+  echo "## Summary"
+  echo
+  echo "| Metric | Value |"
+  echo "|--------|-------|"
+  echo "| Packages with ≥1 finding | ${PKG_WITH_VULNS} |"
+  echo "| Vulnerability records (rows) | ${VULN_ROWS} |"
+  echo "| Unique OSV IDs | ${UNIQUE_IDS} |"
+  echo
+  echo "**By ecosystem (affected packages):** ${BY_ECO:-—}"
+  echo
+  echo "**By advisory severity (row labels):** ${SEV_LINE:-—}"
+  echo
+  echo "## Scanned sources"
+  echo
+  echo "${SOURCES}"
+  echo
+  echo "## Top packages by finding count"
+  echo
+  echo "| Ecosystem | Package | Version | # findings |"
+  echo "|-----------|---------|---------|------------|"
+  if [[ -n "$TOP_PKGS" ]]; then
+    echo "$TOP_PKGS"
+  else
+    echo "| — | — | — | 0 |"
+  fi
+  echo
+  echo "## Detailed advisories (fix + details)"
+  echo
+  echo "| Severity | Ecosystem | Package | Version | Fixed | Advisory | URL | Aliases | Summary |"
+  echo "|----------|-----------|---------|---------|-------|----------|-----|---------|---------|"
+  if [[ -n "$DETAILED_ROWS_MD" ]]; then
+    echo "$DETAILED_ROWS_MD"
+  else
+    echo "| — | — | — | — | — | — | — | — | none |"
+  fi
+  echo
+  echo "---"
+  echo "_Generated by OSV-Scanner nightly workflow._"
+} >"$OUT_MD"
+
+if [[ -n "$OUT_SLACK_DETAILS" ]]; then
+  {
+    echo "OSV nightly detailed CVE report"
+    echo "Repo: ${REPO} | Commit: ${SHA_SHORT:-n/a}"
+    echo "Run: ${RUN_URL}"
+    echo
+    echo "Summary"
+    echo "Packages with findings: ${PKG_WITH_VULNS}"
+    echo "Vulnerability rows: ${VULN_ROWS}"
+    echo "Unique OSV IDs: ${UNIQUE_IDS}"
+    echo "By ecosystem: ${BY_ECO:-N/A}"
+    echo "Severity totals -> *CRITICAL:* ${CRITICAL}  *HIGH:* ${HIGH}  *MEDIUM:* ${MEDIUM}  *LOW:* ${LOW}  *UNKNOWN:* ${UNKNOWN}"
+    echo
+    echo "ALL CVEs:"
+    echo
+    if [[ -n "$ALL_CVE_ROWS" ]]; then
+      while IFS=$'\t' read -r sev eco pkg ver fixed cve url aliases summary src; do
+        case "$sev" in
+          CRITICAL) icon="🔴" ;;
+          HIGH) icon="🟠" ;;
+          MEDIUM) icon="🟡" ;;
+          LOW) icon="🟢" ;;
+          *) icon="⚪" ;;
+        esac
+        printf "%s *%s* · <%s|%s>\n" "$icon" "$sev" "$url" "$cve"
+        printf "• Package: %s %s@%s\n" "$eco" "$pkg" "$ver"
+        printf "• Fixed: %s\n" "$fixed"
+        if [[ -n "$aliases" ]]; then
+          printf "• Aliases: %s\n" "$aliases"
+        fi
+        if [[ -n "$summary" ]]; then
+          printf "• Summary: %s\n" "$summary"
+        fi
+        printf "• Source: %s\n" "$src"
+        printf "—\n"
+      done <<<"$ALL_CVE_ROWS" || true
+    else
+      echo "- none"
+    fi
+  } >"$OUT_SLACK_DETAILS"
+fi

--- a/.github/workflows/osv-nightly.yml
+++ b/.github/workflows/osv-nightly.yml
@@ -1,0 +1,149 @@
+name: OSV Scanner (nightly)
+
+on:
+  schedule:
+    - cron: "15 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: osv-nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare-lockfile:
+    name: Prepare frontend lockfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+      - name: Generate package-lock.json for scan
+        working-directory: web/ui/dashboard
+        run: npm install --package-lock-only --ignore-scripts
+      - name: Upload lockfile artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: osv-lockfiles
+          path: web/ui/dashboard/package-lock.json
+          if-no-files-found: error
+
+  osv-scan:
+    name: Scan repository for vulnerabilities
+    needs: prepare-lockfile
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.5
+    with:
+      fail-on-vuln: false
+      upload-sarif: true
+      download-artifact: osv-lockfiles
+      scan-args: |-
+        --lockfile=./go.mod
+        --lockfile=./web/ui/dashboard/package-lock.json
+
+  report-and-slack:
+    name: Build report and notify Slack
+    runs-on: ubuntu-latest
+    needs: osv-scan
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Materialize JSON report from reusable output
+        env:
+          OSV_RESULTS_JSON: ${{ needs.osv-scan.outputs.results }}
+        run: |
+          python3 - <<'PY'
+          import os
+          data = os.environ.get("OSV_RESULTS_JSON", "")
+          if not data.strip():
+              raise SystemExit("OSV scan results output is empty")
+          with open("osv-report.json", "w", encoding="utf-8") as f:
+              f.write(data)
+          PY
+
+      - name: Build Markdown and Slack detail file
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          chmod +x .github/scripts/osv-nightly-report.sh
+          .github/scripts/osv-nightly-report.sh osv-report.json osv-summary.md slack-details.txt
+
+      - name: Upload reports
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: osv-reports-${{ github.run_id }}
+          path: |
+            osv-report.json
+            osv-summary.md
+          if-no-files-found: error
+
+      - name: Post detailed findings to Slack
+        if: env.SLACK_WEBHOOK_URL != ''
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          webhook = os.environ["SLACK_WEBHOOK_URL"]
+          with open("slack-details.txt", "r", encoding="utf-8") as f:
+              text = f.read().strip()
+
+          if not text:
+              raise SystemExit(0)
+
+          max_chars = 2600
+          lines = text.splitlines()
+          chunks = []
+          current = []
+          size = 0
+          for line in lines:
+              line_len = len(line) + 1
+              if current and size + line_len > max_chars:
+                  chunks.append("\n".join(current))
+                  current = [line]
+                  size = line_len
+              else:
+                  current.append(line)
+                  size += line_len
+          if current:
+              chunks.append("\n".join(current))
+
+          total = len(chunks)
+          for idx, chunk in enumerate(chunks, start=1):
+              payload = {
+                  "text": f"OSV details ({idx}/{total})",
+                  "blocks": [
+                      {
+                          "type": "section",
+                          "text": {
+                              "type": "mrkdwn",
+                              "text": f"*OSV detailed findings ({idx}/{total})*\n{chunk}",
+                          },
+                      }
+                  ],
+              }
+              body = json.dumps(payload).encode("utf-8")
+              req = urllib.request.Request(
+                  webhook,
+                  data=body,
+                  headers={"Content-type": "application/json"},
+                  method="POST",
+              )
+              with urllib.request.urlopen(req):
+                  pass
+          PY


### PR DESCRIPTION
```
change adds nightly CVE scans
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a scheduled GitHub Actions workflow that runs nightly, uploads SARIF, and posts detailed results to a Slack webhook, which could create noise or fail due to dependency/tooling assumptions (Node/npm/jq) in CI.
> 
> **Overview**
> Introduces a nightly `OSV Scanner` GitHub Actions workflow that generates a frontend `package-lock.json`, runs `google/osv-scanner-action` against `go.mod` and the lockfile, and uploads SARIF plus report artifacts.
> 
> Adds `.github/scripts/osv-nightly-report.sh` to turn the OSV JSON output into a Markdown summary and an optional detailed Slack message (chunked to fit limits) posted via `SLACK_WEBHOOK_URL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bc990d9032d1bfc58e44ad01d8df65c317de709. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->