### PR TITLE
ci(infra): skip pubsub, e2e, and go codeql on ui-only changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,8 +22,42 @@ on:
     - cron: '40 17 * * 1'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      has_backend: ${{ steps.filter.outputs.has_backend }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # has_backend is true when ANY changed file is NOT under web/ui/dashboard/**
+      # or docs/**. With predicate-quantifier 'every', a file counts only if it
+      # matches '**' AND none of the negated frontend globs, so a single .go/go.mod/
+      # cmd/** change (or a change to this workflow) marks the set as backend. The Go
+      # analysis is skipped only when has_backend is explicitly 'false', so the gate
+      # is fail-safe; javascript-typescript and actions always run.
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # v3
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            has_backend:
+              - '**'
+              - '!web/ui/dashboard/**'
+              - '!docs/**'
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: changes
+    # Skip only the Go leg on pure UI/docs pull requests; keep javascript-typescript
+    # (the dashboard is TS) and actions analysis running on every PR. push-to-main
+    # and the weekly schedule always run Go so the periodic full-tree scan is never
+    # skipped (paths-filter has no reliable diff base on non-PR events).
+    if: ${{ github.event_name != 'pull_request' || matrix.language != 'go' || needs.changes.outputs.has_backend != 'false' }}
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      has_backend: ${{ steps.filter.outputs.has_backend }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
     steps:
       - name: Check out code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -36,9 +36,7 @@ jobs:
       # has_backend is true when ANY changed file is NOT under web/ui/dashboard/**
       # or docs/**. With predicate-quantifier 'every', a file counts only if it
       # matches '**' AND none of the negated frontend globs, so a single .go/go.mod/
-      # cmd/** change (or a change to this workflow) marks the set as backend. The Go
-      # analysis is skipped only when has_backend is explicitly 'false', so the gate
-      # is fail-safe; javascript-typescript and actions always run.
+      # cmd/** change (or a change to this workflow) marks the set as backend.
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # v3
@@ -50,14 +48,31 @@ jobs:
               - '!web/ui/dashboard/**'
               - '!docs/**'
 
+      # Build the CodeQL language matrix. javascript-typescript (the dashboard is TS)
+      # and actions always run. The Go leg is dropped only on pure UI/docs pull
+      # requests (has_backend == 'false'); push-to-main and the weekly schedule
+      # always include Go so the periodic full-tree scan is never skipped, since
+      # paths-filter has no reliable diff base on non-PR events. This is the only
+      # valid way to skip a single matrix leg, because matrix context is not
+      # available to a job-level if. The gate is fail-safe: any non-'false'
+      # has_backend value keeps Go in the matrix.
+      - name: Build CodeQL language matrix
+        id: matrix
+        env:
+          HAS_BACKEND: ${{ steps.filter.outputs.has_backend }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          all='[{"language":"actions","build-mode":"none"},{"language":"go","build-mode":"autobuild"},{"language":"javascript-typescript","build-mode":"none"}]'
+          ui_only='[{"language":"actions","build-mode":"none"},{"language":"javascript-typescript","build-mode":"none"}]'
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$HAS_BACKEND" = "false" ]; then
+            echo "matrix=$ui_only" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=$all" >> "$GITHUB_OUTPUT"
+          fi
+
   analyze:
     name: Analyze (${{ matrix.language }})
     needs: changes
-    # Skip only the Go leg on pure UI/docs pull requests; keep javascript-typescript
-    # (the dashboard is TS) and actions analysis running on every PR. push-to-main
-    # and the weekly schedule always run Go so the periodic full-tree scan is never
-    # skipped (paths-filter has no reliable diff base on non-PR events).
-    if: ${{ github.event_name != 'pull_request' || matrix.language != 'go' || needs.changes.outputs.has_backend != 'false' }}
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql
     #   - https://gh.io/supported-runners-and-hardware-resources
@@ -77,14 +92,10 @@ jobs:
 
     strategy:
       fail-fast: false
+      # Languages come from the changes job so the Go leg can be dropped on
+      # pure UI/docs PRs. See "Build CodeQL language matrix" above.
       matrix:
-        include:
-        - language: actions
-          build-mode: none
-        - language: go
-          build-mode: autobuild
-        - language: javascript-typescript
-          build-mode: none
+        include: ${{ fromJSON(needs.changes.outputs.matrix) }}
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/docker-smoke-test.yml
+++ b/.github/workflows/docker-smoke-test.yml
@@ -41,18 +41,16 @@ jobs:
   smoke-test:
     name: Docker compose smoke test
     needs: changes
+    if: ${{ needs.changes.outputs.has_backend != 'false' }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        if: ${{ needs.changes.outputs.has_backend != 'false' }}
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Build image from PR
-        if: ${{ needs.changes.outputs.has_backend != 'false' }}
         run: docker build --build-arg VERSION=smoke-test -t convoy:smoke-test -f Dockerfile.dev .
 
       - name: Run smoke test
-        if: ${{ needs.changes.outputs.has_backend != 'false' }}
         run: ./configs/local/smoke-test.sh
         env:
           CONVOY_IMAGE: convoy:smoke-test

--- a/.github/workflows/google-pubsub-tests.yml
+++ b/.github/workflows/google-pubsub-tests.yml
@@ -9,7 +9,37 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      has_backend: ${{ steps.filter.outputs.has_backend }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # has_backend is true when ANY changed file is NOT under web/ui/dashboard/**
+      # or docs/**. With predicate-quantifier 'every', a file counts only if it
+      # matches '**' AND none of the negated frontend globs, so a single .go/go.mod/
+      # cmd/** change (or a change to this workflow) marks the set as backend. This
+      # suite is skipped only when has_backend is explicitly 'false', so the gate is
+      # fail-safe and a mixed UI+backend PR always runs it.
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # v3
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            has_backend:
+              - '**'
+              - '!web/ui/dashboard/**'
+              - '!docs/**'
+
   pubsub-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.has_backend != 'false' }}
     runs-on: ubuntu-latest
     env:
       CONVOY_JWT_SECRET: test-access-secret

--- a/.github/workflows/kafka-pubsub-tests.yml
+++ b/.github/workflows/kafka-pubsub-tests.yml
@@ -9,7 +9,37 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      has_backend: ${{ steps.filter.outputs.has_backend }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # has_backend is true when ANY changed file is NOT under web/ui/dashboard/**
+      # or docs/**. With predicate-quantifier 'every', a file counts only if it
+      # matches '**' AND none of the negated frontend globs, so a single .go/go.mod/
+      # cmd/** change (or a change to this workflow) marks the set as backend. This
+      # suite is skipped only when has_backend is explicitly 'false', so the gate is
+      # fail-safe and a mixed UI+backend PR always runs it.
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # v3
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            has_backend:
+              - '**'
+              - '!web/ui/dashboard/**'
+              - '!docs/**'
+
   pubsub-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.has_backend != 'false' }}
     runs-on: ubuntu-latest
     env:
       CONVOY_JWT_SECRET: test-access-secret

--- a/.github/workflows/rabbitmq-pubsub-tests.yml
+++ b/.github/workflows/rabbitmq-pubsub-tests.yml
@@ -9,7 +9,37 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      has_backend: ${{ steps.filter.outputs.has_backend }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # has_backend is true when ANY changed file is NOT under web/ui/dashboard/**
+      # or docs/**. With predicate-quantifier 'every', a file counts only if it
+      # matches '**' AND none of the negated frontend globs, so a single .go/go.mod/
+      # cmd/** change (or a change to this workflow) marks the set as backend. This
+      # suite is skipped only when has_backend is explicitly 'false', so the gate is
+      # fail-safe and a mixed UI+backend PR always runs it.
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # v3
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            has_backend:
+              - '**'
+              - '!web/ui/dashboard/**'
+              - '!docs/**'
+
   pubsub-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.has_backend != 'false' }}
     runs-on: ubuntu-latest
     env:
       CONVOY_JWT_SECRET: test-access-secret

--- a/.github/workflows/redis-sentinel-e2e-tests.yml
+++ b/.github/workflows/redis-sentinel-e2e-tests.yml
@@ -9,7 +9,37 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      has_backend: ${{ steps.filter.outputs.has_backend }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # has_backend is true when ANY changed file is NOT under web/ui/dashboard/**
+      # or docs/**. With predicate-quantifier 'every', a file counts only if it
+      # matches '**' AND none of the negated frontend globs, so a single .go/go.mod/
+      # cmd/** change (or a change to this workflow) marks the set as backend. This
+      # suite is skipped only when has_backend is explicitly 'false', so the gate is
+      # fail-safe and a mixed UI+backend PR always runs it.
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # v3
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            has_backend:
+              - '**'
+              - '!web/ui/dashboard/**'
+              - '!docs/**'
+
   sentinel-e2e-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.has_backend != 'false' }}
     runs-on: ubuntu-latest
     env:
       CONVOY_JWT_SECRET: test-access-secret

