### PR TITLE
fix(controlplane): resolve community enabled projects from db

### DIFF
--- a/internal/pkg/license/service/licenser.go
+++ b/internal/pkg/license/service/licenser.go
@@ -20,6 +20,16 @@ const (
 	communityProjectLimit = 2
 	communityOrgLimit     = 1
 	communityUserLimit    = 1
+
+	// Community mode resolves its enabled-project set from the database so the
+	// API and worker processes agree on which projects are active. A frozen
+	// startup snapshot is per-process, so a project created after a process
+	// started (the worker, typically) would never be enabled there and its
+	// event deliveries would be gated. communityProjectCacheTTL is the steady
+	// refresh interval; communityProjectMissTTL bounds extra refreshes when a
+	// delivery asks about a project not yet in the cached set.
+	communityProjectCacheTTL = 1 * time.Minute
+	communityProjectMissTTL  = 5 * time.Second
 )
 
 // Licenser implements the license.Licenser interface using the license service
@@ -38,10 +48,12 @@ type Licenser struct {
 	projectRepo datastore.ProjectRepository
 
 	// For community mode: track enabled projects
-	mu              sync.RWMutex
-	enabledProjects map[string]bool
-	isCommunity     bool
-	denyLimits      bool
+	mu                    sync.RWMutex
+	enabledProjects       map[string]bool
+	projectsFetchedAt     time.Time
+	lastProjectMutationAt time.Time
+	isCommunity           bool
+	denyLimits            bool
 
 	logger log.Logger
 }
@@ -115,13 +127,14 @@ func newCommunityLicenser(cfg LicenserConfig) (*Licenser, error) {
 	}
 
 	return &Licenser{
-		isCommunity:     true,
-		enabledProjects: enabledProjects,
-		orgRepo:         cfg.OrgRepo,
-		userRepo:        cfg.UserRepo,
-		projectRepo:     cfg.ProjectRepo,
-		entitlements:    make(map[string]EntitlementValue),
-		logger:          cfg.Logger,
+		isCommunity:       true,
+		enabledProjects:   enabledProjects,
+		projectsFetchedAt: time.Now(),
+		orgRepo:           cfg.OrgRepo,
+		userRepo:          cfg.UserRepo,
+		projectRepo:       cfg.ProjectRepo,
+		entitlements:      make(map[string]EntitlementValue),
+		logger:            cfg.Logger,
 	}, nil
 }
 
