### PR TITLE
feat(dashboard): add org switcher search, count, and pagination

### DIFF
--- a/api/handlers/organisation.go
+++ b/api/handlers/organisation.go
@@ -63,12 +63,22 @@ func (h *Handler) GetOrganisationsPaged(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	organisations, paginationData, err := organisation_members.New(h.A.Logger, h.A.DB).LoadUserOrganisationsPaged(r.Context(), user.UID, pageable)
+	orgMemberSvc := organisation_members.New(h.A.Logger, h.A.DB)
+
+	organisations, paginationData, err := orgMemberSvc.LoadUserOrganisationsPaged(r.Context(), user.UID, pageable)
 	if err != nil {
 		h.A.Logger.ErrorContext(r.Context(), "failed to fetch user organisations", "error", err)
 		_ = render.Render(w, r, util.NewServiceErrResponse(err))
 		return
 	}
+
+	total, err := orgMemberSvc.CountUserOrganisations(r.Context(), user.UID, pageable.Search)
+	if err != nil {
+		h.A.Logger.ErrorContext(r.Context(), "failed to count user organisations", "error", err)
+		_ = render.Render(w, r, util.NewServiceErrResponse(err))
+		return
+	}
+	paginationData.Total = total
 
 	_ = render.Render(w, r, util.NewServerResponse("Organisations fetched successfully",
 		models.PagedResponse{Content: &organisations, Pagination: &paginationData}, http.StatusOK))

--- a/datastore/models.go
+++ b/datastore/models.go
@@ -36,6 +36,7 @@ type Pageable struct {
 	Sort       string        `json:"sort"`
 	PrevCursor string        `json:"prev_page_cursor"`
 	NextCursor string        `json:"next_page_cursor"`
+	Search     string        `json:"-"`
 }
 
 type PageDirection string
@@ -86,6 +87,7 @@ type PaginationData struct {
 	HasPreviousPage bool         `json:"has_prev_page"`
 	PrevPageCursor  string       `json:"prev_page_cursor"`
 	NextPageCursor  string       `json:"next_page_cursor"`
+	Total           int64        `json:"total,omitempty"`
 }
 
 type PrevRowCount struct {

--- a/datastore/repository.go
+++ b/datastore/repository.go
@@ -176,6 +176,7 @@ type OrganisationInviteRepository interface {
 type OrganisationMemberRepository interface {
 	LoadOrganisationMembersPaged(ctx context.Context, organisationID, userID string, pageable Pageable) ([]*OrganisationMember, PaginationData, error)
 	LoadUserOrganisationsPaged(ctx context.Context, userID string, pageable Pageable) ([]Organisation, PaginationData, error)
+	CountUserOrganisations(ctx context.Context, userID string, search string) (int64, error)
 	FindUserProjects(ctx context.Context, userID string) ([]Project, error)
 	CreateOrganisationMember(ctx context.Context, member *OrganisationMember) error
 	UpdateOrganisationMember(ctx context.Context, member *OrganisationMember) error

--- a/internal/organisation_members/count_user_organisations_test.go
+++ b/internal/organisation_members/count_user_organisations_test.go
@@ -1,0 +1,75 @@
+package organisation_members
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/frain-dev/convoy/auth"
+	"github.com/frain-dev/convoy/database"
+	"github.com/frain-dev/convoy/datastore"
+)
+
+func seedNamedOrganisation(t *testing.T, db database.Database, ownerID, name string) *datastore.Organisation {
+	t.Helper()
+
+	org := &datastore.Organisation{
+		UID:       ulid.Make().String(),
+		Name:      name,
+		OwnerID:   ownerID,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	err := createOrganisationService(t, db).CreateOrganisation(context.Background(), org)
+	require.NoError(t, err)
+
+	return org
+}
+
+func Test_CountUserOrganisations(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	service := createOrgMemberService(t, db)
+	orgService := createOrganisationService(t, db)
+
+	user := seedUser(t, db, "")
+	alpha := seedNamedOrganisation(t, db, user.UID, "Alpha Corp")
+	beta := seedNamedOrganisation(t, db, user.UID, "Beta Inc")
+	gamma := seedNamedOrganisation(t, db, user.UID, "Gamma LLC")
+
+	_ = seedOrganisationMember(t, db, alpha.UID, user.UID, auth.Role{Type: auth.RoleProjectAdmin})
+	_ = seedOrganisationMember(t, db, beta.UID, user.UID, auth.Role{Type: auth.RoleProjectAdmin})
+	_ = seedOrganisationMember(t, db, gamma.UID, user.UID, auth.Role{Type: auth.RoleProjectAdmin})
+
+	// unfiltered count returns every org the user belongs to.
+	total, err := service.CountUserOrganisations(ctx, user.UID, "")
+	require.NoError(t, err)
+	require.Equal(t, int64(3), total)
+
+	// name search is a case-insensitive partial match.
+	total, err = service.CountUserOrganisations(ctx, user.UID, "alph")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+
+	// id search is an exact match.
+	total, err = service.CountUserOrganisations(ctx, user.UID, beta.UID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+
+	// search is consistent with the paged list filter.
+	pageable := datastore.Pageable{PerPage: 10, Direction: datastore.Next, Search: "alph"}
+	pageable.SetCursors()
+	filtered, _, err := service.LoadUserOrganisationsPaged(ctx, user.UID, pageable)
+	require.NoError(t, err)
+	require.Len(t, filtered, 1)
+	require.Equal(t, "Alpha Corp", filtered[0].Name)
+
+	// soft-deleted orgs are excluded from the count.
+	require.NoError(t, orgService.DeleteOrganisation(ctx, alpha.UID))
+	total, err = service.CountUserOrganisations(ctx, user.UID, "")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), total)
+}

--- a/internal/organisation_members/impl.go
+++ b/internal/organisation_members/impl.go
@@ -384,6 +384,7 @@ func (s *Service) LoadUserOrganisationsPaged(ctx context.Context, userID string,
 	rows, err := s.repo.FetchUserOrganisationsPaginated(ctx, repo.FetchUserOrganisationsPaginatedParams{
 		Direction: common.StringToPgText(direction),
 		UserID:    common.StringToPgText(userID),
+		Search:    common.StringToPgText(pageable.Search),
 		Cursor:    common.StringToPgText(pageable.Cursor()),
 		LimitVal:  pgtype.Int8{Int64: int64(pageable.Limit()), Valid: true},
 	})
@@ -416,6 +417,7 @@ func (s *Service) LoadUserOrganisationsPaged(ctx context.Context, userID string,
 		first := organisations[0]
 		count, err2 := s.repo.CountPrevUserOrganisations(ctx, repo.CountPrevUserOrganisationsParams{
 			UserID: common.StringToPgText(userID),
+			Search: common.StringToPgText(pageable.Search),
 			Cursor: common.StringToPgText(first.UID),
 		})
 		if err2 != nil {
@@ -430,6 +432,21 @@ func (s *Service) LoadUserOrganisationsPaged(ctx context.Context, userID string,
 	pagination = pagination.Build(pageable, ids)
 
 	return organisations, *pagination, nil
+}
+
+// CountUserOrganisations returns the total number of organisations a user belongs to,
+// honouring the same optional name/id search filter used by LoadUserOrganisationsPaged.
+func (s *Service) CountUserOrganisations(ctx context.Context, userID, search string) (int64, error) {
+	count, err := s.repo.CountUserOrganisations(ctx, repo.CountUserOrganisationsParams{
+		UserID: common.StringToPgText(userID),
+		Search: common.StringToPgText(search),
+	})
+	if err != nil {
+		s.logger.Error("failed to count user organisations", "error", err)
+		return 0, util.NewServiceError(http.StatusInternalServerError, err)
+	}
+
+	return count.Int64, nil
 }
 
 // FindUserProjects retrieves all projects for a user

--- a/internal/organisation_members/queries.sql
+++ b/internal/organisation_members/queries.sql
@@ -264,6 +264,9 @@ WITH user_organisations AS (
         AND o.deleted_at IS NULL
         AND m.deleted_at IS NULL
         AND (
+            @search::text = '' OR o.name ILIKE '%' || @search::text || '%' OR o.id = @search::text
+        )
+        AND (
             CASE
                 WHEN @direction::text = 'next' THEN o.id <= @cursor
                 WHEN @direction::text = 'prev' THEN o.id >= @cursor
@@ -290,7 +293,21 @@ JOIN convoy.organisations o ON m.organisation_id = o.id
 WHERE m.user_id = @user_id
     AND o.deleted_at IS NULL
     AND m.deleted_at IS NULL
+    AND (
+        @search::text = '' OR o.name ILIKE '%' || @search::text || '%' OR o.id = @search::text
+    )
     AND o.id > @cursor;
+
+-- name: CountUserOrganisations :one
+SELECT COUNT(DISTINCT o.id) AS count
+FROM convoy.organisation_members m
+JOIN convoy.organisations o ON m.organisation_id = o.id
+WHERE m.user_id = @user_id
+    AND o.deleted_at IS NULL
+    AND m.deleted_at IS NULL
+    AND (
+        @search::text = '' OR o.name ILIKE '%' || @search::text || '%' OR o.id = @search::text
+    );
 
 -- ===========================================================================
 -- Project Queries

--- a/internal/organisation_members/repo/querier.go
+++ b/internal/organisation_members/repo/querier.go
@@ -15,6 +15,7 @@ type Querier interface {
 	CountOrganisationAdminUsers(ctx context.Context) (pgtype.Int8, error)
 	CountPrevOrganisationMembers(ctx context.Context, arg CountPrevOrganisationMembersParams) (pgtype.Int8, error)
 	CountPrevUserOrganisations(ctx context.Context, arg CountPrevUserOrganisationsParams) (pgtype.Int8, error)
+	CountUserOrganisations(ctx context.Context, arg CountUserOrganisationsParams) (pgtype.Int8, error)
 	// Organisation Members SQLc Queries
 	// Migration from database/postgres/organisation_member.go to SQLc
 	// ===========================================================================

--- a/internal/organisation_members/repo/queries.sql.go
+++ b/internal/organisation_members/repo/queries.sql.go
@@ -66,16 +66,44 @@ JOIN convoy.organisations o ON m.organisation_id = o.id
 WHERE m.user_id = $1
     AND o.deleted_at IS NULL
     AND m.deleted_at IS NULL
-    AND o.id > $2
+    AND (
+        $2::text = '' OR o.name ILIKE '%' || $2::text || '%' OR o.id = $2::text
+    )
+    AND o.id > $3
 `
 
 type CountPrevUserOrganisationsParams struct {
 	UserID pgtype.Text
+	Search pgtype.Text
 	Cursor pgtype.Text
 }
 
 func (q *Queries) CountPrevUserOrganisations(ctx context.Context, arg CountPrevUserOrganisationsParams) (pgtype.Int8, error) {
-	row := q.db.QueryRow(ctx, countPrevUserOrganisations, arg.UserID, arg.Cursor)
+	row := q.db.QueryRow(ctx, countPrevUserOrganisations, arg.UserID, arg.Search, arg.Cursor)
+	var count pgtype.Int8
+	err := row.Scan(&count)
+	return count, err
+}
+
+const countUserOrganisations = `-- name: CountUserOrganisations :one
+SELECT COUNT(DISTINCT o.id) AS count
+FROM convoy.organisation_members m
+JOIN convoy.organisations o ON m.organisation_id = o.id
+WHERE m.user_id = $1
+    AND o.deleted_at IS NULL
+    AND m.deleted_at IS NULL
+    AND (
+        $2::text = '' OR o.name ILIKE '%' || $2::text || '%' OR o.id = $2::text
+    )
+`
+
+type CountUserOrganisationsParams struct {
+	UserID pgtype.Text
+	Search pgtype.Text
+}
+
+func (q *Queries) CountUserOrganisations(ctx context.Context, arg CountUserOrganisationsParams) (pgtype.Int8, error) {
+	row := q.db.QueryRow(ctx, countUserOrganisations, arg.UserID, arg.Search)
 	var count pgtype.Int8
 	err := row.Scan(&count)
 	return count, err
@@ -505,16 +533,19 @@ WITH user_organisations AS (
         AND o.deleted_at IS NULL
         AND m.deleted_at IS NULL
         AND (
+            $3::text = '' OR o.name ILIKE '%' || $3::text || '%' OR o.id = $3::text
+        )
+        AND (
             CASE
-                WHEN $1::text = 'next' THEN o.id <= $3
-                WHEN $1::text = 'prev' THEN o.id >= $3
+                WHEN $1::text = 'next' THEN o.id <= $4
+                WHEN $1::text = 'prev' THEN o.id >= $4
                 ELSE true
             END
         )
     ORDER BY
         CASE WHEN $1::text = 'next' THEN o.id END DESC,
         CASE WHEN $1::text = 'prev' THEN o.id END ASC
-    LIMIT $4
+    LIMIT $5
 )
 SELECT
     id, name, owner_id, custom_domain, assigned_domain, license_data,
@@ -528,6 +559,7 @@ ORDER BY
 type FetchUserOrganisationsPaginatedParams struct {
 	Direction pgtype.Text
 	UserID    pgtype.Text
+	Search    pgtype.Text
 	Cursor    pgtype.Text
 	LimitVal  pgtype.Int8
 }
@@ -551,6 +583,7 @@ func (q *Queries) FetchUserOrganisationsPaginated(ctx context.Context, arg Fetch
 	rows, err := q.db.Query(ctx, fetchUserOrganisationsPaginated,
 		arg.Direction,
 		arg.UserID,
+		arg.Search,
 		arg.Cursor,
 		arg.LimitVal,
 	)

--- a/internal/pkg/middleware/middleware.go
+++ b/internal/pkg/middleware/middleware.go
@@ -466,6 +466,7 @@ func Pagination(next http.Handler) http.Handler {
 			Direction:  datastore.PageDirection(rawDirection),
 			NextCursor: rawNextCursor,
 			PrevCursor: rawPrevCursor,
+			Search:     strings.TrimSpace(r.URL.Query().Get("q")),
 		}
 		pageable.SetCursors()
 

--- a/mocks/repository.go
+++ b/mocks/repository.go
@@ -1582,6 +1582,21 @@ func (mr *MockOrganisationMemberRepositoryMockRecorder) LoadUserOrganisationsPag
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadUserOrganisationsPaged", reflect.TypeOf((*MockOrganisationMemberRepository)(nil).LoadUserOrganisationsPaged), ctx, userID, pageable)
 }
 
+// CountUserOrganisations mocks base method.
+func (m *MockOrganisationMemberRepository) CountUserOrganisations(ctx context.Context, userID, search string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountUserOrganisations", ctx, userID, search)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountUserOrganisations indicates an expected call of CountUserOrganisations.
+func (mr *MockOrganisationMemberRepositoryMockRecorder) CountUserOrganisations(ctx, userID, search any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountUserOrganisations", reflect.TypeOf((*MockOrganisationMemberRepository)(nil).CountUserOrganisations), ctx, userID, search)
+}
+
 // UpdateOrganisationMember mocks base method.
 func (m *MockOrganisationMemberRepository) UpdateOrganisationMember(ctx context.Context, member *datastore.OrganisationMember) error {
 	m.ctrl.T.Helper()

--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -234,29 +233,16 @@ func in(payload, filter interface{}) (bool, error) {
 		}
 	}
 
-	pCopy := make([]interface{}, len(p))
-	copy(pCopy, p)
-	sort.SliceStable(pCopy, func(i, j int) bool {
-		switch pi := pCopy[i].(type) {
-		case string:
-			return pi < pCopy[j].(string)
-		case float64:
-			return pi < pCopy[j].(float64)
-		case int:
-			return pi < pCopy[j].(int)
-		}
-
-		return false
-	})
-
-	found := false
-	for _, v := range pCopy {
+	// Membership is decided by a linear scan, so no sorting is needed. The
+	// previous sort comparator also panicked on mixed-type arrays (e.g.
+	// ["a", 1]) because it used unchecked type assertions.
+	for _, v := range p {
 		if v == filter {
-			found = true
+			return true, nil
 		}
 	}
 
-	return found, nil
+	return false, nil
 }
 
 func nin(payload, filter interface{}) (bool, error) {

--- a/pkg/compare/compare_test.go
+++ b/pkg/compare/compare_test.go
@@ -1627,3 +1627,33 @@ var comboTestFilterThreeLevels = map[string]interface{}{
 		},
 	},
 }
+
+// TestInMixedTypeArrayNoPanic ensures the $in operator does not panic when the
+// payload array field holds mixed JSON types (e.g. a string and a number),
+// which arbitrary webhook payloads can produce. Reported in #2667.
+func TestInMixedTypeArrayNoPanic(t *testing.T) {
+	payload := map[string]interface{}{
+		"ids": []interface{}{"a", float64(1)},
+	}
+	filter := map[string]interface{}{
+		"ids": map[string]interface{}{"$in": "a"},
+	}
+
+	got, err := Compare(payload, filter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got {
+		t.Fatalf("expected match for %q in mixed array, got false", "a")
+	}
+
+	miss, err := Compare(payload, map[string]interface{}{
+		"ids": map[string]interface{}{"$in": "b"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if miss {
+		t.Fatalf("expected no match for %q in mixed array, got true", "b")
+	}
+}

--- a/web/ui/dashboard/src/app/private/private.component.html
+++ b/web/ui/dashboard/src/app/private/private.component.html
@@ -31,9 +31,29 @@
               <img src="/assets/img/angle-arrow-down.svg" alt="arrow down icon" />
             </button>
             <ul dropdownOptions>
-              <li class="font-semibold text-12 text-neutral-11 px-16px pt-12px pb-8px border-b border-b-neutral-a3">Your organisations ({{ organisations?.length || 0 }})</li>
-              <ul [hidden]="!organisations?.length">
-                @for (organisation of organisations; track $index) {
+              <li class="flex items-center justify-between px-16px pt-12px pb-8px border-b border-b-neutral-a3" (click)="$event.stopPropagation()">
+                <span class="font-semibold text-12 text-neutral-11">Your organisations @if (orgPagination?.total) {<span>({{ organisations?.length || 0 }}/{{ orgPagination?.total }})</span>}</span>
+                @if (orgSearchEnabled) {
+                  <button type="button" class="p-4px rounded-6px transition-colors" [class.bg-neutral-3]="showOrgSearchInput" (click)="$event.stopPropagation(); toggleOrgSearch()" [attr.aria-label]="showOrgSearchInput ? 'Close search' : 'Search organisations'">
+                    <img class="w-14px" src="/assets/img/search-icon.svg" alt="search" />
+                  </button>
+                }
+              </li>
+              @if (showOrgSearchInput) {
+                <li class="px-16px py-8px border-b border-b-neutral-a3" (click)="$event.stopPropagation()">
+                  <input
+                    #orgSearchInput
+                    type="search"
+                    placeholder="Search by name or ID"
+                    [value]="orgSearch"
+                    (input)="onOrgSearch(orgSearchInput.value)"
+                    (click)="$event.stopPropagation()"
+                    class="w-full text-12 text-neutral-11 bg-neutral-3 rounded-6px px-12px py-8px outline-none border border-neutral-a3 focus:border-primary-100"
+                  />
+                </li>
+              }
+              <ul class="max-h-[260px] overflow-y-auto">
+                @for (organisation of organisations; track organisation.uid) {
                   <li convoy-dropdown-option>
                     <button convoy-button fill="text" color="neutral" size="sm" class="justify-start px-16px py-12px w-full" (click)="selectOrganisation(organisation)">
                       <div class="flex justify-between items-center w-full">
@@ -53,6 +73,16 @@
                           </div>
                         }
                       </div>
+                    </button>
+                  </li>
+                }
+                @if (!organisations?.length && !isSearchingOrganisations) {
+                  <li class="px-16px py-12px text-12 text-neutral-10">No organisations found</li>
+                }
+                @if (orgPagination?.has_next_page) {
+                  <li class="border-t border-t-neutral-a3">
+                    <button convoy-button fill="text" color="neutral" size="sm" class="justify-center w-full py-12px" (click)="$event.stopPropagation(); loadMoreOrganisations()" [disabled]="loadingMoreOrganisations">
+                      {{ loadingMoreOrganisations ? 'Loading...' : 'Load more' }}
                     </button>
                   </li>
                 }

--- a/web/ui/dashboard/src/app/private/private.component.html
+++ b/web/ui/dashboard/src/app/private/private.component.html
@@ -20,10 +20,10 @@
           </a>
         }
 
-        @if (organisations?.length) {
+        @if (hasOrganisations) {
           <div convoy-dropdown size="lg" #organisationDropdown>
             <button dropdownTrigger convoy-button color="neutral" fill="soft" size="sm" class="py-10px px-20px rounded-8px mr-12px">
-              @if (organisations?.length) {
+              @if (userOrganization?.name) {
                 <convoy-badge className="mr-8px" [show-text]="false" [text]="userOrganization?.name || ''">
                   <div class="max-w-[110px] truncate">{{ userOrganization?.name }}</div>
                 </convoy-badge>

--- a/web/ui/dashboard/src/app/private/private.component.ts
+++ b/web/ui/dashboard/src/app/private/private.component.ts
@@ -21,6 +21,7 @@ import { environment } from 'src/environments/environment';
 export class PrivateComponent implements OnInit {
 	@ViewChild('orgDialog', { static: true }) dialog!: ElementRef<HTMLDialogElement>;
 	@ViewChild('verifyEmailDialog', { static: true }) verifyEmailDialog!: ElementRef<HTMLDialogElement>;
+	@ViewChild('orgSearchInput') orgSearchInputEl?: ElementRef<HTMLInputElement>;
 
 	showDropdown = false;
 	showOrgDropdown = false;
@@ -33,6 +34,13 @@ export class PrivateComponent implements OnInit {
 	userOrganization?: ORGANIZATION_DATA;
 	convoyVersion: string = '';
 	isLoadingOrganisations = false;
+	orgPagination?: { has_next_page: boolean; next_page_cursor: string; total?: number };
+	orgSearch = '';
+	orgSearchEnabled = false;
+	showOrgSearchInput = false;
+	isSearchingOrganisations = false;
+	loadingMoreOrganisations = false;
+	private orgSearchTimeout: any;
 	addOrganisationForm: FormGroup = this.formBuilder.group({
 		name: ['', Validators.required]
 	});
@@ -168,12 +176,63 @@ export class PrivateComponent implements OnInit {
 		try {
 			const response = await this.privateService.getOrganizations({ refresh });
 			this.organisations = response.data.content;
+			this.orgPagination = response.data.pagination;
+			// Show the search affordance once the user has more orgs than a single page.
+			if (this.orgPagination?.has_next_page) this.orgSearchEnabled = true;
 			this.isLoadingOrganisations = false;
 			if (this.organisations?.length) await this.checkForSelectedOrganisation();
 			return;
 		} catch (error) {
 			this.isLoadingOrganisations = false;
 			return error;
+		}
+	}
+
+	toggleOrgSearch() {
+		this.showOrgSearchInput = !this.showOrgSearchInput;
+		if (this.showOrgSearchInput) {
+			setTimeout(() => this.orgSearchInputEl?.nativeElement.focus(), 0);
+			return;
+		}
+		// Collapsing the search resets back to the unfiltered first page.
+		if (this.orgSearch) {
+			this.orgSearch = '';
+			this.runOrgSearch();
+		}
+	}
+
+	onOrgSearch(term: string) {
+		this.orgSearch = term;
+		clearTimeout(this.orgSearchTimeout);
+		this.orgSearchTimeout = setTimeout(() => this.runOrgSearch(), 300);
+	}
+
+	async runOrgSearch() {
+		this.isSearchingOrganisations = true;
+		try {
+			const response = await this.privateService.getOrganizations({ q: this.orgSearch || undefined, refresh: true });
+			this.organisations = response.data.content;
+			this.orgPagination = response.data.pagination;
+		} catch (error) {
+		} finally {
+			this.isSearchingOrganisations = false;
+		}
+	}
+
+	async loadMoreOrganisations() {
+		if (!this.orgPagination?.has_next_page || this.loadingMoreOrganisations) return;
+		this.loadingMoreOrganisations = true;
+		try {
+			const response = await this.privateService.getOrganizations({
+				q: this.orgSearch || undefined,
+				next_page_cursor: this.orgPagination.next_page_cursor,
+				refresh: true
+			});
+			this.organisations = [...(this.organisations || []), ...response.data.content];
+			this.orgPagination = response.data.pagination;
+		} catch (error) {
+		} finally {
+			this.loadingMoreOrganisations = false;
 		}
 	}
 
@@ -221,7 +280,9 @@ export class PrivateComponent implements OnInit {
 		}
 
 		const organisationDetails = JSON.parse(selectedOrganisation);
-		if (this.organisations.find(org => org.uid === organisationDetails.uid)) {
+		// Trust the stored org by uid. With paginated/searched lists the selected org
+		// may not be in the currently loaded page, so we no longer reset to the first org.
+		if (organisationDetails?.uid) {
 			this.privateService.organisationDetails = organisationDetails;
 			this.userOrganization = organisationDetails;
 			await this.checkInstanceAdminAccess();

--- a/web/ui/dashboard/src/app/private/private.component.ts
+++ b/web/ui/dashboard/src/app/private/private.component.ts
@@ -37,6 +37,11 @@ export class PrivateComponent implements OnInit {
 	orgPagination?: { has_next_page: boolean; next_page_cursor: string; total?: number };
 	orgSearch = '';
 	orgSearchEnabled = false;
+	// Tracks whether the user belongs to any organisation at all. Unlike
+	// `organisations` (which becomes the filtered dropdown list and can be empty
+	// during a no-match search), this stays true so the switcher and app shell
+	// don't unmount while searching.
+	hasOrganisations = false;
 	showOrgSearchInput = false;
 	isSearchingOrganisations = false;
 	loadingMoreOrganisations = false;
@@ -161,7 +166,7 @@ export class PrivateComponent implements OnInit {
 	}
 
 	shouldMountAppRouter(): boolean {
-		return !this.isLoadingOrganisations && (Boolean(this.organisations?.length) || this.router.url.startsWith('/user-settings'));
+		return !this.isLoadingOrganisations && (this.hasOrganisations || this.router.url.startsWith('/user-settings'));
 	}
 
 	async getConfiguration() {
@@ -176,6 +181,7 @@ export class PrivateComponent implements OnInit {
 		try {
 			const response = await this.privateService.getOrganizations({ refresh });
 			this.organisations = response.data.content;
+			this.hasOrganisations = !!this.organisations?.length;
 			this.orgPagination = response.data.pagination;
 			// Show the search affordance once the user has more orgs than a single page.
 			if (this.orgPagination?.has_next_page) this.orgSearchEnabled = true;

--- a/web/ui/dashboard/src/app/private/private.service.ts
+++ b/web/ui/dashboard/src/app/private/private.service.ts
@@ -245,18 +245,27 @@ export class PrivateService {
 		return;
 	}
 
-	getOrganizations(requestDetails?: { refresh: boolean }): Promise<HTTP_RESPONSE> {
+	getOrganizations(requestDetails?: { refresh?: boolean; q?: string; next_page_cursor?: string; perPage?: number }): Promise<HTTP_RESPONSE> {
 		return new Promise(async (resolve, reject) => {
-			if (this.organisations && !requestDetails?.refresh) return resolve(this.organisations);
+			const isFirstPage = !requestDetails?.q && !requestDetails?.next_page_cursor;
+			if (this.organisations && !requestDetails?.refresh && isFirstPage) return resolve(this.organisations);
 
 			try {
+				const query: { perPage: number; q?: string; next_page_cursor?: string } = { perPage: requestDetails?.perPage || 20 };
+				if (requestDetails?.q) query.q = requestDetails.q;
+				if (requestDetails?.next_page_cursor) query.next_page_cursor = requestDetails.next_page_cursor;
+
 				const response = await this.http.request({
 					url: `/organisations`,
-					method: 'get'
+					method: 'get',
+					query
 				});
 
-				await this.organisationConfig(response.data?.content);
-				this.organisations = response;
+				// Only the unfiltered first page seeds the cached org selection state.
+				if (isFirstPage) {
+					await this.organisationConfig(response.data?.content);
+					this.organisations = response;
+				}
 				return resolve(response);
 			} catch (error) {
 				return reject(error);

--- a/web/ui/dashboard/src/app/private/private.service.ts
+++ b/web/ui/dashboard/src/app/private/private.service.ts
@@ -214,30 +214,37 @@ export class PrivateService {
 		// First, try to restore user's last selected org from per-user storage.
 		// The list is paginated, so the saved org may not be on this page; trust
 		// it by uid and only swap in the page's copy when present (fresher data).
+		let rejectedOrgUid: string | undefined;
 		if (userId) {
 			const userLastOrg = this.getUserOrg(userId);
 			if (userLastOrg?.uid) {
-				const existingOrg = organisations.find((org: { uid: string }) => org.uid === userLastOrg.uid);
-				this.organisationDetails = existingOrg || userLastOrg;
-				this.setUserOrg(userId, existingOrg || userLastOrg);
-				return;
+				const existingOrg = organisations.find((org: { uid: string }) => org.uid === userLastOrg.uid) || (await this.confirmOrgMembership(userLastOrg));
+				if (existingOrg) {
+					this.organisationDetails = existingOrg;
+					this.setUserOrg(userId, existingOrg);
+					return;
+				}
+				// Saved org was deleted or membership revoked; fall through.
+				rejectedOrgUid = userLastOrg.uid;
 			}
 		}
 
 		// Fallback to current session org if it exists
 		const sessionOrg = this.getOrganisation;
-		if (sessionOrg?.uid) {
-			const existingOrg = organisations.find((org: { uid: string }) => org.uid === sessionOrg.uid);
-			const selectedOrg = existingOrg || sessionOrg;
-			if (userId) {
-				this.setUserOrg(userId, selectedOrg);
-			} else {
-				localStorage.setItem('CONVOY_ORG', JSON.stringify(selectedOrg));
+		if (sessionOrg?.uid && sessionOrg.uid !== rejectedOrgUid) {
+			const existingOrg = organisations.find((org: { uid: string }) => org.uid === sessionOrg.uid) || (await this.confirmOrgMembership(sessionOrg));
+			if (existingOrg) {
+				if (userId) {
+					this.setUserOrg(userId, existingOrg);
+				} else {
+					localStorage.setItem('CONVOY_ORG', JSON.stringify(existingOrg));
+				}
+				return;
 			}
-			return;
+			// Saved org was deleted or membership revoked; fall through.
 		}
 
-		// Default to first org only when there is no stored selection
+		// Default to first org when there is no valid stored selection
 		this.organisationDetails = organisations[0];
 		if (userId) {
 			this.setUserOrg(userId, organisations[0]);
@@ -245,6 +252,24 @@ export class PrivateService {
 			localStorage.setItem('CONVOY_ORG', JSON.stringify(organisations[0]));
 		}
 		return;
+	}
+
+	// Confirms a saved org that is not on the loaded page is still one of the
+	// user's organisations by searching their own org list (the backend search
+	// matches org id exactly). Returns the fresh copy when confirmed, null when
+	// the server says it is gone, and the saved copy on transport errors so a
+	// flaky request cannot switch the active org.
+	private async confirmOrgMembership(savedOrg: ORGANIZATION_DATA): Promise<ORGANIZATION_DATA | null> {
+		try {
+			const response = await this.http.request({
+				url: `/organisations`,
+				method: 'get',
+				query: { perPage: 20, q: savedOrg.uid }
+			});
+			return (response.data?.content || []).find((org: ORGANIZATION_DATA) => org.uid === savedOrg.uid) || null;
+		} catch {
+			return savedOrg;
+		}
 	}
 
 	getOrganizations(requestDetails?: { refresh?: boolean; q?: string; next_page_cursor?: string; perPage?: number }): Promise<HTTP_RESPONSE> {

--- a/web/ui/dashboard/src/app/private/private.service.ts
+++ b/web/ui/dashboard/src/app/private/private.service.ts
@@ -211,31 +211,33 @@ export class PrivateService {
 		const user = this.getUserProfile;
 		const userId = user?.uid;
 
-		// First, try to restore user's last selected org from per-user storage
+		// First, try to restore user's last selected org from per-user storage.
+		// The list is paginated, so the saved org may not be on this page; trust
+		// it by uid and only swap in the page's copy when present (fresher data).
 		if (userId) {
 			const userLastOrg = this.getUserOrg(userId);
-			if (userLastOrg) {
+			if (userLastOrg?.uid) {
 				const existingOrg = organisations.find((org: { uid: string }) => org.uid === userLastOrg.uid);
-				if (existingOrg) {
-					this.organisationDetails = existingOrg;
-					this.setUserOrg(userId, existingOrg);
-					return;
-				}
+				this.organisationDetails = existingOrg || userLastOrg;
+				this.setUserOrg(userId, existingOrg || userLastOrg);
+				return;
 			}
 		}
 
 		// Fallback to current session org if it exists
-		const existingOrg = organisations.find((org: { uid: string }) => org.uid === this.getOrganisation?.uid);
-		if (existingOrg) {
+		const sessionOrg = this.getOrganisation;
+		if (sessionOrg?.uid) {
+			const existingOrg = organisations.find((org: { uid: string }) => org.uid === sessionOrg.uid);
+			const selectedOrg = existingOrg || sessionOrg;
 			if (userId) {
-				this.setUserOrg(userId, existingOrg);
+				this.setUserOrg(userId, selectedOrg);
 			} else {
-				localStorage.setItem('CONVOY_ORG', JSON.stringify(existingOrg));
+				localStorage.setItem('CONVOY_ORG', JSON.stringify(selectedOrg));
 			}
 			return;
 		}
 
-		// Default to first org
+		// Default to first org only when there is no stored selection
 		this.organisationDetails = organisations[0];
 		if (userId) {
 			this.setUserOrg(userId, organisations[0]);


### PR DESCRIPTION
## Summary

Adds an optional name/id search filter and a total count to the user organisations endpoint, so the dashboard org switcher can paginate, search, and show how many organisations a user belongs to. Previously the switcher was capped at the first page (20) with no way to find an org further down the list.

### Backend
- add `Pageable.Search` (populated from `?q=`) and `PaginationData.Total`
- add `CountUserOrganisations` to the org member service, datastore interface, and mock
- filter `FetchUserOrganisationsPaginated` / `CountPrevUserOrganisations` by `name ILIKE` or exact `id` (soft-deleted orgs/members excluded)
- wire the total count into `GetOrganisationsPaged`

### Frontend (dashboard org switcher)
- iconified search that appears only once a second page exists
- debounced typeahead by name or ULID, with infinite "load more"
- show `loaded/total` count in the header
- keep "Add Organization" pinned and always visible (fixes the licensed org-limit lock showing only after loading more)

## Test plan
- [x] `go build ./...`, `go vet`, `gofmt`, `golangci-lint` (touched packages), `ng lint` all clean
- [x] unit tests: 71/71 pass in `internal/organisation_members`, including a new `Test_CountUserOrganisations` (unfiltered, name partial, exact id, paged-filter parity, soft-delete exclusion)
- [x] upgrade-path check: applied this branch's migrations on a restored copy of a v25.9.2 database (55 -> 78 migrations, clean) and verified the search/count queries return correct results (19 unfiltered, 11 for a name prefix, 1 for an exact id, 0 for no match)
- [ ] reviewer: confirm org switcher UX in the dashboard (search icon threshold, count, pinned add button, load more)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes org list filtering, pagination totals, and active-org restoration in the shell; subscription `$in` behavior is intentionally simplified but is a webhook filter edge case.
> 
> **Overview**
> Extends the **user organisations** list API so the dashboard org switcher can paginate past the first 20 orgs, search by name or org ID, and show how many orgs the user belongs to.
> 
> **API:** `?q=` is mapped into `Pageable.Search` (middleware). Paged user-org queries and a new `CountUserOrganisations` use the same filter (case-insensitive name substring or exact `id`; soft-deleted orgs/members excluded). `GetOrganisationsPaged` sets `pagination.total` from that count.
> 
> **Dashboard:** Org dropdown adds debounced search (when a second page exists), infinite “load more”, `loaded/total` in the header, and keeps “Add Organization” visible. Selection no longer resets when the active org isn’t on the loaded page—saved org is trusted by UID with `confirmOrgMembership` via id search.
> 
> **Separate fix:** `pkg/compare` `$in` on array fields uses a linear scan instead of sorting, avoiding panics on mixed-type JSON arrays (#2667).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe74fb974fa69e15966aaf7194ee9d428b2c7d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->