### PR TITLE
fix(dataplane): allow idempotency header overrides

### DIFF
--- a/net/dispatcher.go
+++ b/net/dispatcher.go
@@ -14,6 +14,7 @@ import (
 	"net/netip"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/stealthrocket/netjail"
@@ -509,12 +510,12 @@ func (d *Dispatcher) sendWebhookInternal(ctx context.Context, endpoint string, j
 	req.Header.Add("Content-Type", converter.ContentType())
 	req.Header.Set("Accept-Encoding", "gzip")
 	req.Header.Add("User-Agent", defaultUserAgent())
-	if len(idempotencyKey) > 0 {
-		req.Header.Set("X-Convoy-Idempotency-Key", idempotencyKey)
-	}
 
 	header := httpheader.HTTPHeader(req.Header)
 	header.MergeHeaders(headers)
+	if len(idempotencyKey) > 0 && !hasHeader(header, "X-Convoy-Idempotency-Key") {
+		header["X-Convoy-Idempotency-Key"] = []string{idempotencyKey}
+	}
 
 	req.Header = http.Header(header)
 
@@ -528,6 +529,16 @@ func (d *Dispatcher) sendWebhookInternal(ctx context.Context, endpoint string, j
 	}
 
 	return r, err
+}
+
+func hasHeader(header httpheader.HTTPHeader, key string) bool {
+	for k := range header {
+		if strings.EqualFold(k, key) {
+			return true
+		}
+	}
+
+	return false
 }
 
 type Response struct {

--- a/net/dispatcher_test.go
+++ b/net/dispatcher_test.go
@@ -895,6 +895,99 @@ func TestDispatcherSendRequest(t *testing.T) {
 	require.Equal(t, "custom-value", resp.RequestHeader.Get("X-Custom-Header"))
 }
 
+func TestDispatcherIdempotencyKeyHeaderCanBeOverriddenByCustomHeaders(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "customer-idempotency-key", r.Header.Get("X-Convoy-Idempotency-Key"))
+		require.NotEqual(t, "event-idempotency-key", r.Header.Get("X-Convoy-Idempotency-Key"))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status": "success"}`))
+	}))
+	defer server.Close()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	licenser := mocks.NewMockLicenser(ctrl)
+	licenser.EXPECT().UseForwardProxy().Times(1).Return(true)
+	licenser.EXPECT().IpRules().Times(4).Return(true)
+
+	dispatcher, err := NewDispatcher(
+		licenser,
+		fflag.NewFFlag([]string{string(fflag.IpRules)}),
+		LoggerOption(log.New("convoy", log.LevelInfo)),
+		ProxyOption("nil"),
+		AllowListOption([]string{"0.0.0.0/0"}),
+		BlockListOption([]string{"10.0.0.0/8"}),
+	)
+	require.NoError(t, err)
+
+	headers := httpheader.HTTPHeader{
+		"X-Convoy-Idempotency-Key": []string{"customer-idempotency-key"},
+	}
+
+	resp, err := dispatcher.SendWebhook(
+		context.Background(),
+		server.URL,
+		json.RawMessage(`{"key": "value"}`),
+		"X-Signature",
+		"test-hmac",
+		1024,
+		headers,
+		"event-idempotency-key",
+		5*time.Second,
+		constants.ContentTypeJSON,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "customer-idempotency-key", resp.RequestHeader.Get("X-Convoy-Idempotency-Key"))
+}
+
+func TestDispatcherDoesNotSetIdempotencyKeyHeaderWhenEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Empty(t, r.Header.Get("X-Convoy-Idempotency-Key"))
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status": "success"}`))
+	}))
+	defer server.Close()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	licenser := mocks.NewMockLicenser(ctrl)
+	licenser.EXPECT().UseForwardProxy().Times(1).Return(true)
+	licenser.EXPECT().IpRules().Times(4).Return(true)
+
+	dispatcher, err := NewDispatcher(
+		licenser,
+		fflag.NewFFlag([]string{string(fflag.IpRules)}),
+		LoggerOption(log.New("convoy", log.LevelInfo)),
+		ProxyOption("nil"),
+		AllowListOption([]string{"0.0.0.0/0"}),
+		BlockListOption([]string{"10.0.0.0/8"}),
+	)
+	require.NoError(t, err)
+
+	resp, err := dispatcher.SendWebhook(
+		context.Background(),
+		server.URL,
+		json.RawMessage(`{"key": "value"}`),
+		"X-Signature",
+		"test-hmac",
+		1024,
+		nil,
+		"",
+		5*time.Second,
+		constants.ContentTypeJSON,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Empty(t, resp.RequestHeader.Get("X-Convoy-Idempotency-Key"))
+}
+
 // TestDispatcherWithTimeout tests the timeout functionality
 func TestDispatcherWithTimeout(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- allow custom delivery headers to override the default `X-Convoy-Idempotency-Key` value
- keep the existing default idempotency header when no custom override is supplied
- add focused dispatcher coverage for default, override, and empty-key behavior

## Test plan
- `go test ./net -run 'TestDispatcher(SendRequest|IdempotencyKeyHeaderCanBeOverriddenByCustomHeaders|DoesNotSetIdempotencyKeyHeaderWhenEmpty)$' -count=1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized outbound webhook header ordering in the dispatcher with focused tests; no auth, persistence, or API contract changes beyond honoring custom idempotency headers.
> 
> **Overview**
> Webhook dispatch now applies the default **`X-Convoy-Idempotency-Key`** only **after** custom delivery headers are merged, and only when a non-empty idempotency key is provided and that header is not already present (case-insensitive check).
> 
> **Custom headers can override** Convoy’s event idempotency value instead of always winning or always losing. An **empty** idempotency key leaves the header unset unless the customer supplies it.
> 
> New dispatcher tests cover default header behavior, customer override, and the empty-key case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82873acf55940ec20423a6bd0349b894a236e337. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->