### PR TITLE
fix(dashboard): avoid user profile request without uid

### DIFF
--- a/web/ui/dashboard/src/app/private/private.component.ts
+++ b/web/ui/dashboard/src/app/private/private.component.ts
@@ -177,8 +177,11 @@ export class PrivateComponent implements OnInit {
 	}
 
 	async getUserDetails() {
+		const auth = this.authDetails();
+		if (!auth || typeof auth !== 'object' || !auth.uid) return;
+
 		try {
-			const response = await this.privateService.getUserDetails({ userId: this.authDetails()?.uid });
+			const response = await this.privateService.getUserDetails({ userId: auth.uid });
 			const userDetails = response.data;
 			this.isEmailVerified = userDetails?.email_verified;
 		} catch (error) {}

--- a/web/ui/dashboard/src/app/private/private.service.ts
+++ b/web/ui/dashboard/src/app/private/private.service.ts
@@ -390,11 +390,16 @@ export class PrivateService {
 
 	getUserDetails(requestDetails: { userId: string; refresh?: boolean }): Promise<HTTP_RESPONSE> {
 		return new Promise(async (resolve, reject) => {
+			const userId = requestDetails?.userId;
+			if (!userId || userId === 'undefined') {
+				return reject(new Error('missing user id'));
+			}
+
 			if (this.profileDetails && !requestDetails.refresh) return resolve(this.profileDetails);
 
 			try {
 				const response = await this.http.request({
-					url: `/users/${requestDetails.userId}/profile`,
+					url: `/users/${userId}/profile`,
 					method: 'get'
 				});
 


### PR DESCRIPTION
## Summary
- Guard `PrivateComponent.getUserDetails()` so we never call the API without a valid `uid` from `CONVOY_AUTH`.
- Guard `PrivateService.getUserDetails()` so we never request `/users/undefined/profile` (e.g. during logout or races).

## Test plan
- [x] `npm run build` in `web/ui/dashboard`
- [ ] Playwright MCP or manual: login → logout; confirm no request to `/ui/users/undefined/profile` in Network (when running this branch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds defensive guards around user profile fetching and fails fast when `userId` is missing, with minimal behavioral change beyond preventing a bad request.
> 
> **Overview**
> Prevents user profile lookups from being triggered without a valid `uid`.
> 
> `PrivateComponent.getUserDetails()` now validates `CONVOY_AUTH` and early-returns when `uid` is missing, and `PrivateService.getUserDetails()` rejects when `userId` is empty/`'undefined'` before building the `/users/:id/profile` request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843ef2205759906c40925780b4f621ecda8e16f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->