### PR TITLE
fix(dashboard): stop portal link crash from undefined portalDetails

### DIFF
--- a/web/ui/dashboard/src/app/portal/endpoints/endpoints.component.html
+++ b/web/ui/dashboard/src/app/portal/endpoints/endpoints.component.html
@@ -10,7 +10,7 @@
         </button>
       }
     </form>
-    @if (portalDetails.can_manage_endpoint && portalDetails.owner_id) {
+    @if (portalDetails?.can_manage_endpoint && portalDetails?.owner_id) {
       <button convoy-button fill="soft" class="py-4px px-10px rounded-8px text-12" (click)="openEndpointForm('create')">
         <img src="/assets/img/add-icon.svg" alt="add icon" class="mr-8px w-12px" />
         Add Endpoint
@@ -63,7 +63,7 @@
               <img src="assets/img/more-icon-vertical.svg" class="h-5" alt="more icon" />
             </button>
             <ul dropdownOptions class="p-10px">
-              @if (portalDetails.can_manage_endpoint) {
+              @if (portalDetails?.can_manage_endpoint) {
                 <li class="mb-10px hover:bg-new.primary-25 transition-all duration-300 rounded-8px">
                   <button convoy-dropdown-option convoy-button size="sm" fill="text" class="w-full !justify-start px-8px py-4px text-neutral-12" color="neutral"
                     (click)="activeEndpoint = endpoint; openEndpointForm('update')">
@@ -74,7 +74,7 @@
                   </button>
                 </li>
               }
-              @if (portalDetails.can_manage_endpoint) {
+              @if (portalDetails?.can_manage_endpoint) {
                 <li class="mb-10px hover:bg-new.primary-25 transition-all duration-300 rounded-8px">
                   <button convoy-dropdown-option convoy-button size="sm" fill="text" class="w-full !justify-start px-8px py-4px text-neutral-12" color="neutral" (click)="activeEndpoint = endpoint; secretDialog.showModal()">
                     <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" class="mr-8px">
@@ -113,7 +113,7 @@
                   Send Test Event
                 </button>
               </li>
-              @if (portalDetails.can_manage_endpoint) {
+              @if (portalDetails?.can_manage_endpoint) {
                 <li class="mb-10px hover:bg-new.primary-25 transition-all duration-300 rounded-8px">
                   <button convoy-dropdown-option convoy-button size="sm" fill="text" class="w-full !justify-start px-8px py-4px text-neutral-12" color="neutral" (click)="toggleEndpoint(i, endpoint)">
                     @if (endpoint.status === 'active') {

--- a/web/ui/dashboard/src/app/portal/endpoints/endpoints.component.ts
+++ b/web/ui/dashboard/src/app/portal/endpoints/endpoints.component.ts
@@ -65,7 +65,7 @@ export class EndpointsComponent implements OnInit {
 	showCreateEndpoint = false;
 	showSubscriptionsList = false;
 	isTogglingEndpoint = false;
-	portalDetails!: PORTAL_LINK;
+	portalDetails?: PORTAL_LINK;
 	fetchedEndpoints?: { content: ENDPOINT[]; pagination?: PAGINATION };
 	displayedEndpoints?: { date: string; content: ENDPOINT[] }[];
 	endpoints: PORTAL_ENDPOINT[] = [];

--- a/web/ui/dashboard/src/app/portal/subscriptions/subscriptions.component.html
+++ b/web/ui/dashboard/src/app/portal/subscriptions/subscriptions.component.html
@@ -10,7 +10,7 @@
         </button>
       }
     </form>
-    @if (portalDetails.can_manage_endpoint && portalDetails.owner_id) {
+    @if (portalDetails?.can_manage_endpoint && portalDetails?.owner_id) {
       <button convoy-button fill="soft" class="py-4px px-10px rounded-8px text-12" (click)="openSubsriptionForm('create')">
         <img src="/assets/img/add-icon.svg" alt="add icon" class="mr-8px w-12px" />
         Add Subscription
@@ -61,7 +61,7 @@
               <img src="assets/img/more-icon-vertical.svg" class="h-5" alt="more icon" />
             </button>
             <ul dropdownOptions class="p-10px">
-              @if (portalDetails.can_manage_endpoint) {
+              @if (portalDetails?.can_manage_endpoint) {
                 <li class="hover:bg-new.primary-25 transition-all duration-300 rounded-8px mb-4px">
                   <button convoy-dropdown-option convoy-button size="sm" fill="text" class="w-full !justify-start px-8px py-4px text-neutral-12" color="neutral" (click)="activeSubscription = subscription; openSubsriptionForm('update')">
                     <svg width="16" height="16" class="mr-8px">

--- a/web/ui/dashboard/src/app/portal/subscriptions/subscriptions.component.ts
+++ b/web/ui/dashboard/src/app/portal/subscriptions/subscriptions.component.ts
@@ -30,7 +30,7 @@ export class SubscriptionsComponent implements OnInit {
 	@ViewChild('deleteDialog', { static: true }) deleteDialog!: ElementRef<HTMLDialogElement>;
 
 	endpointId = this.route.snapshot.queryParams.endpointId;
-	portalDetails!: PORTAL_LINK;
+	portalDetails?: PORTAL_LINK;
 
 	isLoadingSubscriptions = false;
 	isDeletingSubscription = false;


### PR DESCRIPTION
## Summary

Portal links crash on load with `TypeError: Cannot read properties of undefined (reading 'can_manage_endpoint')`, breaking the Endpoints and Subscriptions portal pages.

`portalDetails` is declared with a definite-assignment assertion (`portalDetails!: PORTAL_LINK`) but is populated asynchronously in `getPortalDetails()`. The Angular 21 control-flow migration (#2651) trusted that non-null type and rewrote `portalDetails?.x` to `portalDetails.x` in the two portal templates. At runtime `portalDetails` is `undefined` until the fetch resolves (and stays undefined if it fails, since the error is swallowed), so the bare access throws on the first change-detection pass.

The fix makes the type honest and restores optional chaining only where it is now justified:

- `portalDetails!: PORTAL_LINK` -> `portalDetails?: PORTAL_LINK` in `endpoints` and `subscriptions` portal components.
- `portalDetails?.can_manage_endpoint` / `portalDetails?.owner_id` in the `@if` conditions of both templates.

The type now includes `undefined`, so `?.` is justified (no `NG8107`), the `@if` conditions accept `undefined` (no strict-template error), and the portal renders cleanly before the fetch completes.

## Scope note

I swept all 79 templates touched by the control-flow migration. A blanket `?.` restore is wrong under Angular 21 strict templates: most fields are genuinely non-null (`NG8107`), and re-adding `?.` in guarded conditions or `string`/pipe inputs produces hard `TS` errors. `portalDetails` is the only field where the declared type lied (definite-assignment + async load + unguarded access), so it is the only real regression.

## Test plan

- [x] AOT production build (`ng build`): exit 0, 0 `TS` errors, 0 `NG8107` warnings.
- [x] eslint on both portal components: clean.
- [x] Verified other portal `!` object fields (`eventDeliveries`, `chartData`, `subscription`) are guarded and do not crash.
- [ ] Load a portal link in cloud and confirm the Endpoints and Subscriptions pages render without the console `TypeError`.
