### PR TITLE
fix(controlplane): address overwatch with env license for self-hosted billing view

### DIFF
--- a/api/handlers/billing_selfhosted.go
+++ b/api/handlers/billing_selfhosted.go
@@ -57,14 +57,11 @@ func (h *BillingHandler) selfHostedLicenseKey(w http.ResponseWriter, r *http.Req
 		return "", false
 	}
 
-	// Overwatch keys the self-hosted org/subscription by the purchased guest key it
-	// issued. Under an env/file override the effective license_key is the env key,
-	// which Overwatch does not know, so address Overwatch with the preserved checkout
-	// key. Fall back to the effective key for legacy rows that predate the column.
-	billingKey := strings.TrimSpace(instanceBilling.CheckoutLicenseKey)
-	if billingKey == "" {
-		billingKey = effectiveKey
-	}
+	// The billing view follows the effective license: an env/file override (e.g. a
+	// payment-link license) is Overwatch-issued, so address Overwatch with it.
+	// Otherwise use the purchased checkout key Overwatch issued at guest checkout,
+	// falling back to the effective key for legacy rows that predate the column.
+	billingKey := config.ResolveBillingLicenseKey(effectiveKey, instanceBilling.CheckoutLicenseKey, instanceBilling.LicenseKeySource)
 
 	return billingKey, true
 }
@@ -128,9 +125,9 @@ func (h *BillingHandler) DeleteSelfHostedSubscription(w http.ResponseWriter, r *
 
 	// Rebuild the local licenser around the effective key. The env/file key and the
 	// db checkout key are both purchased keys; they differ only by source, and
-	// precedence makes the env/file key effective when set. Overwatch is addressed
-	// by the db checkout key it issued (used for the cancel above), but local
-	// entitlements must track whichever key precedence selects.
+	// precedence makes the env/file key effective when set. The cancel above and the
+	// local entitlements both follow that effective key (selfHostedLicenseKey returns
+	// the env key when its source is env, else the db checkout key).
 	effectiveKey, err := h.effectiveInstanceLicenseKey(r.Context())
 	if err != nil {
 		_ = render.Render(w, r, util.NewErrorResponse("failed to refresh license entitlements", http.StatusInternalServerError))

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -724,3 +724,47 @@ func TestResolveCheckoutLicenseKey(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveBillingLicenseKey(t *testing.T) {
+	tests := []struct {
+		name         string
+		effectiveKey string
+		checkoutKey  string
+		source       string
+		expected     string
+	}{
+		{
+			name:         "env override addresses overwatch with the effective key",
+			effectiveKey: "  env-key  ",
+			checkoutKey:  "checkout-key",
+			source:       LicenseSourceEnv,
+			expected:     "env-key",
+		},
+		{
+			name:         "guest checkout uses the purchased checkout key",
+			effectiveKey: "checkout-key",
+			checkoutKey:  "  checkout-key  ",
+			source:       LicenseSourceGuestCheckout,
+			expected:     "checkout-key",
+		},
+		{
+			name:         "legacy guest row without checkout column falls back to effective key",
+			effectiveKey: "  legacy-guest-key  ",
+			checkoutKey:  "",
+			source:       LicenseSourceGuestCheckout,
+			expected:     "legacy-guest-key",
+		},
+		{
+			name:         "env source with blank effective key falls back to checkout key",
+			effectiveKey: "  ",
+			checkoutKey:  "checkout-key",
+			source:       LicenseSourceEnv,
+			expected:     "checkout-key",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, ResolveBillingLicenseKey(tc.effectiveKey, tc.checkoutKey, tc.source))
+		})
+	}
+}

--- a/config/license.go
+++ b/config/license.go
@@ -40,3 +40,23 @@ func ResolveCheckoutLicenseKey(checkoutKey, licenseKey, source string) string {
 	}
 	return ""
 }
+
+// ResolveBillingLicenseKey returns the license key the self-hosted billing view
+// uses to address Overwatch. The billing identity follows the effective license:
+// when the source is an env/file override it wins, since a payment-link license is
+// delivered that way and is Overwatch-issued, so the view must address that org.
+// Otherwise use the purchased checkout key Overwatch issued at guest checkout,
+// falling back to the effective key for legacy rows that predate the checkout
+// column. The checkout key stays persisted either way, so removing the env
+// override still reverts the view to the purchased subscription.
+func ResolveBillingLicenseKey(effectiveKey, checkoutKey, source string) string {
+	if source == LicenseSourceEnv {
+		if e := strings.TrimSpace(effectiveKey); e != "" {
+			return e
+		}
+	}
+	if c := strings.TrimSpace(checkoutKey); c != "" {
+		return c
+	}
+	return strings.TrimSpace(effectiveKey)
+}


### PR DESCRIPTION
When the instance license source is `env`, the self-hosted billing view now addresses Overwatch with the effective env/file key instead of a previously persisted checkout key. The checkout key stays persisted, so removing the env override still reverts to the purchase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which license key identifies the instance to Overwatch for all self-hosted billing operations, including subscription cancel; behavior is covered by new unit tests but wrong resolution could hit the wrong org or fail billing UI.
> 
> **Overview**
> Self-hosted billing API calls (subscription, org, invoices, payment methods, cancel) now pick the Overwatch license key via **`ResolveBillingLicenseKey`**, instead of always preferring the persisted checkout key.
> 
> When **`license_key_source` is `env`**, Overwatch is addressed with the **effective env/file key** (e.g. payment-link licenses). Guest checkout still uses the **purchased checkout key**, with fallbacks for legacy rows missing that column. The checkout key remains stored so clearing the env override reverts billing to the original purchase.
> 
> Comments on subscription cancel were updated to match: upstream cancel and local licenser refresh both follow the key returned from **`selfHostedLicenseKey`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b175908968120d5b4c587aca9b8bce87c1f8119a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->