### PR TITLE
fix(controlplane): route oauth2 token exchange through netjail dispatcher

### DIFF
--- a/internal/dataplane/worker.go
+++ b/internal/dataplane/worker.go
@@ -299,15 +299,22 @@ func NewWorker(ctx context.Context, opts RuntimeOpts, cfg config.Configuration) 
 	channels["broadcast"] = broadcastCh
 	channels["dynamic"] = dynamicCh
 
-	// Route OAuth2 token exchange through the same netjail dispatcher used for
-	// webhook delivery so the outbound request to authentication.oauth2.url is
-	// subject to the IP allow/block rules when IpRules is enabled. Without this
-	// the token endpoint is an unfiltered outbound request (SSRF bypass).
+	// Route OAuth2 token exchange through a netjail dispatcher so the outbound
+	// request to authentication.oauth2.url is subject to the IP allow/block
+	// rules when IpRules is enabled. Without this the token endpoint is an
+	// unfiltered outbound request (SSRF bypass). A dedicated dispatcher is used
+	// so the token hop always validates TLS, instead of inheriting the webhook
+	// insecure_skip_verify setting.
+	oauth2Dispatcher, err := net.NewOAuth2Dispatcher(opts.Licenser, featureFlag, lo, cfg, caCertTLSCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create oauth2 dispatcher: %w", err)
+	}
+
 	oauth2TokenService := services.NewOAuth2TokenService(
 		opts.Cache,
 		lo,
-		services.WithOAuth2HTTPClient(dispatcher.HTTPClient()),
-		services.WithOAuth2Context(dispatcher.ContextWithRules),
+		services.WithOAuth2HTTPClient(oauth2Dispatcher.HTTPClient()),
+		services.WithOAuth2Context(oauth2Dispatcher.ContextWithRules),
 	)
 
 	eventDeliveryProcessorDeps := task.EventDeliveryProcessorDeps{

--- a/internal/dataplane/worker.go
+++ b/internal/dataplane/worker.go
@@ -299,7 +299,16 @@ func NewWorker(ctx context.Context, opts RuntimeOpts, cfg config.Configuration) 
 	channels["broadcast"] = broadcastCh
 	channels["dynamic"] = dynamicCh
 
-	oauth2TokenService := services.NewOAuth2TokenService(opts.Cache, lo)
+	// Route OAuth2 token exchange through the same netjail dispatcher used for
+	// webhook delivery so the outbound request to authentication.oauth2.url is
+	// subject to the IP allow/block rules when IpRules is enabled. Without this
+	// the token endpoint is an unfiltered outbound request (SSRF bypass).
+	oauth2TokenService := services.NewOAuth2TokenService(
+		opts.Cache,
+		lo,
+		services.WithOAuth2HTTPClient(dispatcher.HTTPClient()),
+		services.WithOAuth2Context(dispatcher.ContextWithRules),
+	)
 
 	eventDeliveryProcessorDeps := task.EventDeliveryProcessorDeps{
 		EndpointRepo:               endpointRepo,

--- a/net/dispatcher.go
+++ b/net/dispatcher.go
@@ -283,6 +283,24 @@ func NewDispatcher(l license.Licenser, ff *fflag.FFlag, options ...DispatcherOpt
 	return d, nil
 }
 
+// NewOAuth2Dispatcher builds a dispatcher for OAuth2 token exchange. It mirrors
+// the webhook dispatcher's SSRF protection (IP allow/block rules) and proxy,
+// but always enforces TLS verification regardless of the webhook
+// `insecure_skip_verify` setting. OAuth2 token endpoints carry client secrets,
+// signed assertions, and access tokens, so their TLS trust must not be weakened
+// by a webhook compatibility flag. Custom CA trust is preserved when licensed.
+func NewOAuth2Dispatcher(l license.Licenser, ff *fflag.FFlag, logger log.Logger, cfg config.Configuration, caCertTLSConfig *tls.Config) (*Dispatcher, error) {
+	return NewDispatcher(
+		l,
+		ff,
+		LoggerOption(logger),
+		ProxyOption(cfg.Server.HTTP.HttpProxy, cfg.Server.HTTP.NoProxy),
+		AllowListOption(cfg.Dispatcher.AllowList),
+		BlockListOption(cfg.Dispatcher.BlockList),
+		TLSConfigOption(false, l, caCertTLSConfig),
+	)
+}
+
 func (d *Dispatcher) HTTPClient() *http.Client {
 	return d.client
 }

--- a/services/create_endpoint.go
+++ b/services/create_endpoint.go
@@ -294,12 +294,17 @@ func (a *CreateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 		// OAuth2 token exchange uses a dedicated dispatcher that keeps the SSRF
 		// allow/block rules but always validates TLS (it must not inherit the
 		// webhook insecure_skip_verify setting, since it carries credentials).
-		oauth2Dispatcher, innerErr := net.NewOAuth2Dispatcher(a.Licenser, a.FeatureFlag, a.Logger, cfg, caCertTLSCfg)
-		if innerErr != nil {
-			return "", innerErr
-		}
+		// Only build it when OAuth2 is configured so non-OAuth2 endpoints do not
+		// pay for an unused dispatcher.
+		var oauth2TokenGetter net.OAuth2TokenGetter
+		if a.E.Authentication != nil && a.E.Authentication.Type == datastore.OAuth2Authentication && a.E.Authentication.OAuth2 != nil {
+			oauth2Dispatcher, innerErr := net.NewOAuth2Dispatcher(a.Licenser, a.FeatureFlag, a.Logger, cfg, caCertTLSCfg)
+			if innerErr != nil {
+				return "", innerErr
+			}
 
-		oauth2TokenGetter := createOAuth2TokenGetter(a.E.Authentication, a.E.URL, "", a.Logger, oauth2Dispatcher)
+			oauth2TokenGetter = createOAuth2TokenGetter(a.E.Authentication, a.E.URL, "", a.Logger, oauth2Dispatcher)
+		}
 
 		pingErr = dispatcher.Ping(ctx, net.PingOptions{
 			Endpoint:          a.E.URL,

--- a/services/create_endpoint.go
+++ b/services/create_endpoint.go
@@ -26,17 +26,19 @@ import (
 )
 
 // createOAuth2TokenGetter creates an OAuth2TokenGetter for ping validation.
-// It uses a noop cache since this is a one-time validation.
-func createOAuth2TokenGetter(auth *models.EndpointAuthentication, endpointURL, existingEndpointID string, logger log.Logger) net.OAuth2TokenGetter {
+// It uses a noop cache since this is a one-time validation. The dispatcher is
+// threaded through so the token exchange request honours the IP allow/block
+// rules, matching the webhook ping.
+func createOAuth2TokenGetter(auth *models.EndpointAuthentication, endpointURL, existingEndpointID string, logger log.Logger, dispatcher *net.Dispatcher) net.OAuth2TokenGetter {
 	if auth == nil || auth.Type != datastore.OAuth2Authentication || auth.OAuth2 == nil {
 		return nil
 	}
 
-	return createOAuth2TokenGetterFromDatastore(auth.OAuth2.Transform(), endpointURL, existingEndpointID, logger)
+	return createOAuth2TokenGetterFromDatastore(auth.OAuth2.Transform(), endpointURL, existingEndpointID, logger, dispatcher)
 }
 
 // createOAuth2TokenGetterFromDatastore creates an OAuth2TokenGetter from a datastore OAuth2 config.
-func createOAuth2TokenGetterFromDatastore(oauth2 *datastore.OAuth2, endpointURL, existingEndpointID string, logger log.Logger) net.OAuth2TokenGetter {
+func createOAuth2TokenGetterFromDatastore(oauth2 *datastore.OAuth2, endpointURL, existingEndpointID string, logger log.Logger, dispatcher *net.Dispatcher) net.OAuth2TokenGetter {
 	if oauth2 == nil {
 		return nil
 	}
@@ -56,7 +58,12 @@ func createOAuth2TokenGetterFromDatastore(oauth2 *datastore.OAuth2, endpointURL,
 	}
 
 	noopCache := ncache.NewNoopCache()
-	oauth2TokenService := NewOAuth2TokenService(noopCache, logger)
+	oauth2TokenService := NewOAuth2TokenService(
+		noopCache,
+		logger,
+		WithOAuth2HTTPClient(dispatcher.HTTPClient()),
+		WithOAuth2Context(dispatcher.ContextWithRules),
+	)
 
 	return func(ctx context.Context) (string, error) {
 		return oauth2TokenService.GetAuthorizationHeader(ctx, tempEndpoint)
@@ -284,7 +291,7 @@ func (a *CreateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 			}
 		}
 
-		oauth2TokenGetter := createOAuth2TokenGetter(a.E.Authentication, a.E.URL, "", a.Logger)
+		oauth2TokenGetter := createOAuth2TokenGetter(a.E.Authentication, a.E.URL, "", a.Logger, dispatcher)
 
 		pingErr = dispatcher.Ping(ctx, net.PingOptions{
 			Endpoint:          a.E.URL,

--- a/services/create_endpoint.go
+++ b/services/create_endpoint.go
@@ -291,7 +291,15 @@ func (a *CreateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 			}
 		}
 
-		oauth2TokenGetter := createOAuth2TokenGetter(a.E.Authentication, a.E.URL, "", a.Logger, dispatcher)
+		// OAuth2 token exchange uses a dedicated dispatcher that keeps the SSRF
+		// allow/block rules but always validates TLS (it must not inherit the
+		// webhook insecure_skip_verify setting, since it carries credentials).
+		oauth2Dispatcher, innerErr := net.NewOAuth2Dispatcher(a.Licenser, a.FeatureFlag, a.Logger, cfg, caCertTLSCfg)
+		if innerErr != nil {
+			return "", innerErr
+		}
+
+		oauth2TokenGetter := createOAuth2TokenGetter(a.E.Authentication, a.E.URL, "", a.Logger, oauth2Dispatcher)
 
 		pingErr = dispatcher.Ping(ctx, net.PingOptions{
 			Endpoint:          a.E.URL,

--- a/services/oauth2_token_service.go
+++ b/services/oauth2_token_service.go
@@ -32,6 +32,7 @@ const (
 	maxTokenCacheTTL          = 1 * time.Hour
 	oauth2TokenCacheKeyPrefix = "oauth2_token:"
 	defaultTokenType          = "Bearer"
+	tokenExchangeTimeout      = 30 * time.Second
 )
 
 // OAuth2TokenResponse represents the response from OAuth2 token endpoint
@@ -189,6 +190,12 @@ func (s *OAuth2TokenService) exchangeToken(ctx context.Context, oauth2 *datastor
 	if s.prepareContext != nil {
 		ctx = s.prepareContext(ctx)
 	}
+
+	// Cap the exchange so a slow tenant-controlled token URL cannot stall the
+	// caller indefinitely. A tighter parent deadline (e.g. the ping timeout)
+	// still wins; this only bounds callers that pass an unbounded context.
+	ctx, cancel := context.WithTimeout(ctx, tokenExchangeTimeout)
+	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "POST", oauth2.URL, strings.NewReader(reqBody.Encode()))
 	if err != nil {

--- a/services/update_endpoint.go
+++ b/services/update_endpoint.go
@@ -126,13 +126,24 @@ func (a *UpdateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 			contentType = *a.E.ContentType
 		}
 
+		// OAuth2 token exchange uses a dedicated dispatcher that keeps the SSRF
+		// allow/block rules but always validates TLS (it must not inherit the
+		// webhook insecure_skip_verify setting, since it carries credentials).
 		var oauth2TokenGetter net.OAuth2TokenGetter
-		if a.E.Authentication != nil && a.E.Authentication.Type == datastore.OAuth2Authentication {
-			// OAuth2 is being set or updated
-			oauth2TokenGetter = createOAuth2TokenGetter(a.E.Authentication, a.E.URL, existingEndpoint.UID, a.Logger, dispatcher)
-		} else if existingEndpoint != nil && existingEndpoint.Authentication != nil && existingEndpoint.Authentication.Type == datastore.OAuth2Authentication {
-			// OAuth2 is not being updated, but endpoint already has OAuth2 - use existing config
-			oauth2TokenGetter = createOAuth2TokenGetterFromDatastore(existingEndpoint.Authentication.OAuth2, a.E.URL, existingEndpoint.UID, a.Logger, dispatcher)
+		if (a.E.Authentication != nil && a.E.Authentication.Type == datastore.OAuth2Authentication) ||
+			(existingEndpoint != nil && existingEndpoint.Authentication != nil && existingEndpoint.Authentication.Type == datastore.OAuth2Authentication) {
+			oauth2Dispatcher, innerErr := net.NewOAuth2Dispatcher(a.Licenser, a.FeatureFlag, a.Logger, cfg, caCertTLSCfg)
+			if innerErr != nil {
+				return "", innerErr
+			}
+
+			if a.E.Authentication != nil && a.E.Authentication.Type == datastore.OAuth2Authentication {
+				// OAuth2 is being set or updated
+				oauth2TokenGetter = createOAuth2TokenGetter(a.E.Authentication, a.E.URL, existingEndpoint.UID, a.Logger, oauth2Dispatcher)
+			} else {
+				// OAuth2 is not being updated, but endpoint already has OAuth2 - use existing config
+				oauth2TokenGetter = createOAuth2TokenGetterFromDatastore(existingEndpoint.Authentication.OAuth2, a.E.URL, existingEndpoint.UID, a.Logger, oauth2Dispatcher)
+			}
 		}
 
 		pingErr = dispatcher.Ping(ctx, net.PingOptions{

--- a/services/update_endpoint.go
+++ b/services/update_endpoint.go
@@ -129,10 +129,10 @@ func (a *UpdateEndpointService) ValidateEndpoint(ctx context.Context, enforceSec
 		var oauth2TokenGetter net.OAuth2TokenGetter
 		if a.E.Authentication != nil && a.E.Authentication.Type == datastore.OAuth2Authentication {
 			// OAuth2 is being set or updated
-			oauth2TokenGetter = createOAuth2TokenGetter(a.E.Authentication, a.E.URL, existingEndpoint.UID, a.Logger)
+			oauth2TokenGetter = createOAuth2TokenGetter(a.E.Authentication, a.E.URL, existingEndpoint.UID, a.Logger, dispatcher)
 		} else if existingEndpoint != nil && existingEndpoint.Authentication != nil && existingEndpoint.Authentication.Type == datastore.OAuth2Authentication {
 			// OAuth2 is not being updated, but endpoint already has OAuth2 - use existing config
-			oauth2TokenGetter = createOAuth2TokenGetterFromDatastore(existingEndpoint.Authentication.OAuth2, a.E.URL, existingEndpoint.UID, a.Logger)
+			oauth2TokenGetter = createOAuth2TokenGetterFromDatastore(existingEndpoint.Authentication.OAuth2, a.E.URL, existingEndpoint.UID, a.Logger, dispatcher)
 		}
 
 		pingErr = dispatcher.Ping(ctx, net.PingOptions{


### PR DESCRIPTION
## Summary

- the webhook-delivery worker built the OAuth2 token service with the default http client, so when `IpRules` was enabled the webhook to `endpoint.url` was filtered by the netjail allow/block rules but the token exchange to `authentication.oauth2.url` was an unfiltered outbound request. that is a SSRF bypass on a separate, tenant-controlled URL. only the test-connection handler wired the token service through the dispatcher.
- wire the worker (`internal/dataplane/worker.go`) and the create/update-time validation token getters (`services/create_endpoint.go`, `services/update_endpoint.go`) through the same netjail dispatcher via `WithOAuth2HTTPClient` + `WithOAuth2Context`, so the token endpoint honours the IP allow/block rules on every live path (event creation, retry, and endpoint create/update validation).
- cap the token exchange with a 30s context timeout in `exchangeToken`, since replacing the service's `http.Client` with the dispatcher client drops the client-level timeout. a tighter parent deadline (e.g. the ping's 10s) still wins; this only bounds callers that pass an unbounded context (the worker).

when `IpRules` is off/unlicensed the allow/block options are no-ops and the dispatcher returns the vanilla client, so OSS behaviour is unchanged.

## Test plan

- [x] `go build ./...` on touched packages
- [x] `gofmt`, `go vet`, `golangci-lint` clean on touched packages
- [x] `go test ./services/ -run 'OAuth2|Token'` (74 pass); existing `oauth2_token_service_test.go` netjail test proves a loopback token URL is blocked (0 hits) when wired through the dispatcher
- [ ] manual: with `IpRules` enabled and a blocklist covering internal ranges, confirm an endpoint whose `oauth2.url` points at a blocked host fails token exchange on delivery

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security-critical fix for outbound SSRF on tenant OAuth2 URLs; behavior changes when IpRules is on (blocked internal token URLs will fail) and TLS verification for token endpoints is stricter than webhook skip-verify.
> 
> **Overview**
> Closes an **SSRF bypass** where webhook delivery and endpoint validation applied netjail IP allow/block rules to `endpoint.url` but OAuth2 token requests to tenant-controlled `authentication.oauth2.url` used an unfiltered default HTTP client.
> 
> **OAuth2 outbound traffic** now goes through a dedicated `NewOAuth2Dispatcher` on the dataplane worker, create/update ping validation, and shared token getters—wired via `WithOAuth2HTTPClient` and `WithOAuth2Context` so token exchange matches webhook SSRF rules when **IpRules** is licensed and enabled. That dispatcher reuses proxy and allow/block lists but **always verifies TLS** (it does not inherit webhook `insecure_skip_verify`), since token hops carry secrets and assertions.
> 
> `exchangeToken` adds a **30s context deadline** so replacing the service client with the dispatcher (no built-in client timeout) cannot hang callers with an unbounded context; stricter parent deadlines (e.g. 10s ping) still apply first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ebe1e2a641ba008029d9917500d4b718a48c51a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->