### PR TITLE
feat(dashboard): show real billing cycle and consolidate event delivery details

### DIFF
--- a/internal/pkg/billing/models.go
+++ b/internal/pkg/billing/models.go
@@ -85,12 +85,18 @@ type PricingOption struct {
 }
 
 type BillingSubscription struct {
-	ID        string `json:"id,omitempty"`
-	Status    string `json:"status,omitempty"`
-	PlanID    string `json:"plan_id,omitempty"`
-	Plan      *Plan  `json:"plan,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
+	ID     string `json:"id,omitempty"`
+	Status string `json:"status,omitempty"`
+	PlanID string `json:"plan_id,omitempty"`
+	Plan   *Plan  `json:"plan,omitempty"`
+	// Billing cycle as reported by the billing service. ISO8601 strings, empty when there
+	// is no upcoming invoice. Passed through so the dashboard shows the real subscription
+	// period instead of deriving it from the usage month.
+	CurrentPeriodStart string `json:"current_period_start,omitempty"`
+	CurrentPeriodEnd   string `json:"current_period_end,omitempty"`
+	NextInvoiceDate    string `json:"next_invoice_date,omitempty"`
+	CreatedAt          string `json:"created_at,omitempty"`
+	UpdatedAt          string `json:"updated_at,omitempty"`
 }
 
 type Invoice struct {

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.html
@@ -52,146 +52,162 @@
 
   <!-- event delivery details  -->
   @if (!isLoadingDeliveryDetails) {
-    <div class="flex items-center py-16px border-t border-t-new.primary-25">
-      <div class="flex items-center">
-        <div class="pr-30px">
-          <p class="text-neutral-10 text-12 font-light mb-6px">STATUS</p>
-          <convoy-tag [color]="eventDelsDetails?.status || '' | statuscolor">{{ eventDelsDetails?.status }}</convoy-tag>
-        </div>
-        <div class="w-[1px] h-40px bg-new.primary-25"></div>
-      </div>
-      <div class="flex items-center">
-        <div class="px-30px">
-          <p class="text-neutral-10 text-12 font-light mb-6px">EVENT TYPE</p>
-          <convoy-tag color="primary" fill="soft">{{ eventDelsDetails?.event_metadata?.event_type }}</convoy-tag>
-        </div>
-        <div class="w-[1px] h-40px bg-new.primary-25"></div>
-      </div>
-      <div class="flex items-center">
-        @if (!eventDelsDetails?.device_id) {
-          <div class="px-30px">
-            <p class="text-neutral-10 text-12 font-light mb-6px">IP ADDRESS</p>
-            <p class="text-12 font-medium">{{ eventDeliveryAtempt?.ip_address || '-' }}</p>
+    <div class="relative mb-50px">
+      <div #metaStrip (scroll)="onStripScroll()" [style.mask-image]="stripMaskImage" [style.-webkit-mask-image]="stripMaskImage" class="overflow-x-auto no-scrollbar border-t border-b border-t-new.primary-25 border-b-new.primary-25">
+        <div class="flex items-center py-16px w-max">
+        <div class="flex items-center">
+          <div class="pr-30px">
+            <p class="text-neutral-10 text-12 font-light mb-6px">STATUS</p>
+            <convoy-tag [color]="eventDelsDetails?.status || '' | statuscolor">{{ eventDelsDetails?.status }}</convoy-tag>
           </div>
-        }
-        @if (eventDelsDetails?.device_id) {
+          <div class="w-[1px] h-40px bg-new.primary-25"></div>
+        </div>
+        <div class="flex items-center">
           <div class="px-30px">
-            <p class="text-neutral-10 text-12 font-light mb-6px">DEVICE</p>
-            <div class="flex items-center text-12 font-medium">
-              <div>
-                <svg width="16" height="14" class="mr-8px">
-                  <use xlink:href="#cli-icon"></use>
-                </svg>
-              </div>
-              <span class="w-100px whitespace-nowrap overflow-hidden overflow-ellipsis">{{ eventDelsDetails?.device_metadata?.host_name || '-' }}</span>
+            <p class="text-neutral-10 text-12 font-light mb-6px">EVENT TYPE</p>
+            <convoy-tag color="primary" fill="soft">{{ eventDelsDetails?.event_metadata?.event_type }}</convoy-tag>
+          </div>
+          <div class="w-[1px] h-40px bg-new.primary-25"></div>
+        </div>
+        <div class="flex items-center">
+          <div class="px-30px">
+            <p class="text-neutral-10 text-12 font-light mb-6px">EVENT RECEIVED</p>
+            @if (eventDelsDetails?.event_metadata?.created_at) {
+              <convoy-copy-button [text]="formatPreciseTimestamp(eventDelsDetails?.event_metadata?.created_at)" show-icon="false" notificationText="Event received timestamp copied to clipboard">
+                <span class="relative inline-flex text-12 font-medium group" [title]="formatPreciseTimestamp(eventDelsDetails?.event_metadata?.created_at)">
+                  <span>{{ eventDelsDetails?.event_metadata?.created_at | date : 'medium' }}</span>
+                  <span class="pointer-events-none absolute left-1/2 bottom-[calc(100%+8px)] z-50 -translate-x-1/2 whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
+                    {{ formatPreciseTimestamp(eventDelsDetails?.event_metadata?.created_at) }}
+                  </span>
+                </span>
+              </convoy-copy-button>
+            } @else {
+              <p class="text-12 font-medium">-</p>
+            }
+          </div>
+          <div class="w-[1px] h-40px bg-new.primary-25"></div>
+        </div>
+        <div class="flex items-center">
+          <div class="px-30px">
+            <p class="text-neutral-10 text-12 font-light mb-6px">DELIVERY QUEUED</p>
+            @if (eventDelsDetails?.created_at) {
+              <convoy-copy-button [text]="formatPreciseTimestamp(eventDelsDetails?.created_at)" show-icon="false" notificationText="Delivery queued timestamp copied to clipboard">
+                <span class="relative inline-flex text-12 font-medium group" [title]="formatPreciseTimestamp(eventDelsDetails?.created_at)">
+                  <span>{{ eventDelsDetails?.created_at | date : 'medium' }}</span>
+                  <span class="pointer-events-none absolute left-1/2 bottom-[calc(100%+8px)] z-50 -translate-x-1/2 whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
+                    {{ formatPreciseTimestamp(eventDelsDetails?.created_at) }}
+                  </span>
+                </span>
+              </convoy-copy-button>
+            } @else {
+              <p class="text-12 font-medium">-</p>
+            }
+          </div>
+          <div class="w-[1px] h-40px bg-new.primary-25"></div>
+        </div>
+        <div class="flex items-center">
+          <div class="px-30px">
+            <p class="text-neutral-10 text-12 font-light mb-6px">ACKNOWLEDGED</p>
+            @if (eventDelsDetails?.acknowledged_at) {
+              <convoy-copy-button [text]="formatPreciseTimestamp(eventDelsDetails?.acknowledged_at)" show-icon="false" notificationText="Acknowledged timestamp copied to clipboard">
+                <span class="relative inline-flex text-12 font-medium group" [title]="formatPreciseTimestamp(eventDelsDetails?.acknowledged_at)">
+                  <span>{{ eventDelsDetails?.acknowledged_at | date : 'medium' }}</span>
+                  <span class="pointer-events-none absolute left-1/2 bottom-[calc(100%+8px)] z-50 -translate-x-1/2 whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
+                    {{ formatPreciseTimestamp(eventDelsDetails?.acknowledged_at) }}
+                  </span>
+                </span>
+              </convoy-copy-button>
+            } @else {
+              <p class="text-12 font-medium">-</p>
+            }
+          </div>
+          <div class="w-[1px] h-40px bg-new.primary-25"></div>
+        </div>
+        <div class="flex items-center">
+          <div class="px-30px">
+            <p class="text-neutral-10 text-12 font-light mb-6px">LATEST ATTEMPT</p>
+            @if (eventDeliveryAtempt?.created_at) {
+              <convoy-copy-button [text]="formatPreciseTimestamp(eventDeliveryAtempt?.created_at)" show-icon="false" notificationText="Latest attempt timestamp copied to clipboard">
+                <span class="relative inline-flex text-12 font-medium group" [title]="formatPreciseTimestamp(eventDeliveryAtempt?.created_at)">
+                  <span>{{ eventDeliveryAtempt?.created_at | date : 'medium' }}</span>
+                  <span class="pointer-events-none absolute left-1/2 bottom-[calc(100%+8px)] z-50 -translate-x-1/2 whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
+                    {{ formatPreciseTimestamp(eventDeliveryAtempt?.created_at) }}
+                  </span>
+                </span>
+              </convoy-copy-button>
+            } @else {
+              <p class="text-12 font-medium">-</p>
+            }
+          </div>
+          <div class="w-[1px] h-40px bg-new.primary-25"></div>
+        </div>
+        <div class="flex items-center">
+          <div class="px-30px">
+            <p class="text-neutral-10 text-12 font-light mb-6px">LATENCY</p>
+            <p class="text-12 font-medium">{{ formatLatencySeconds(eventDelsDetails?.latency_seconds, eventDelsDetails?.status) }}</p>
+          </div>
+          <div class="w-[1px] h-40px bg-new.primary-25"></div>
+        </div>
+        <div class="flex items-center">
+          @if (!eventDelsDetails?.device_id) {
+            <div class="px-30px">
+              <p class="text-neutral-10 text-12 font-light mb-6px">IP ADDRESS</p>
+              <p class="text-12 font-medium">{{ eventDeliveryAtempt?.ip_address || '-' }}</p>
             </div>
-          </div>
-        }
-        <div class="w-[1px] h-40px bg-new.primary-25"></div>
-      </div>
-      <div class="flex items-center">
-        @if (!eventDelsDetails?.device_id) {
+          }
+          @if (eventDelsDetails?.device_id) {
+            <div class="px-30px">
+              <p class="text-neutral-10 text-12 font-light mb-6px">DEVICE</p>
+              <div class="flex items-center text-12 font-medium">
+                <div>
+                  <svg width="16" height="14" class="mr-8px">
+                    <use xlink:href="#cli-icon"></use>
+                  </svg>
+                </div>
+                <span class="w-100px whitespace-nowrap overflow-hidden overflow-ellipsis">{{ eventDelsDetails?.device_metadata?.host_name || '-' }}</span>
+              </div>
+            </div>
+          }
+          <div class="w-[1px] h-40px bg-new.primary-25"></div>
+        </div>
+        <div class="flex items-center">
+          @if (!eventDelsDetails?.device_id) {
+            <div class="px-30px">
+              <p class="text-neutral-10 text-12 font-light mb-6px">API VERSION</p>
+              <p class="text-12 font-medium">{{ eventDeliveryAtempt?.api_version || '-' }}</p>
+            </div>
+          }
+          <div class="w-[1px] h-40px bg-new.primary-25"></div>
+        </div>
+        <div class="flex items-center">
           <div class="px-30px">
-            <p class="text-neutral-10 text-12 font-light mb-6px">API VERSION</p>
-            <p class="text-12 font-medium">{{ eventDeliveryAtempt?.api_version || '-' }}</p>
+            <p class="text-neutral-10 text-12 font-light mb-6px">IDEMPOTENCY KEY</p>
+            <p class="text-12 font-medium w-150px truncate">{{ eventDelsDetails?.idempotency_key || '-' }}</p>
           </div>
-        }
-        <div class="w-[1px] h-40px bg-new.primary-25"></div>
-      </div>
-      <div class="flex items-center">
-        <div class="px-30px">
-          <p class="text-neutral-10 text-12 font-light mb-6px">IDEMPOTENCY KEY</p>
-          <p class="text-12 font-medium w-150px truncate">{{ eventDelsDetails?.idempotency_key || '-' }}</p>
+          <div class="w-[1px] h-40px bg-new.primary-25"></div>
         </div>
-        <div class="w-[1px] h-40px bg-new.primary-25"></div>
-      </div>
-      <div class="pl-30px">
-        <p class="text-neutral-10 text-12 font-light mb-6px">DESCRIPTION</p>
-        <p class="text-12 font-medium w-150px text-wrap">{{ eventDelsDetails?.description || '-' }}</p>
-      </div>
-    </div>
-  }
-
-  @if (!isLoadingDeliveryDetails) {
-    <div class="flex items-center mb-50px py-16px border-t border-b border-t-neutral-a3 border-b-new.primary-25">
-      <div class="flex items-center">
-        <div class="pr-30px">
-          <p class="text-neutral-10 text-12 font-light mb-6px">EVENT RECEIVED</p>
-          @if (eventDelsDetails?.event_metadata?.created_at) {
-            <convoy-copy-button [text]="formatPreciseTimestamp(eventDelsDetails?.event_metadata?.created_at)" show-icon="false" notificationText="Event received timestamp copied to clipboard">
-              <span class="relative inline-flex text-12 font-medium group" [title]="formatPreciseTimestamp(eventDelsDetails?.event_metadata?.created_at)">
-                <span>{{ eventDelsDetails?.event_metadata?.created_at | date : 'medium' }}</span>
-                <span class="pointer-events-none absolute left-1/2 bottom-[calc(100%+8px)] z-50 -translate-x-1/2 whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
-                  {{ formatPreciseTimestamp(eventDelsDetails?.event_metadata?.created_at) }}
-                </span>
-              </span>
-            </convoy-copy-button>
-          } @else {
-            <p class="text-12 font-medium">-</p>
-          }
-        </div>
-        <div class="w-[1px] h-40px bg-new.primary-25"></div>
-      </div>
-      <div class="flex items-center">
-        <div class="px-30px">
-          <p class="text-neutral-10 text-12 font-light mb-6px">DELIVERY QUEUED</p>
-          @if (eventDelsDetails?.created_at) {
-            <convoy-copy-button [text]="formatPreciseTimestamp(eventDelsDetails?.created_at)" show-icon="false" notificationText="Delivery queued timestamp copied to clipboard">
-              <span class="relative inline-flex text-12 font-medium group" [title]="formatPreciseTimestamp(eventDelsDetails?.created_at)">
-                <span>{{ eventDelsDetails?.created_at | date : 'medium' }}</span>
-                <span class="pointer-events-none absolute left-1/2 bottom-[calc(100%+8px)] z-50 -translate-x-1/2 whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
-                  {{ formatPreciseTimestamp(eventDelsDetails?.created_at) }}
-                </span>
-              </span>
-            </convoy-copy-button>
-          } @else {
-            <p class="text-12 font-medium">-</p>
-          }
-        </div>
-        <div class="w-[1px] h-40px bg-new.primary-25"></div>
-      </div>
-      <div class="flex items-center">
-        <div class="px-30px">
-          <p class="text-neutral-10 text-12 font-light mb-6px">ACKNOWLEDGED</p>
-          @if (eventDelsDetails?.acknowledged_at) {
-            <convoy-copy-button [text]="formatPreciseTimestamp(eventDelsDetails?.acknowledged_at)" show-icon="false" notificationText="Acknowledged timestamp copied to clipboard">
-              <span class="relative inline-flex text-12 font-medium group" [title]="formatPreciseTimestamp(eventDelsDetails?.acknowledged_at)">
-                <span>{{ eventDelsDetails?.acknowledged_at | date : 'medium' }}</span>
-                <span class="pointer-events-none absolute left-1/2 bottom-[calc(100%+8px)] z-50 -translate-x-1/2 whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
-                  {{ formatPreciseTimestamp(eventDelsDetails?.acknowledged_at) }}
-                </span>
-              </span>
-            </convoy-copy-button>
-          } @else {
-            <p class="text-12 font-medium">-</p>
-          }
-        </div>
-        <div class="w-[1px] h-40px bg-new.primary-25"></div>
-      </div>
-      <div class="flex items-center">
-        <div class="px-30px">
-          <p class="text-neutral-10 text-12 font-light mb-6px">LATEST ATTEMPT</p>
-          @if (eventDeliveryAtempt?.created_at) {
-            <convoy-copy-button [text]="formatPreciseTimestamp(eventDeliveryAtempt?.created_at)" show-icon="false" notificationText="Latest attempt timestamp copied to clipboard">
-              <span class="relative inline-flex text-12 font-medium group" [title]="formatPreciseTimestamp(eventDeliveryAtempt?.created_at)">
-                <span>{{ eventDeliveryAtempt?.created_at | date : 'medium' }}</span>
-                <span class="pointer-events-none absolute left-1/2 bottom-[calc(100%+8px)] z-50 -translate-x-1/2 whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
-                  {{ formatPreciseTimestamp(eventDeliveryAtempt?.created_at) }}
-                </span>
-              </span>
-            </convoy-copy-button>
-          } @else {
-            <p class="text-12 font-medium">-</p>
-          }
-        </div>
-        <div class="w-[1px] h-40px bg-new.primary-25"></div>
-      </div>
-      <div class="flex items-center">
-        <div class="px-30px">
-          <p class="text-neutral-10 text-12 font-light mb-6px">LATENCY</p>
-          <p class="text-12 font-medium">{{ formatLatencySeconds(eventDelsDetails?.latency_seconds, eventDelsDetails?.status) }}</p>
+        <div class="flex items-center">
+          <div class="px-30px">
+            <p class="text-neutral-10 text-12 font-light mb-6px">DESCRIPTION</p>
+            <p class="text-12 font-medium w-150px text-wrap">{{ eventDelsDetails?.description || '-' }}</p>
+          </div>
         </div>
       </div>
+      </div>
+      @if (canScrollLeft) {
+        <button type="button" aria-label="Scroll left" (click)="scrollStrip('left')" class="absolute left-0 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center w-[28px] h-[28px] rounded-[50%] bg-white-100 shadow-md border border-new.primary-25">
+          <svg width="20" height="20" class="fill-primary-100">
+            <use xlink:href="#arrow-left-icon"></use>
+          </svg>
+        </button>
+      }
+      @if (canScrollRight) {
+        <button type="button" aria-label="Scroll right" (click)="scrollStrip('right')" class="absolute right-0 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center w-[28px] h-[28px] rounded-[50%] bg-white-100 shadow-md border border-new.primary-25">
+          <svg width="20" height="20" class="fill-primary-100">
+            <use xlink:href="#arrow-right-icon"></use>
+          </svg>
+        </button>
+      }
     </div>
   }
 

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.scss
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.scss
@@ -1,0 +1,2 @@
+// Metadata strip fade is applied as an inline mask in the component (Android-style
+// fading edge), and the scrollbar is hidden via the global .no-scrollbar utility.

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, HostListener, OnInit, Output } from '@angular/core';
+import { AfterViewInit, Component, ElementRef, EventEmitter, HostListener, OnInit, Output, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { EVENT_DELIVERY, EVENT_DELIVERY_ATTEMPT } from 'src/app/models/event.model';
 import { EventDeliveryDetailsService } from './event-delivery-details.service';
@@ -11,8 +11,12 @@ import { EventsService } from '../events.service';
     styleUrls: ['./event-delivery-details.component.scss'],
     standalone: false
 })
-export class EventDeliveryDetailsComponent implements OnInit {
+export class EventDeliveryDetailsComponent implements OnInit, AfterViewInit {
 	@Output('onViewEndpoint') onViewEndpoint = new EventEmitter<any>();
+	@ViewChild('metaStrip') metaStrip?: ElementRef<HTMLDivElement>;
+	canScrollLeft = false;
+	canScrollRight = false;
+	private readonly stripFadeWidth = 64;
 	eventDelsDetails?: EVENT_DELIVERY;
 	eventDeliveryAtempt?: EVENT_DELIVERY_ATTEMPT;
 	eventDeliveryAtempts: EVENT_DELIVERY_ATTEMPT[] = [];
@@ -38,6 +42,10 @@ export class EventDeliveryDetailsComponent implements OnInit {
 		this.getEventDeliveryAttempts(eventDeliveryId);
 	}
 
+	ngAfterViewInit(): void {
+		this.updateStripFade();
+	}
+
 	async getEventDeliveryDetails(id: string) {
 		this.isLoadingDeliveryDetails = true;
 
@@ -45,6 +53,7 @@ export class EventDeliveryDetailsComponent implements OnInit {
 			const response = await this.eventDeliveryDetailsService.getEventDeliveryDetails(id);
 			this.eventDelsDetails = response.data;
 			this.isLoadingDeliveryDetails = false;
+			this.scheduleStripFadeUpdate();
 		} catch (error) {
 			this.isLoadingDeliveryDetails = false;
 		}
@@ -87,6 +96,9 @@ export class EventDeliveryDetailsComponent implements OnInit {
 			this.selectedDeliveryAttempt = this.eventDeliveryAtempt;
 
 			this.isloadingDeliveryAttempts = false;
+			// Attempt data fills LATEST ATTEMPT / IP ADDRESS / API VERSION, so the strip width
+			// can change after this second response; recompute the scroll arrows and fade.
+			this.scheduleStripFadeUpdate();
 		} catch (error) {
 			this.isloadingDeliveryAttempts = false;
 		}
@@ -119,9 +131,49 @@ export class EventDeliveryDetailsComponent implements OnInit {
 		this.screenWidth > 1010 ? (this.shouldRenderSmallSize = false) : (this.shouldRenderSmallSize = true);
 	}
 
+	onStripScroll() {
+		this.updateStripFade();
+	}
+
+	scrollStrip(direction: 'left' | 'right') {
+		const el = this.metaStrip?.nativeElement;
+		if (!el) return;
+
+		const amount = Math.max(el.clientWidth * 0.8, 200);
+		el.scrollBy({ left: direction === 'right' ? amount : -amount, behavior: 'smooth' });
+	}
+
+	private scheduleStripFadeUpdate() {
+		// Recompute once the strip has rendered with the loaded data.
+		setTimeout(() => this.updateStripFade());
+	}
+
+	updateStripFade() {
+		const el = this.metaStrip?.nativeElement;
+		if (!el) {
+			this.canScrollLeft = false;
+			this.canScrollRight = false;
+			return;
+		}
+
+		const maxScroll = el.scrollWidth - el.clientWidth;
+		this.canScrollLeft = el.scrollLeft > 1;
+		this.canScrollRight = el.scrollLeft < maxScroll - 1;
+	}
+
+	// Android-style fading edge: only fade the side that still has content to scroll to,
+	// and leave both edges crisp when the strip fits without scrolling.
+	get stripMaskImage(): string {
+		const fade = this.stripFadeWidth;
+		const leftStop = this.canScrollLeft ? 'transparent 0' : '#000 0';
+		const rightStop = this.canScrollRight ? 'transparent 100%' : '#000 100%';
+		return `linear-gradient(to right, ${leftStop}, #000 ${fade}px, #000 calc(100% - ${fade}px), ${rightStop})`;
+	}
+
 	@HostListener('window:resize')
 	onWindowResize() {
 		this.screenWidth = window.innerWidth;
 		this.checkScreenSize();
+		this.updateStripFade();
 	}
 }

