### PR TITLE
fix(dashboard): keep settings shell for team tab

### DIFF
--- a/web/ui/dashboard/src/app/private/pages/settings/teams/teams.module.ts
+++ b/web/ui/dashboard/src/app/private/pages/settings/teams/teams.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TeamsComponent } from './teams.component';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { RouterModule, Routes } from '@angular/router';
 import { TableLoaderModule } from '../../../components/table-loader/table-loader.module';
 import { PageDirective } from 'src/app/components/page/page.component';
 import { DialogDirective, DialogHeaderComponent } from 'src/app/components/dialog/dialog.directive';
@@ -21,16 +20,10 @@ import { EnterpriseDirective } from '../../../components/enterprise/enterprise.d
 import { RolePipe } from 'src/app/pipes/role/role.pipe';
 import { CopyButtonComponent } from 'src/app/components/copy-button/copy-button.component';
 
-const routes: Routes = [
-	{ path: '', component: TeamsComponent },
-	{ path: 'new', component: TeamsComponent }
-];
-
 @NgModule({
 	declarations: [TeamsComponent],
 	imports: [
 		CommonModule,
-		RouterModule.forChild(routes),
 		FormsModule,
 		TableLoaderModule,
 		ReactiveFormsModule,


### PR DESCRIPTION
## Summary
- Remove nested `RouterModule.forChild` registration from `TeamsModule` so `/settings` renders through `SettingsComponent` again.
- Keeps the Team tab embedded via the exported `TeamsComponent` without letting its empty child route take over the settings route.

## Test plan
- Logged into local dashboard.
- Opened `/settings` and confirmed the Organisation Settings sidebar and Organisation Info content render together.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Angular routing composition for the Settings area; risk is limited but could affect `/settings` and team-tab navigation/rendering if route expectations differ.
> 
> **Overview**
> Fixes the Settings Teams tab routing by removing `RouterModule.forChild` (and its `''`/`new` routes) from `TeamsModule`.
> 
> This keeps the teams UI embedded under `SettingsComponent` via the exported `TeamsComponent`, preventing the teams module’s empty child route from taking over the `/settings` shell/sidebars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4464e8b125f4a71e3d91fe472407f1692153add. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->