### PR TITLE
chore(build): bump actions/checkout in docs and load-test workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Run `openapi` command 🚀
         uses: readmeio/rdme@51a80867c45de15e2b41af0c4bd5bbc61b932804 # v8

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -22,7 +22,7 @@ jobs:
 
      steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Run Local K6 Test
         uses: grafana/k6-action@55845c6c2e400af4356c84e5b514aeabb1bfdbd4 # v0.2.0


### PR DESCRIPTION
## Summary

Phase 1 of Dependabot backlog cleanup for GitHub Actions: `origin/main` already pins newer GitHub Actions in most workflows; two workflows still used old `actions/checkout` revisions (docs: v3, load-test: v1).

## Changes

- `.github/workflows/docs.yml`: checkout → same **v5** full SHA used across integration / release workflows.
- `.github/workflows/load-test.yml`: same bump.

This supersedes / overlaps intent of stale Dependabot PR **#2339** (now misaligned with `main`).

## Related

- Closes/supersedes overlapping bot PRs once merged (`actions/checkout` bumps only).

## Verification

CI should run workflows that lint YAML; docs workflow runs on merge to main only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pins `actions/checkout` to the v5 SHA in two GitHub Actions workflows; no application code or runtime behavior changes outside CI.
> 
> **Overview**
> Updates the `docs.yml` and `load-test.yml` GitHub Actions workflows to use `actions/checkout` **v5** (pinned by full SHA), replacing older pinned revisions (v3 and v1 respectively).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce2700bbd063f43682d5cd557767ae68b662cd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->