--- a/web/ui/dashboard/src/app/private/pages/settings/billing/billing-overview.service.ts
+++ b/web/ui/dashboard/src/app/private/pages/settings/billing/billing-overview.service.ts
@@ -10,7 +10,7 @@ export interface BillingOverview {
   };
   usage: {
     period: string;
-    daysUntilReset: number;
+    daysUntilReset?: number;
   };
   payment: {
     last4: string;
@@ -73,11 +73,37 @@ export class BillingOverviewService {
       };
     }
 
-    const currentPlan = data.subscription?.plan || { name: 'No plan', price: 0, currency: 'USD' };
+    const subscription = data.subscription;
+    const currentPlan = subscription?.plan || { name: 'No plan', price: 0, currency: 'USD' };
+    // Match the billing page's own notion of an active subscription (an id, or a plan with
+    // an id/name) rather than only the nested plan object. A subscription can carry cycle
+    // fields at the root with the plan omitted; treating that as "no cycle" would wrongly
+    // render "No active cycle" and skip the usage-month fallback below.
+    const hasActiveSubscription = !!(subscription && (subscription.id || subscription.plan?.id || subscription.plan?.name));
 
     const usage = data.usage || { period: this.getCurrentPeriod() };
-    const usagePeriod = this.formatUsagePeriod(usage.period);
-    const daysUntilReset = this.calculateDaysUntilReset(usage.period);
+    // Resolve the period label and the reset countdown from a single source so the two
+    // cards never disagree. Prefer the real billing cycle reported by the billing service
+    // (current_period_start/end + next_invoice_date); only when both the cycle range and a
+    // future next-invoice date are present do we use them together. Otherwise fall back to
+    // the usage-month derivation for both, matching the backend's fail-open behaviour, so we
+    // never render a wrong fixed "month 01 - next month 01" cycle or a period that resets on
+    // an unrelated date. With no subscription there is no cycle, so we show neither.
+    const billingPeriod = this.formatBillingCycle(data.subscription?.current_period_start, data.subscription?.current_period_end);
+    const daysFromCycle = this.daysUntilDate(data.subscription?.next_invoice_date);
+
+    let usagePeriod: string;
+    let daysUntilReset: number | undefined;
+    if (!hasActiveSubscription) {
+      usagePeriod = 'No active cycle';
+      daysUntilReset = undefined;
+    } else if (billingPeriod && daysFromCycle !== null) {
+      usagePeriod = billingPeriod;
+      daysUntilReset = daysFromCycle;
+    } else {
+      usagePeriod = this.formatUsagePeriod(usage.period);
+      daysUntilReset = this.calculateDaysUntilReset(usage.period);
+    }
     // Find the default payment method, or fall back to the first one if no default is set
     const payment = data.payment && data.payment.length > 0 
       ? (data.payment.find((pm: any) => pm.defaulted_at !== null && pm.defaulted_at !== undefined) || data.payment[0])
