### PR TITLE
chore(deps): bump posthog-js in dashboard

### DIFF
--- a/web/ui/dashboard/package.json
+++ b/web/ui/dashboard/package.json
@@ -30,7 +30,7 @@
 		"axios": "^1.6.7",
 		"date-fns": "^2.27.0",
 		"monaco-editor": "^0.34.1",
-		"posthog-js": "1.127.0",
+		"posthog-js": "1.150.0",
 		"prismjs": "^1.29.0",
 		"rxjs": "^6.6.0",
 		"tslib": "^2.3.1",


### PR DESCRIPTION
## Summary

Bumps `posthog-js` from **1.127.0** to **1.150.0** in `web/ui/dashboard/package.json`.

## Why not 1.281 (Dependabot #2469)?

- **1.281.x** pulls `@posthog/core` typings that use `export type *`, which **TypeScript 4.7** (Angular 14 toolchain) rejects.
- Intermediate **1.200.x** failed on missing `@rrweb/*` types under the same compiler.

**1.150.0** builds cleanly with the current dashboard stack (`npm run build` verified locally).

## Follow-up

Revisit **#2469** (or a fresh Dependabot PR) after the planned **Angular + TypeScript** upgrade; then we can move toward current `posthog-js` majors.

## Related

- Partially addresses Dependabot noise for the PostHog line without merging the incompatible bot branch as-is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; impact is limited to PostHog analytics behavior in the dashboard runtime/build.
> 
> **Overview**
> Bumps the dashboard’s `posthog-js` dependency from `1.127.0` to `1.150.0` in `web/ui/dashboard/package.json`, updating the bundled PostHog client used by `AppComponent` initialization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79d8c199c0fa0cf3f213b37161eb755d50a108f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->