--- a/.github/workflows/sqs-pubsub-tests.yml
+++ b/.github/workflows/sqs-pubsub-tests.yml
@@ -9,7 +9,37 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      has_backend: ${{ steps.filter.outputs.has_backend }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # has_backend is true when ANY changed file is NOT under web/ui/dashboard/**
+      # or docs/**. With predicate-quantifier 'every', a file counts only if it
+      # matches '**' AND none of the negated frontend globs, so a single .go/go.mod/
+      # cmd/** change (or a change to this workflow) marks the set as backend. This
+      # suite is skipped only when has_backend is explicitly 'false', so the gate is
+      # fail-safe and a mixed UI+backend PR always runs it.
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # v3
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            has_backend:
+              - '**'
+              - '!web/ui/dashboard/**'
+              - '!docs/**'
+
   pubsub-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.has_backend != 'false' }}
     runs-on: ubuntu-latest
     env:
       CONVOY_JWT_SECRET: test-access-secret

--- a/.github/workflows/vanilla-e2e-tests.yml
+++ b/.github/workflows/vanilla-e2e-tests.yml
@@ -9,7 +9,37 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      has_backend: ${{ steps.filter.outputs.has_backend }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      # has_backend is true when ANY changed file is NOT under web/ui/dashboard/**
+      # or docs/**. With predicate-quantifier 'every', a file counts only if it
+      # matches '**' AND none of the negated frontend globs, so a single .go/go.mod/
+      # cmd/** change (or a change to this workflow) marks the set as backend. This
+      # suite is skipped only when has_backend is explicitly 'false', so the gate is
+      # fail-safe and a mixed UI+backend PR always runs it.
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@668c092af3649c4b664c54e4b704aa46782f6f7c # v3
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            has_backend:
+              - '**'
+              - '!web/ui/dashboard/**'
+              - '!docs/**'
+
   pubsub-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.has_backend != 'false' }}
     runs-on: ubuntu-latest
     env:
       CONVOY_JWT_SECRET: test-access-secret