@@ -97,6 +123,45 @@ export class BillingOverviewService {
         brand: payment.card_type || payment.brand || 'unknown'
       } : null
     };
+  }
+
+  // Formats the provider billing cycle as "May 28 - Jun 28". Returns null when either
+  // bound is missing or unparseable so the caller falls back to the usage-month period.
+  // Includes the year on both bounds when they span different years (e.g. yearly terms),
+  // otherwise "Jun 28 - Jun 28" would render as an identical, confusing range.
+  private formatBillingCycle(startIso?: string, endIso?: string): string | null {
+    if (!startIso || !endIso) return null;
+
+    const start = new Date(startIso);
+    const end = new Date(endIso);
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) return null;
+
+    const withYear = start.getUTCFullYear() !== end.getUTCFullYear();
+    return `${this.formatCycleDay(start, withYear)} - ${this.formatCycleDay(end, withYear)}`;
+  }
+
+  // Billing-cycle boundaries from the billing service are UTC instants (often midnight UTC
+  // on yearly terms). Format them in UTC so a user west of UTC doesn't see the previous
+  // calendar day and disagree with the provider invoice date.
+  private formatCycleDay(date: Date, withYear = false): string {
+    const month = date.toLocaleDateString('en-US', { month: 'short', timeZone: 'UTC' });
+    const day = date.getUTCDate().toString().padStart(2, '0');
+    return withYear ? `${month} ${day}, ${date.getUTCFullYear()}` : `${month} ${day}`;
+  }
+
+  // Whole days from now until the next invoice date. Returns null when the date is missing
+  // or unparseable so the caller falls back to the usage-month reset calculation.
+  private daysUntilDate(iso?: string): number | null {
+    if (!iso) return null;
+
+    const target = new Date(iso);
+    if (isNaN(target.getTime())) return null;
+
+    const diffMs = target.getTime() - Date.now();
+    // A past invoice date means our cached cycle is stale; return null so the caller falls
+    // back to the usage-month reset instead of showing a misleading "Resets in 0 days".
+    if (diffMs < 0) return null;
+    return Math.ceil(diffMs / (1000 * 60 * 60 * 24));
   }
 
   private formatUsagePeriod(period: string): string {


### PR DESCRIPTION
## Summary

Two dashboard improvements:

- **Billing cycle in usage**: surface the real subscription billing cycle (`current_period_start/end` + `next_invoice_date`) instead of a fixed calendar-month "month 01 - next month 01" window, which was wrong for subscriptions anchored mid-month or on yearly terms. The cycle fields are added to `BillingSubscription` so they survive Go unmarshaling. Period label and reset countdown are resolved from one source so the two cards never disagree, cycle bounds are formatted in UTC to match the provider invoice date, the year is shown when bounds span different years (yearly), it falls back to the usage month when cycle data is missing or stale, and shows "No active cycle" only when there is no subscription.

- **Event delivery details strip**: merge the metadata and timeline into a single horizontally scrollable row ordered by lifecycle (status, event type, received, queued, acknowledged, latest attempt, latency, then ip/device, api version, idempotency key, description). The scrollbar is hidden in favor of an Android-style scroll-aware edge fade plus left/right chevron buttons that appear only when there is more content to scroll. Fade and chevrons recompute after both the delivery details and the later attempts response load.

## Test plan

- [ ] Subscribe to a monthly and a yearly plan, confirm the usage period and reset countdown match the provider invoice date (no off-by-a-day, no "Jun 28 - Jun 28").
- [ ] With no subscription, confirm "No active cycle" and no reset countdown.
- [ ] Open an event delivery with many fields and a narrow viewport: confirm horizontal scroll, edge fade, and chevrons appear/disappear correctly, including after attempts load.