### PR TITLE
chore(deps): added path filter to build image workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -9,6 +9,25 @@ on:
   push:
     branches:
       - main
+    # Only run when something in the release artifact surface changes (fail
+    # closed). Tag pushes (v*) always run; path filters apply only to branch
+    # pushes. If a new top-level package is added under the module, extend this
+    # list. Include non-Go embeds (VERSION, sql, web, email templates). Verify: go list -deps './cmd/...'.
+    paths:
+      - "**/*.go"
+      - "internal/email/templates/**"
+      - "VERSION"
+      - "go.mod"
+      - "go.sum"
+      - "sqlc.yaml"
+      - "sql/**"
+      - "web/**"
+      - "Makefile"
+      - "release.Dockerfile"
+      - "scripts/ui.sh"
+      - ".dockerignore"
+      - ".github/workflows/build-image.yml"
+
     tags:
       - v*
 


### PR DESCRIPTION
```
change adds path filter to the build image workflow inorder to reduce how often we push to the registry
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; main risk is missing a relevant path in the allowlist, which could prevent image builds on `main` for some changes.
> 
> **Overview**
> Reduces unnecessary Docker image builds by adding a **fail-closed `paths` filter** to `.github/workflows/build-image.yml` for `push` events on `main`, so the workflow runs only when release-affecting files change (Go sources, embeds/templates, SQL, web assets, build scripts, Dockerfile/ignore, and the workflow itself).
> 
> Tag pushes (`v*`) continue to always trigger builds; the filter applies only to branch pushes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775f4ec48e768814ce7742286ae49c2d3c9c4a87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->