### PR TITLE
fix(dataplane,dashboard): deliver meta events with populated payload and fix meta-events config UI

### DIFF
--- a/web/ui/dashboard/src/app/components/select/select.component.html
+++ b/web/ui/dashboard/src/app/components/select/select.component.html
@@ -55,9 +55,11 @@
         <li class="text-14 text-neutral-4">Select</li>
         @if (multiple) {
           @for (option of options; track $index) {
-            <li class="list-none py-10px border-b border-new.primary-25">
-              <button convoy-button color="neutral" type="button" fill="text" (click)="selectOption(option)" class="text-12 w-full !justify-start">{{ option?.name || option }}</button>
-            </li>
+            @if (!isSelected(option)) {
+              <li class="list-none py-10px border-b border-new.primary-25">
+                <button convoy-button color="neutral" type="button" fill="text" (click)="selectOption(option)" class="text-12 w-full !justify-start">{{ option?.name || option }}</button>
+              </li>
+            }
           }
         }
         @if (!multiple) {

--- a/web/ui/dashboard/src/app/components/select/select.component.ts
+++ b/web/ui/dashboard/src/app/components/select/select.component.ts
@@ -93,14 +93,20 @@ export class SelectComponent implements OnInit, AfterViewChecked, ControlValueAc
 		}
 	}
 
+	private isSameOption(a: any, b: any): boolean {
+		// Primitive (string) options must be compared by value; they have no uid.
+		if (typeof a === 'string' || typeof b === 'string') return a === b;
+		// Object options: match by identity or a defined uid (guard against undefined === undefined).
+		return a === b || (a?.uid != null && a.uid === b?.uid);
+	}
+
+	isSelected(option: any): boolean {
+		return this.selectedOptions?.some((item: any) => this.isSameOption(item, option)) || false;
+	}
+
 	selectOption(option?: any) {
 		if (this.multiple) {
-			const selectedOption =
-				this.selectedOptions?.find((item: any) => item === option) ||
-				this.selectedOptions?.find((item: any) => item.uid === option) ||
-				this.selectedOptions?.find((item: any) => item.uid === option.uid) ||
-				this.selectedOptions?.find((item: any) => item.name === option.name && item.uid === option.uid);
-			if (!selectedOption) this.selectedOptions?.push(option);
+			if (!this.isSelected(option)) this.selectedOptions?.push(option);
 
 			this.updateSelectedOptions();
 		} else {

--- a/web/ui/dashboard/src/app/components/select/select.component.ts
+++ b/web/ui/dashboard/src/app/components/select/select.component.ts
@@ -93,11 +93,19 @@ export class SelectComponent implements OnInit, AfterViewChecked, ControlValueAc
 		}
 	}
 
+	private optionKey(o: any): any {
+		// Selected items can be objects ({uid, name}) while options are plain strings
+		// (or vice versa); normalise both to a comparable key before matching.
+		return typeof o === 'string' ? o : o?.uid;
+	}
+
 	private isSameOption(a: any, b: any): boolean {
-		// Primitive (string) options must be compared by value; they have no uid.
-		if (typeof a === 'string' || typeof b === 'string') return a === b;
-		// Object options: match by identity or a defined uid (guard against undefined === undefined).
-		return a === b || (a?.uid != null && a.uid === b?.uid);
+		const aKey = this.optionKey(a);
+		const bKey = this.optionKey(b);
+		// Compare by key when both resolve to one (handles object-vs-string, e.g. a
+		// loaded {uid:'x'} against the string option 'x'); otherwise fall back to identity.
+		if (aKey != null && bKey != null) return aKey === bKey;
+		return a === b;
 	}
 
 	isSelected(option: any): boolean {

--- a/web/ui/dashboard/src/app/private/components/create-project-component/create-project-component.component.ts
+++ b/web/ui/dashboard/src/app/private/components/create-project-component/create-project-component.component.ts
@@ -394,15 +394,16 @@ export class CreateProjectComponent implements OnInit {
 	}
 
 	checkMetaEventsConfig() {
-		const is_meta_events_enabled = this.projectForm.value.config.meta_event.is_enabled;
-		const metaEventsConfig = Object.keys(this.projectForm.value.config.meta_event).slice(1, -1);
+		const metaEvent = this.projectForm.value.config?.meta_event;
+		const is_meta_events_enabled = metaEvent?.is_enabled;
+		const metaEventsConfig = Object.keys(metaEvent ?? {}).slice(1, -1);
 		if (!is_meta_events_enabled) {
 			metaEventsConfig.forEach(config => {
 				this.projectForm.get(`config.meta_event.${config}`)?.clearValidators();
 				this.projectForm.get(`config.meta_event.${config}`)?.setErrors(null);
 				this.projectForm.updateValueAndValidity();
 			});
-		} else if (!this.projectForm.value.config.meta_event.type) {
+		} else if (!metaEvent?.type) {
 			// `http` is currently the only supported meta event transport; it has no UI control,
 			// so ensure it's set when meta events are enabled (load can null it out).
 			this.projectForm.get('config.meta_event.type')?.patchValue('http');

--- a/web/ui/dashboard/src/app/private/components/create-project-component/create-project-component.component.ts
+++ b/web/ui/dashboard/src/app/private/components/create-project-component/create-project-component.component.ts
@@ -350,6 +350,7 @@ export class CreateProjectComponent implements OnInit {
 			this.onAction.emit(response.data);
 			this.isCreatingProject = false;
 		} catch (error) {
+			console.error('[updateProject] update failed:', error);
 			this.isCreatingProject = false;
 		}
 	}
@@ -401,6 +402,10 @@ export class CreateProjectComponent implements OnInit {
 				this.projectForm.get(`config.meta_event.${config}`)?.setErrors(null);
 				this.projectForm.updateValueAndValidity();
 			});
+		} else if (!this.projectForm.value.config.meta_event.type) {
+			// `http` is currently the only supported meta event transport; it has no UI control,
+			// so ensure it's set when meta events are enabled (load can null it out).
+			this.projectForm.get('config.meta_event.type')?.patchValue('http');
 		}
 	}
 
