### PR TITLE
ci(build): add dashboard build workflow for PR and main

### DIFF
--- a/.github/workflows/dashboard-build.yml
+++ b/.github/workflows/dashboard-build.yml
@@ -1,0 +1,39 @@
+name: Build dashboard
+on:
+  pull_request:
+    paths:
+      - 'web/ui/dashboard/**'
+      - '.github/workflows/dashboard-build.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'web/ui/dashboard/**'
+      - '.github/workflows/dashboard-build.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web/ui/dashboard
+    steps:
+      - name: Check out code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # No npm cache: package-lock.json is gitignored in this repo, so cache-dependency-path would fail on CI.
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '18'
+
+      # npm ci requires a committed lockfile; dashboard uses npm install instead.
+      - name: Install and build
+        run: npm install && npm run build


### PR DESCRIPTION
## Summary

Adds a single GitHub Actions workflow that builds the Angular dashboard when dashboard-related paths change.

## What runs

- **Workflow:** `.github/workflows/dashboard-build.yml` (job name: **Build dashboard** / **build**)
- **Triggers:** `pull_request` and `push` to `main`, scoped with `paths` to `web/ui/dashboard/**` and the workflow file itself.
- **Steps:** checkout → Node 18 → `npm install && npm run build` in `web/ui/dashboard` (uses `npm install` because `package-lock.json` is gitignored there).
- **Concurrency:** `cancel-in-progress: true` so newer pushes on the same branch supersede older runs.

## Out of scope

Earlier CI-wide changes (integration tests, broker workflows, Makefile, shared `go test` script, etc.) were dropped; this PR is only the dashboard build gate.

## Admin follow-up (optional)

If dashboard PRs should be blocked until this passes, add the resulting check name under branch protection after the first successful run on a PR.