### PR DESCRIPTION
## Summary

Extends the UI-only CI fast path so pure dashboard/docs PRs skip the slow backend suites. Adds the same `dorny/paths-filter` `changes` detector (`predicate-quantifier: every`) already used by `linter.yml`, `integration-tests.yml`, and `docker-smoke-test.yml` to:

- `google-pubsub-tests.yml`, `sqs-pubsub-tests.yml`, `kafka-pubsub-tests.yml`, `rabbitmq-pubsub-tests.yml` (`pubsub-tests`)
- `vanilla-e2e-tests.yml` (`pubsub-tests`) and `redis-sentinel-e2e-tests.yml` (`sentinel-e2e-tests`)
- `codeql.yml`: gates only the **Go** matrix leg; `javascript-typescript` and `actions` always run
- `docker-smoke-test.yml`: converted from step-level to job-level skip for consistency

Each heavy job now has `needs: changes` and `if: ${{ needs.changes.outputs.has_backend != 'false' }}`. The gate is **fail-safe**: a job runs unless `has_backend` is explicitly `false`, so any non-frontend file (`.go`, `go.mod`, `cmd/**`, workflow edits) still triggers the full suite, and mixed UI+backend PRs always run backend CI.

CodeQL keeps Go analysis on **push-to-main** and the **weekly schedule** (`github.event_name != 'pull_request'` short-circuits the skip), so the periodic full-tree scan is never skipped where `paths-filter` has no reliable diff base.

Required `Lint` and `test` are untouched (they keep their existing step-level self-skip). `dashboard-build` is untouched and still runs on UI PRs.

## Notes

- This PR edits `.github/workflows/**`, so `has_backend` is `true` for the PR itself; the full suite runs here and proves the YAML. The skip only benefits future pure-UI PRs.
- On UI-only PRs, skipped non-required checks report as skipped (not blocking) and the PR finishes in ~3 min instead of ~30.

## Test plan

- [ ] CI green on this PR (all heavy suites run because workflows changed, proving the YAML).
- [ ] Next pure-dashboard PR shows pubsub/e2e/`Analyze (go)` skipped while `Lint`, `test`, `Analyze (javascript-typescript)`, `dashboard-build`, title check, and AI reviewers still run.