### PR TITLE
feat(dashboard): add google oauth signup

### DIFF
--- a/web/ui/dashboard/src/app/public/signup/signup.component.html
+++ b/web/ui/dashboard/src/app/public/signup/signup.component.html
@@ -54,13 +54,31 @@
     </button>
 
     <button convoy-button size="sm" type="button" fill="text" class="w-full" (click)="signUpWithSSO()">Sign Up with SSO</button>
+
+    @if (authConfigLoaded && isGoogleOAuthEnabled) {
+      <button convoy-button size="sm" type="button" fill="text" class="w-full mt-12px" (click)="signUpWithGoogle()" [disabled]="isGoogleSigningIn">
+        @if (!isGoogleSigningIn) {
+          <img src="/assets/img/svg/google.svg" alt="Google icon" class="w-16px h-16px inline mr-8px" />
+        }
+        @if (isGoogleSigningIn) {
+          <div class="loading-dots inline mr-8px">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+        }
+        @if (!isGoogleSigningIn) {
+          <span>Sign up with Google</span>
+        }
+        @if (isGoogleSigningIn) {
+          <span>Signing up...</span>
+        }
+      </button>
+    }
   </form>
 </section>
 
 <button convoy-button fill="link" class="mt-34px w-full" (click)="router.navigateByUrl('/login')" size="sm">Log in if you already have an account</button>
