### PR TITLE
fix(compare): prevent panic on mixed-type arrays in $in operator

### DIFF
--- a/pkg/compare/compare.go
+++ b/pkg/compare/compare.go
@@ -239,11 +239,14 @@ func in(payload, filter interface{}) (bool, error) {
 	sort.SliceStable(pCopy, func(i, j int) bool {
 		switch pi := pCopy[i].(type) {
 		case string:
-			return pi < pCopy[j].(string)
+			pj, ok := pCopy[j].(string)
+			return ok && pi < pj
 		case float64:
-			return pi < pCopy[j].(float64)
+			pj, ok := pCopy[j].(float64)
+			return ok && pi < pj
 		case int:
-			return pi < pCopy[j].(int)
+			pj, ok := pCopy[j].(int)
+			return ok && pi < pj
 		}
 
 		return false

--- a/pkg/compare/repro_test.go
+++ b/pkg/compare/repro_test.go
@@ -1,0 +1,24 @@
+package compare
+
+import "testing"
+
+// TestInMixedTypeArrayNoPanic ensures the $in operator does not panic when the
+// payload array field holds mixed JSON types (e.g. a string and a number).
+// Arbitrary webhook payloads can produce such arrays, and previously the sort
+// comparator in `in` did an unchecked type assertion on pCopy[j], panicking.
+func TestInMixedTypeArrayNoPanic(t *testing.T) {
+	payload := map[string]interface{}{
+		"ids": []interface{}{"a", float64(1)},
+	}
+	filter := map[string]interface{}{
+		"ids": map[string]interface{}{"$in": "a"},
+	}
+
+	got, err := Compare(payload, filter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got {
+		t.Fatalf("expected match for \"a\" in mixed array, got false")
+	}
+}


### PR DESCRIPTION
## What's broken

`compare.in()` (the `$in` operator) sorts the payload array with a comparator that type-switches on `pCopy[i]` and then asserts `pCopy[j]` to the same type with an unchecked assertion. A JSON array holding mixed types crashes the matcher with a panic. This is reachable from the live event-delivery path: the incoming webhook event body is flattened and matched against subscription filters (`process_event_creation.go` → `CompareFlattenedPayload` → `Compare`), and `flatten.Flatten` only inspects `v[0]` so a mixed array passes through unsplit. An event whose array field is mixed-type (e.g. `["a", 1]`) plus a subscription using `$in` panics the event-processing worker.

```
panic: interface conversion: interface {} is string, not float64
  pkg/compare/compare.go:244 (sort comparator)
```

## Why it happens

The sort comparator does `pCopy[j].(string)` / `.(float64)` / `.(int)` without the comma-ok form; arrays from `json.Unmarshal` are `[]interface{}` and can be heterogeneous.

## Fix

Use the comma-ok assertion in each branch and treat a type mismatch as not-less-than, so the comparator can't panic.

## Test

`TestInMixedTypeArrayNoPanic` models the production flatten→compare path with a mixed-type array; panics before, passes after.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized comparator change in subscription matching with a regression test; no auth or data-model changes.
> 
> **Overview**
> Fixes a **worker-crashing panic** in the `$in` compare operator when a payload array mixes JSON types (e.g. `["a", 1]`).
> 
> The `in` helper sorts the array before membership checks; the comparator now uses **comma-ok type assertions** on `pCopy[j]` and treats type mismatches as not-less-than instead of panicking on unchecked casts. **`TestInMixedTypeArrayNoPanic`** covers `Compare` with a mixed `ids` array and an `$in` filter on the flatten→match path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 514972ff462639906a8c6f29bdfbed302794d88a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->