### PR TITLE
chore(deps): bump stdlib to v1.26.2

### DIFF
--- a/.github/workflows/build-dev-image.yml
+++ b/.github/workflows/build-dev-image.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
         with:
-            go-version: 1.25.9
+            go-version: 1.26.2
 
       - name: Get and verify dependencies
         run: go mod tidy && go mod download && go mod verify

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: 1.25.9
+          go-version: 1.26.2
 
       - name: Get and verify dependencies
         run: go mod tidy && go mod download && go mod verify

--- a/.github/workflows/google-pubsub-tests.yml
+++ b/.github/workflows/google-pubsub-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.25.9]
+        go-version: [1.26.2]
         postgres-version: ["15"]
         redis-version: ["6.2.6"]
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,7 +14,7 @@ jobs:
         if: ${{ !(contains(github.head_ref, 'ui/')) || !(contains(github.head_ref, 'cms/')) }}
         strategy:
             matrix:
-                go-version: [1.25.9]
+                go-version: [1.26.2]
                 os: [ubuntu-latest]
                 postgres-version: ["15"]
                 redis-version: ["6.2.6"]

--- a/.github/workflows/kafka-pubsub-tests.yml
+++ b/.github/workflows/kafka-pubsub-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.25.9]
+        go-version: [1.26.2]
         postgres-version: ["15"]
         redis-version: ["6.2.6"]
 

--- a/.github/workflows/rabbitmq-pubsub-tests.yml
+++ b/.github/workflows/rabbitmq-pubsub-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.25.9]
+        go-version: [1.26.2]
         postgres-version: ["15"]
         redis-version: ["6.2.6"]
 

--- a/.github/workflows/redis-sentinel-e2e-tests.yml
+++ b/.github/workflows/redis-sentinel-e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.25.9 ]
+        go-version: [ 1.26.2 ]
 
     steps:
       - name: Set up Go

--- a/.github/workflows/sqs-pubsub-tests.yml
+++ b/.github/workflows/sqs-pubsub-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.25.9]
+        go-version: [1.26.2]
         postgres-version: ["15"]
         redis-version: ["6.2.6"]
 

--- a/.github/workflows/vanilla-e2e-tests.yml
+++ b/.github/workflows/vanilla-e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ 1.25.9 ]
+        go-version: [ 1.26.2 ]
         postgres-version: [ "15" ]
         redis-version: [ "6.2.6" ]
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,7 +6,7 @@ RUN git config --global url."https://".insteadOf git://
 RUN npm install
 RUN npm run build
 
-FROM golang:1.25.9 as build-env
+FROM golang:1.26.2 as build-env
 WORKDIR /go/src/frain-dev/convoy
 
 ENV CGO_ENABLED=0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/frain-dev/convoy
 
-go 1.25.9
+go 1.26.2
 
 require (
 	cloud.google.com/go/pubsub v1.50.1

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@
 # file, you can specify more tools or different version of listed ones below as
 # well as overriding environment variables.
 [tools]
-go = "1.25.9"
+go = "1.26.2"
 golangci-lint = "2.4.0"
 nodejs = "24.10.0"
  postgres = "18"


### PR DESCRIPTION
```
change bumps go version to v1.26.2
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because a Go version upgrade can change compiler/vet behavior and subtly affect builds/tests and Docker images, even though no application logic changes.
> 
> **Overview**
> Updates the repository’s Go toolchain baseline to `1.26.2` by changing the `go` directive in `go.mod`, the Go version used in GitHub Actions build/test workflows, the `golang` base image in `Dockerfile.dev`, and the local tool version in `mise.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6f948a8d4afc55c50e0e69b842915c88893de10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->