@@ -438,7 +443,7 @@ export class CreateProjectComponent implements OnInit {
 	}
 
 	switchTab(tab: TAB) {
-		if (tab.label === 'meta events') this.projectForm.patchValue({ config: { meta_event: { type: 'http' } } });
+		if (tab.label === 'meta events config') this.projectForm.patchValue({ config: { meta_event: { type: 'http' } } });
 		this.activeTab = tab;
 		this.addPageToUrl();
 	}

--- a/worker/task/process_meta_event.go
+++ b/worker/task/process_meta_event.go
@@ -128,8 +128,12 @@ func sendUrlRequest(ctx context.Context, project *datastore.Project, metaEvent *
 		return nil, err
 	}
 
+	// Metadata.Data holds the canonical {event_type, data} payload; Metadata.Raw is
+	// legacy and left empty at creation. Signing/sending Raw produced an empty
+	// json.RawMessage, which fails HMAC generation ("unexpected end of JSON input")
+	// and meant meta events were never delivered (PDE-782).
 	sig := &signature.Signature{
-		Payload: json.RawMessage(metaEvent.Metadata.Raw),
+		Payload: metaEvent.Metadata.Data,
 		Schemes: []signature.Scheme{
 			{
 				Secret:   []string{project.Config.MetaEvent.Secret},


### PR DESCRIPTION
## Summary

Meta events (`eventdelivery.success` / `eventdelivery.failed`) were never delivered, and the dashboard meta-events project config couldn't be saved. This fixes both (PDE-782).

### Backend (dataplane): meta events never delivered
The worker signed and sent `Metadata.Raw`, but the create path leaves `Raw` empty and puts the payload in `Metadata.Data`. Marshalling an empty `json.RawMessage` fails HMAC generation (`unexpected end of JSON input`), so the request was **never sent**: the meta event looped `Retry` until `Failure`, with zero HTTP calls. Now we sign/send `Metadata.Data`, restoring the `{event_type, data}` delivery-outcome envelope.

### Dashboard: meta-events config was unusable
- **select:** multi-select couldn't add more than one option because the dedup compared `item.uid === option.uid` on plain-string options (`undefined === undefined`, so every option looked already selected). It now compares by value for strings and guards `uid` for objects, and also hides already-selected options from the dropdown.
- **create-project:** `meta_event.type` is `required` but load nulled it, so Save silently aborted on an invalid form. Force `type='http'` when meta events are enabled, and fix the `switchTab` label (`'meta events config'`). Surface update failures via `console.error`.

## Verified locally
- Before: HMAC error, 0 deliveries, perpetual `Retry`.
- After: all meta events reach `Success`; the receiver got a `POST` with a non-empty body (`{"event_type":"eventdelivery.success","data":{...attempt incl. http_status/response_data...}}`) and a valid `X-Convoy-Signature` (HMAC-SHA256, hex).

## Test plan
- [ ] Enable meta events on a project (dashboard), select multiple event types, Save succeeds.
- [ ] Trigger an event delivery; confirm a `eventdelivery.success` meta event is POSTed with the full signed payload and the record flips to `Success`.
- [ ] `eventdelivery.failed` path delivers similarly.
- [ ] Existing meta-event tests pass.

Refs: PDE-782

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Worker change affects signed webhook delivery for meta events (security-sensitive signing path); dashboard changes are localized to select and project config forms.
> 
> **Overview**
> Fixes **meta event delivery** in the worker by signing and sending `Metadata.Data` instead of empty `Metadata.Raw`, which was breaking HMAC and blocking all meta event HTTP posts (PDE-782).
> 
> On the **dashboard**, the multi-select component now compares options by string value or `uid` (not broken `undefined === undefined` checks), hides already-selected choices, and the create-project flow **defaults `meta_event.type` to `http`** when meta events are enabled so Save isn’t blocked by a null required field. Tab switching uses the correct **meta events config** label, and failed project updates log to the console.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c8e28c1e94be7ed7d6a3dd961755d774a84b697. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->