### PR TITLE
fix(controlplane): remove invalid group by from api keys pagination

### DIFF
--- a/internal/api_keys/load_api_keys_paged_test.go
+++ b/internal/api_keys/load_api_keys_paged_test.go
@@ -142,6 +142,49 @@ func TestLoadAPIKeysPaged_EmptyResults(t *testing.T) {
 	require.False(t, pagination.HasPreviousPage)
 }
 
+func TestLoadAPIKeysPaged_PersonalSecurityQueryReturnsRows(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	user, _, project := seedTestData(t, db)
+	service := createAPIKeyService(t, db)
+
+	keysToCreate := []string{"dashboard-token", "cli-token"}
+	for _, name := range keysToCreate {
+		apiKey := &datastore.APIKey{
+			UID:    ulid.Make().String(),
+			Name:   name,
+			Type:   datastore.PersonalKey,
+			MaskID: ulid.Make().String(),
+			Role: auth.Role{
+				Type:    auth.RoleProjectAdmin,
+				Project: project.UID,
+			},
+			Hash:   ulid.Make().String(),
+			Salt:   ulid.Make().String(),
+			UserID: user.UID,
+		}
+		err := service.CreateAPIKey(ctx, apiKey)
+		require.NoError(t, err)
+	}
+
+	// Mirrors /ui/users/:id/security?keyType=personal_key&page=1 flow.
+	filter := &datastore.Filter{
+		UserID:  user.UID,
+		KeyType: datastore.PersonalKey,
+	}
+	pageable := datastore.Pageable{
+		PerPage:   10,
+		Direction: datastore.Next,
+	}
+	pageable.SetCursors()
+
+	keys, _, err := service.LoadAPIKeysPaged(ctx, filter, &pageable)
+	require.NoError(t, err)
+	require.Len(t, keys, len(keysToCreate))
+	for _, key := range keys {
+		require.NotEmpty(t, key.Name)
+	}
+}
+
 func TestLoadAPIKeysPaged_SinglePage(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	user, _, project := seedTestData(t, db)

--- a/internal/api_keys/queries.sql
+++ b/internal/api_keys/queries.sql
@@ -186,7 +186,6 @@ WITH filtered_api_keys AS (
                 ELSE true
             END
         )
-    GROUP BY id
     -- Sort order: DESC for forward (next), ASC for backward (prev)
     -- This ensures we get the right direction for cursor-based pagination
     ORDER BY

--- a/internal/api_keys/repo/queries.sql.go
+++ b/internal/api_keys/repo/queries.sql.go
@@ -156,7 +156,6 @@ WITH filtered_api_keys AS (
                 ELSE true
             END
         )
-    GROUP BY id
     -- Sort order: DESC for forward (next), ASC for backward (prev)
     -- This ensures we get the right direction for cursor-based pagination
     ORDER BY


### PR DESCRIPTION
## Summary
- remove the unnecessary `GROUP BY id` from `FetchAPIKeysPaginated` in `internal/api_keys/queries.sql`
- update generated SQLc query text in `internal/api_keys/repo/queries.sql.go` to match
- add a regression test for the personal access token security-page path in `internal/api_keys/load_api_keys_paged_test.go`

## Test plan
- [x] `go test ./internal/api_keys -run 'TestLoadAPIKeysPaged_(EmptyResults|PersonalSecurityQueryReturnsRows)$' -count=1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adjusts a single SQL pagination query and its generated sqlc output, plus adds a targeted regression test; main risk is subtle pagination/filter behavior differences in API key listings.
> 
> **Overview**
> Fixes `FetchAPIKeysPaginated` by removing an unnecessary/invalid `GROUP BY id` from the filtered CTE, and updates the sqlc-generated query text to match.
> 
> Adds a regression test (`TestLoadAPIKeysPaged_PersonalSecurityQueryReturnsRows`) that exercises the user security-page path (`UserID` + `KeyType=personal_key`) to ensure personal keys are returned under that filter/pagination setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4befe67a3680b49ce4608a8c9b3ec4b0c9552f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->