-@if (isGoogleOAuthEnabled) {
-  <div class="text-center text-12 text-gray-600 mt-0px">Google sign-in available</div>
-}
 </div>
 
 @if (isFetchingConfig) {

--- a/web/ui/dashboard/src/app/public/signup/signup.component.scss
+++ b/web/ui/dashboard/src/app/public/signup/signup.component.scss
@@ -1,0 +1,37 @@
+.loading-dots {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+
+	span {
+		width: 6px;
+		height: 6px;
+		border-radius: 50%;
+		background-color: currentColor;
+		animation: loading-dots 1.4s ease-in-out infinite both;
+
+		&:nth-child(1) {
+			animation-delay: -0.32s;
+		}
+
+		&:nth-child(2) {
+			animation-delay: -0.16s;
+		}
+
+		&:nth-child(3) {
+			animation-delay: 0s;
+		}
+	}
+}
+
+@keyframes loading-dots {
+	0%, 80%, 100% {
+		transform: scale(0);
+		opacity: 0.5;
+	}
+
+	40% {
+		transform: scale(1);
+		opacity: 1;
+	}
+}

--- a/web/ui/dashboard/src/app/public/signup/signup.component.ts
+++ b/web/ui/dashboard/src/app/public/signup/signup.component.ts
@@ -14,6 +14,10 @@ import {HubspotService} from 'src/app/services/hubspot/hubspot.service';
 import {SignupService} from './signup.service';
 import {LicensesService} from 'src/app/services/licenses/licenses.service';
 import {ConfigService} from 'src/app/services/config/config.service';
+import {GoogleOAuthService} from 'src/app/services/google-oauth/google-oauth.service';
+import {LoginService} from '../login/login.service';
+import {PrivateService} from 'src/app/private/private.service';
+import {GeneralService} from 'src/app/services/general/general.service';
 
 @Component({
     selector: 'convoy-signup',
@@ -26,6 +30,8 @@ export class SignupComponent implements OnInit {
 	disableSignupBtn = false;
 	isFetchingConfig = false;
 	isGoogleOAuthEnabled = false;
+	isGoogleSigningIn = false;
+	authConfigLoaded = false;
 	signupForm: FormGroup = this.formBuilder.group({
 		email: ['', Validators.required],
 		first_name: ['', Validators.required],
@@ -40,7 +46,11 @@ export class SignupComponent implements OnInit {
 		public router: Router,
 		private hubspotService: HubspotService,
 		private licenseService: LicensesService,
-		private configService: ConfigService
+		private configService: ConfigService,
+		private googleOAuthService: GoogleOAuthService,
+		private loginService: LoginService,
+		private privateService: PrivateService,
+		private generalService: GeneralService
 	) {}
 
 	async ngOnInit(): Promise<void> {
@@ -78,6 +88,12 @@ export class SignupComponent implements OnInit {
 			this.isGoogleOAuthEnabled = config.auth?.google_oauth?.enabled || false;
 		} catch (error) {
 			this.isGoogleOAuthEnabled = false;
+		} finally {
+			this.authConfigLoaded = true;
+		}
+
+		if (this.isGoogleOAuthEnabled) {
+			await this.googleOAuthService.initialize();
 		}
 	}
 
@@ -90,6 +106,110 @@ export class SignupComponent implements OnInit {
 			window.open(redirectUrl, '_blank');
 		} catch (error) {
 			throw error;
+		}
+	}
+
+	private clearCachedSession(previousUserId?: string) {
+		localStorage.removeItem('CONVOY_LAST_USER_ID');
+		localStorage.removeItem('CONVOY_AUTH');
+		localStorage.removeItem('CONVOY_AUTH_TOKENS');
+		localStorage.removeItem('CONVOY_ORG');
+		localStorage.removeItem('CONVOY_PROJECT');
+		this.licenseService.clearLicenses();
+
+		if (previousUserId) {
+			this.privateService.clearCache(true, previousUserId);
+		}
+	}
+
+	async signUpWithGoogle() {
+		try {
+			if (!this.isGoogleOAuthEnabled) {
+				this.generalService.showNotification({
+					message: 'Google OAuth is disabled',
+					style: 'error'
+				});
+				return;
+			}
+
+			if (!this.googleOAuthService.isReady()) {
+				this.generalService.showNotification({
+					message: 'Google OAuth not initialized',
+					style: 'error'
+				});
+				return;
+			}
+
+			this.isGoogleSigningIn = true;
+
+			const result = await this.googleOAuthService.signIn();
+			if (!result.credential) return;
+
+			const response = await this.loginService.loginWithGoogleToken(result.credential);
+			if (!response.data) return;
+
+			if (response.data.needs_setup) {
+				this.clearCachedSession(localStorage.getItem('CONVOY_LAST_USER_ID') || undefined);
+				localStorage.setItem('AUTH_TYPE', 'signup');
+				localStorage.setItem('GOOGLE_OAUTH_ID_TOKEN', result.credential);
+				localStorage.setItem('GOOGLE_OAUTH_USER_INFO', JSON.stringify({
+					name: response.data.first_name + ' ' + response.data.last_name,
+					email: response.data.email,
+					picture: response.data.picture
+				}));
+
+				await this.router.navigateByUrl('/google-oauth-setup');
+				return;
+			}
+
+			const lastUserId = localStorage.getItem('CONVOY_LAST_USER_ID');
+			if (!lastUserId || lastUserId !== response.data.uid) {
+				this.clearCachedSession(lastUserId || undefined);
+			}
+
+			localStorage.setItem('CONVOY_LAST_USER_ID', response.data.uid);
+			localStorage.setItem('CONVOY_AUTH', JSON.stringify(response.data));
+			localStorage.setItem('CONVOY_AUTH_TOKENS', JSON.stringify(response.data.token));
+
+			this.generalService.showNotification({
+				message: 'Google signup successful! Welcome.',
+				style: 'success'
+			});
+
+			try {
+				await this.privateService.getOrganizations({ refresh: true });
+			} catch {
+				// Google auth already succeeded; org refresh is best effort and should not surface as signup failure.
+			}
+
+			await this.router.navigateByUrl('/');
+		} catch (error: any) {
+			const rawErrorMessage = typeof error === 'string' ? error : (error?.message || error?.error?.message);
+			let errorMessage = rawErrorMessage || 'Google signup failed';
+
+			if (rawErrorMessage) {
+				if (rawErrorMessage.includes('FedCM') || rawErrorMessage.includes('NetworkError')) {
+					errorMessage = 'Browser blocked authentication. Check browser settings for third-party sign-in.';
+				} else if (rawErrorMessage.includes('prompt was skipped')) {
+					errorMessage = 'Sign-in blocked. Check browser settings for third-party sign-in.';
+				} else if (rawErrorMessage.includes('prompt not displayed')) {
+					errorMessage = 'Sign-in prompt unavailable. Check browser settings.';
+				} else if (rawErrorMessage.includes('cancelled by user') ||
+					rawErrorMessage.includes('was cancelled') ||
+					rawErrorMessage.includes('prompt was dismissed') ||
+					rawErrorMessage.includes('popup_closed')) {
+					return;
+				} else if (rawErrorMessage.includes('access_denied')) {
+					errorMessage = 'Access denied. Please try again.';
+				}
+			}
+
+			this.generalService.showNotification({
+				message: errorMessage,
+				style: 'error'
+			});
+		} finally {
+			this.isGoogleSigningIn = false;
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add the Google OAuth signup action to the signup page when Google OAuth is enabled in auth config.
- Reuse the existing Google token exchange and setup flow for new Google users.
- Clear stale session state on Google setup/user switch and keep org refresh best effort after auth succeeds.

## Test plan
- Bugbot: no bugs
- Security Review: no medium-or-higher issues
- ReadLints: no signup diagnostics
- `npm run build` in `web/ui/dashboard`