### PR TITLE
fix(dashboard): allow instance admins to manage early adopter features

### DIFF
--- a/web/ui/dashboard/src/app/private/pages/settings/early-adopter-features/early-adopter-features.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/settings/early-adopter-features/early-adopter-features.component.ts
@@ -41,7 +41,9 @@ export class EarlyAdopterFeaturesComponent implements OnInit {
 		}
 
 		const userRole = await this.rbacService.getUserRole();
-		this.canManage = userRole === 'ORGANISATION_ADMIN';
+		// Instance admins are a superset of organisation admins (see RbacService.userPermission),
+		// so they must also be able to manage early adopter features.
+		this.canManage = userRole === 'ORGANISATION_ADMIN' || userRole === 'INSTANCE_ADMIN';
 		await this.getEarlyAdopterFeatures();
 	}
 


### PR DESCRIPTION
## Summary

- The Early Adopter Features settings panel gated its toggles on `canManage = userRole === 'ORGANISATION_ADMIN'`. That fit the cloud model but excluded self-hosted **instance admins** (the default superuser maps to `INSTANCE_ADMIN` in `RbacService.mapRole`).
- Result: a self-hosted superuser could see the licensed features (e.g. Endpoint URL Templates) but `toggleFeature` early-returned on `!canManage`, so none could be enabled. The backend already permits it (`PUT /organisations/{orgID}/feature-flags` succeeds for instance admins).
- Fix: allow `INSTANCE_ADMIN` as well as `ORGANISATION_ADMIN`. Instance admin is a superset of organisation admin everywhere else (`RbacService.userPermission` concats org-admin perms), and an instance admin always has an org, so this is consistent.

## Test plan

- [ ] Self-hosted, logged in as the default superuser (`INSTANCE_ADMIN`): Org Settings -> Early Adopter Features toggles are enabled and persist when a licensed feature is turned on.
- [ ] Cloud `ORGANISATION_ADMIN`: behaviour unchanged, toggles still work.
- [ ] Non-admin roles: toggles remain disabled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single client-side permission check aligned with existing RBAC; no auth, data, or API changes.
> 
> **Overview**
> **Early Adopter Features** settings now treat **`INSTANCE_ADMIN`** the same as **`ORGANISATION_ADMIN`** for **`canManage`**, so self-hosted superusers can use the toggles instead of hitting the existing **`toggleFeature`** guard when **`canManage`** was false.
> 
> The change is only in **`ngOnInit`**: **`canManage`** is set when the role is either admin type, with a short comment pointing at **`RbacService.userPermission`** (instance admin already inherits org-admin capabilities). No API or template changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2dc8e044ecba7f9fffa51cacc2d4c9dedfea738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->