### PR TITLE
chore(deps): fix package.lock path

### DIFF
--- a/.github/workflows/osv-nightly.yml
+++ b/.github/workflows/osv-nightly.yml
@@ -47,7 +47,7 @@ jobs:
       download-artifact: osv-lockfiles
       scan-args: |-
         --lockfile=./go.mod
-        --lockfile=./web/ui/dashboard/package-lock.json
+        --lockfile=./package-lock.json
 
   report-and-slack:
     name: Build report and notify Slack
@@ -73,7 +73,7 @@ jobs:
             --format=json
             --output=osv-report.json
             --lockfile=./go.mod
-            --lockfile=./web/ui/dashboard/package-lock.json
+            --lockfile=./package-lock.json
 
       - name: Ensure OSV JSON exists
         run: |


### PR DESCRIPTION
```
change fixes package.lock path
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adjusts lockfile paths for vulnerability scanning; risk is limited to potentially affecting nightly scan/report completeness if the path is still incorrect.
> 
> **Overview**
> Updates `.github/workflows/osv-nightly.yml` to scan the frontend dependencies using `--lockfile=./package-lock.json` instead of `--lockfile=./web/ui/dashboard/package-lock.json` in both the reusable OSV scan job and the JSON report step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad7a46eb3ed57a068fe65d0a4f74051d3b72d644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->