@@ -573,12 +586,67 @@ func (l *Licenser) FeatureListJSON(ctx context.Context) (json.RawMessage, error)
 }
 
 func (l *Licenser) ProjectEnabled(projectID string) bool {
-	if l.isCommunity {
-		l.mu.RLock()
-		defer l.mu.RUnlock()
-		return l.enabledProjects[projectID]
+	if !l.isCommunity {
+		return true
 	}
-	return true
+
+	l.refreshEnabledProjectsIfStale(projectID)
+
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return l.enabledProjects[projectID]
+}
+
+// refreshEnabledProjectsIfStale reconciles the community enabled-project set
+// with the database. It refreshes when the cached set is older than the TTL, or
+// when projectID is unknown (likely created after this process started) and we
+// have not refreshed within the shorter miss window. This keeps the delivery
+// hot path cheap while still letting the worker pick up newly created projects.
+//
+// Failure policy: if the database read fails we keep the last-known set and do
+// not change any project's enablement. This fails closed (a not-yet-enabled
+// project stays gated until a successful refresh) rather than bypassing the
+// community project limit on a transient DB error.
+func (l *Licenser) refreshEnabledProjectsIfStale(projectID string) {
+	l.mu.RLock()
+	_, present := l.enabledProjects[projectID]
+	age := time.Since(l.projectsFetchedAt)
+	l.mu.RUnlock()
+
+	if age < communityProjectCacheTTL && (present || age < communityProjectMissTTL) {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// startedAt is captured before the read so we can detect an AddEnabledProject
+	// or RemoveEnabledProject that committed while the read was in flight on this
+	// (API) process. The DB read may predate that mutation, so applying its
+	// result would clobber the fresher local state (re-enable a deleted project
+	// or drop a newly created one). When that happens we discard this refresh and
+	// let the next one reconcile.
+	startedAt := time.Now()
+
+	enabled, err := enforceProjectLimit(ctx, l.projectRepo)
+	if err != nil {
+		if l.logger != nil {
+			l.logger.Warnf("failed to refresh community enabled projects, keeping cached set: %v", err)
+		}
+		// Mark the attempt so a failing DB does not trigger a refresh on every
+		// delivery; the miss/TTL windows still apply on the next call.
+		l.mu.Lock()
+		l.projectsFetchedAt = time.Now()
+		l.mu.Unlock()
+		return
+	}
+
+	l.mu.Lock()
+	if !l.lastProjectMutationAt.After(startedAt) {
+		l.enabledProjects = enabled
+	}
+	l.projectsFetchedAt = time.Now()
+	l.mu.Unlock()
 }
 
 func (l *Licenser) AddEnabledProject(projectID string) {
@@ -594,6 +662,9 @@ func (l *Licenser) AddEnabledProject(projectID string) {
 	}
 
 	l.enabledProjects[projectID] = true
+	// Record the mutation so an in-flight DB refresh that predates this create
+	// does not overwrite it with a staler set.
+	l.lastProjectMutationAt = time.Now()
 }
 
 func (l *Licenser) RemoveEnabledProject(projectID string) {
@@ -605,6 +676,9 @@ func (l *Licenser) RemoveEnabledProject(projectID string) {
 	defer l.mu.Unlock()
 
 	delete(l.enabledProjects, projectID)
+	// Record the mutation so an in-flight DB refresh that predates this delete
+	// does not re-enable the removed project.
+	l.lastProjectMutationAt = time.Now()
 }
 
 var ErrLicenseExpired = errors.New("license expired")

--- a/internal/pkg/license/service/licenser_test.go
+++ b/internal/pkg/license/service/licenser_test.go
@@ -3,6 +3,8 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -121,4 +123,142 @@ func (r communityProjectRepo) GetProjectsWithEventsInTheInterval(context.Context
 }
 func (r communityProjectRepo) FillProjectsStatistics(context.Context, *datastore.Project) error {
 	return nil
+}
+
+// mutableProjectRepo lets a test change the set of projects (and force a DB
+// error) after the licenser has been built, simulating projects created in
+// another process and transient database failures.
+type mutableProjectRepo struct {
+	communityProjectRepo
+	mu     sync.Mutex
+	uids   []string
+	err    error
+	onLoad func()
+}
+
+func (r *mutableProjectRepo) set(uids []string, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.uids = uids
+	r.err = err
+}
+
+func (r *mutableProjectRepo) LoadProjects(context.Context, *datastore.ProjectFilter) ([]*datastore.Project, error) {
+	r.mu.Lock()
+	onLoad := r.onLoad
+	err := r.err
+	uids := append([]string(nil), r.uids...)
+	r.mu.Unlock()
+
+	// Simulate a concurrent project mutation that commits while this read is in
+	// flight. Run outside the repo lock so it can take the licenser lock.
+	if onLoad != nil {
+		onLoad()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	projects := make([]*datastore.Project, 0, len(uids))
+	for _, id := range uids {
+		projects = append(projects, &datastore.Project{UID: id})
+	}
+	return projects, nil
+}
+
+func (r *mutableProjectRepo) CountProjects(context.Context) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.err != nil {
+		return 0, r.err
+	}
+	return int64(len(r.uids)), nil
+}
+
+func newCommunityLicenserForTest(t *testing.T, repo datastore.ProjectRepository) *Licenser {
+	t.Helper()
+	l, err := NewLicenser(LicenserConfig{
+		OrgRepo:     communityOrgRepo{},
+		UserRepo:    communityUserRepo{},
+		ProjectRepo: repo,
+	})
+	require.NoError(t, err)
+	require.True(t, l.isCommunity)
+	return l
+}
+
+func (l *Licenser) expireProjectCacheForTest() {
+	l.mu.Lock()
+	l.projectsFetchedAt = time.Now().Add(-2 * communityProjectCacheTTL)
+	l.mu.Unlock()
+}
+
+// TestCommunityProjectEnabledRefreshesFromDB proves the worker picks up a
+// project created after it started. Without the refresh, the per-process
+// snapshot would gate that project's event deliveries forever.
+func TestCommunityProjectEnabledRefreshesFromDB(t *testing.T) {
+	repo := &mutableProjectRepo{uids: []string{"a"}}
+	l := newCommunityLicenserForTest(t, repo)
+
+	require.True(t, l.ProjectEnabled("a"))
+	require.False(t, l.ProjectEnabled("b"))
+
+	// A project is created in another process after this licenser started.
+	repo.set([]string{"a", "b"}, nil)
+
+	// Within the miss window the cached set is reused (no DB refresh yet).
+	require.False(t, l.ProjectEnabled("b"))
+
+	// Once the cache is stale, the next lookup reconciles with the DB.
+	l.expireProjectCacheForTest()
+	require.True(t, l.ProjectEnabled("b"))
+	require.True(t, l.ProjectEnabled("a"))
+}
+
+// TestCommunityProjectEnabledEnforcesLimit proves the downgrade case still
+// holds: with more projects than the community limit, only the allowed subset
+// stays enabled.
+func TestCommunityProjectEnabledEnforcesLimit(t *testing.T) {
+	repo := &mutableProjectRepo{uids: []string{"a", "b", "c"}}
+	l := newCommunityLicenserForTest(t, repo)
+
+	// enforceProjectLimit keeps the last communityProjectLimit projects.
+	require.False(t, l.ProjectEnabled("a"))
+	require.True(t, l.ProjectEnabled("b"))
+	require.True(t, l.ProjectEnabled("c"))
+}
+
+// TestCommunityProjectEnabledKeepsCacheOnRefreshError proves the failure policy:
+// a transient DB error keeps the last-known set and does not enable an unknown
+// project (fail closed), rather than bypassing the project limit.
+func TestCommunityProjectEnabledKeepsCacheOnRefreshError(t *testing.T) {
+	repo := &mutableProjectRepo{uids: []string{"a"}}
+	l := newCommunityLicenserForTest(t, repo)
+	require.True(t, l.ProjectEnabled("a"))
+
+	repo.set([]string{"a"}, errors.New("db down"))
+	l.expireProjectCacheForTest()
+
+	require.True(t, l.ProjectEnabled("a"))
+	require.False(t, l.ProjectEnabled("b"))
+}
+
+// TestCommunityProjectEnabledRefreshDoesNotClobberConcurrentMutation proves a
+// refresh that read the DB before a concurrent AddEnabledProject committed does
+// not overwrite that optimistic mutation. The repo's read returns the stale set
+// (without "b"), but "b" is added during the read, so the refresh is discarded.
+func TestCommunityProjectEnabledRefreshDoesNotClobberConcurrentMutation(t *testing.T) {
+	repo := &mutableProjectRepo{uids: []string{"a"}}
+	l := newCommunityLicenserForTest(t, repo)
+
+	repo.mu.Lock()
+	repo.onLoad = func() { l.AddEnabledProject("b") }
+	repo.mu.Unlock()
+
+	l.expireProjectCacheForTest()
+
+	// The lookup triggers a refresh; the DB read does not include "b", but "b"
+	// is added mid-read. The refresh must not drop it.
+	require.True(t, l.ProjectEnabled("b"))
+	require.True(t, l.ProjectEnabled("a"))
 }


### PR DESCRIPTION
## Summary

Community/OSS instances were gating event delivery with a "this project has been disabled... until you re-subscribe" error even with no license key and well under the 2-project community limit.

Root cause: the community licenser built its enabled-project set once at process startup (`enforceProjectLimit`) and only mutated it in-process via `AddEnabledProject`. The API server and the worker run as separate processes, so a project created after the worker started was never enabled in the worker. The worker's `EnsureProjectEnabled` check in the delivery path then failed for that project.

## What changed

- Community `ProjectEnabled` now resolves the enabled-project set from the database (the shared source of truth) with a short TTL plus a miss-triggered refresh, so the API and worker agree and the worker picks up runtime-created projects.
- A mutation-generation guard prevents an in-flight refresh (whose DB read predates a concurrent create/delete) from clobbering the fresher local state.
- Failure policy: a DB error keeps the last-known set and does not enable unknown projects (fail closed), so a transient DB outage cannot bypass the project limit.
- Over-limit downgrade enforcement (disable all but the allowed subset) is unchanged.

Licensed self-hosted, cloud, and billing-only modes are untouched: `ProjectEnabled` still returns true unconditionally for them.

## Test plan

- [x] `go test -race ./internal/pkg/license/service/` (new tests for refresh-on-staleness, over-limit enforcement, fail-closed on DB error, and the concurrent-mutation guard)
- [x] `go vet` + `golangci-lint` clean on the package
- [x] Bugbot + security review clean