### PR TITLE
fix(dashboard): mobile responsiveness across pages, plus service nil-logger panic fix

### DIFF
--- a/api/handlers/auth.go
+++ b/api/handlers/auth.go
@@ -282,6 +282,7 @@ func (h *Handler) RefreshToken(w http.ResponseWriter, r *http.Request) {
 		UserRepo: users.New(h.A.Logger, h.A.DB),
 		JWT:      jwt.NewJwt(&configuration.Auth.Jwt, h.A.Cache),
 		Data:     &refreshToken,
+		Logger:   h.A.Logger,
 	}
 
 	token, err := rf.Run(r.Context())
@@ -313,6 +314,7 @@ func (h *Handler) LogoutUser(w http.ResponseWriter, r *http.Request) {
 		UserRepo: users.New(h.A.Logger, h.A.DB),
 		JWT:      jwt.NewJwt(&configuration.Auth.Jwt, h.A.Cache),
 		Token:    auth.Token,
+		Logger:   h.A.Logger,
 	}
 
 	err = lg.Run(r.Context())

--- a/api/handlers/configuration.go
+++ b/api/handlers/configuration.go
@@ -94,6 +94,7 @@ func (h *Handler) UpdateConfiguration(w http.ResponseWriter, r *http.Request) {
 	uc := services.UpdateConfigService{
 		ConfigRepo: h.A.ConfigRepo,
 		Config:     &newConfig,
+		Logger:     h.A.Logger,
 	}
 
 	configuration, err := uc.Run(r.Context())

--- a/api/handlers/endpoint.go
+++ b/api/handlers/endpoint.go
@@ -527,6 +527,7 @@ func (h *Handler) ExpireSecret(w http.ResponseWriter, r *http.Request) {
 		S:            e,
 		Endpoint:     endpoint,
 		Project:      project,
+		Logger:       h.A.Logger,
 	}
 
 	endpoint, err = xs.Run(r.Context())
@@ -579,6 +580,7 @@ func (h *Handler) PauseEndpoint(w http.ResponseWriter, r *http.Request) {
 		EndpointRepo: endpointsvc.New(h.A.Logger, h.A.DB),
 		ProjectID:    project.UID,
 		EndpointId:   endpointID,
+		Logger:       h.A.Logger,
 	}
 
 	endpoint, err := ps.Run(r.Context())
@@ -642,6 +644,7 @@ func (h *Handler) ActivateEndpoint(w http.ResponseWriter, r *http.Request) {
 		EndpointRepo: endpointsvc.New(h.A.Logger, h.A.DB),
 		ProjectID:    project.UID,
 		EndpointId:   chi.URLParam(r, "endpointID"),
+		Logger:       h.A.Logger,
 	}
 
 	endpoint, err := aes.Run(r.Context())

--- a/api/handlers/event.go
+++ b/api/handlers/event.go
@@ -148,6 +148,7 @@ func (h *Handler) CreateBroadcastEvent(w http.ResponseWriter, r *http.Request) {
 		Queue:          h.A.Queue,
 		BroadcastEvent: &newMessage,
 		Project:        project,
+		Logger:         h.A.Logger,
 	}
 
 	err = cbe.Run(r.Context())
@@ -287,6 +288,7 @@ func (h *Handler) CreateDynamicEvent(w http.ResponseWriter, r *http.Request) {
 		Queue:        h.A.Queue,
 		DynamicEvent: &newMessage,
 		Project:      project,
+		Logger:       h.A.Logger,
 	}
 
 	err = cde.Run(r.Context())

--- a/api/handlers/event_delivery.go
+++ b/api/handlers/event_delivery.go
@@ -88,6 +88,7 @@ func (h *Handler) ResendEventDelivery(w http.ResponseWriter, r *http.Request) {
 		Queue:             h.A.Queue,
 		EventDelivery:     eventDelivery,
 		Project:           project,
+		Logger:            h.A.Logger,
 	}
 
 	err = fr.Run(r.Context())
@@ -168,6 +169,7 @@ func (h *Handler) BatchRetryEventDelivery(w http.ResponseWriter, r *http.Request
 		Queue:             h.A.Queue,
 		Filter:            data.Filter,
 		ProjectID:         project.UID,
+		Logger:            h.A.Logger,
 	}
 
 	err = br.Run(r.Context())
@@ -248,6 +250,7 @@ func (h *Handler) ForceResendEventDeliveries(w http.ResponseWriter, r *http.Requ
 		Queue:             h.A.Queue,
 		IDs:               eventDeliveryIDs.IDs,
 		Project:           project,
+		Logger:            h.A.Logger,
 	}
 
 	successes, failures, err := fr.Run(r.Context())

--- a/api/handlers/meta_event.go
+++ b/api/handlers/meta_event.go
@@ -102,7 +102,7 @@ func (h *Handler) ResendMetaEvent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	metaEventRepo := meta_events.New(h.A.Logger, h.A.DB)
-	metaEventService := &services.MetaEventService{Queue: h.A.Queue, MetaEventRepo: metaEventRepo}
+	metaEventService := &services.MetaEventService{Queue: h.A.Queue, MetaEventRepo: metaEventRepo, Logger: h.A.Logger}
 	err = metaEventService.Run(r.Context(), metaEvent)
 	if err != nil {
 		_ = render.Render(w, r, util.NewServiceErrResponse(err))

--- a/api/handlers/organisation.go
+++ b/api/handlers/organisation.go
@@ -149,6 +149,7 @@ func (h *Handler) UpdateOrganisation(w http.ResponseWriter, r *http.Request) {
 		OrgMemberRepo: organisation_members.New(h.A.Logger, h.A.DB),
 		Org:           org,
 		Update:        &orgUpdate,
+		Logger:        h.A.Logger,
 	}
 
 	org, err = us.Run(r.Context())

--- a/api/handlers/organisation_invite.go
+++ b/api/handlers/organisation_invite.go
@@ -61,6 +61,7 @@ func (h *Handler) InviteUserToOrganisation(w http.ResponseWriter, r *http.Reques
 		Role:         newIV.Role,
 		User:         user,
 		Organisation: org,
+		Logger:       h.A.Logger,
 	}
 
 	iv, err := inviteService.Run(r.Context())
@@ -141,6 +142,7 @@ func (h *Handler) FindUserByInviteToken(w http.ResponseWriter, r *http.Request) 
 		OrgRepo:    organisations.New(h.A.Logger, h.A.DB),
 		UserRepo:   users.New(h.A.Logger, h.A.DB),
 		Token:      token,
+		Logger:     h.A.Logger,
 	}
 
 	user, iv, err := fub.Run(r.Context())
@@ -186,6 +188,7 @@ func (h *Handler) ResendOrganizationInvite(w http.ResponseWriter, r *http.Reques
 		InviteID:     chi.URLParam(r, "inviteID"),
 		User:         user,
 		Organisation: org,
+		Logger:       h.A.Logger,
 	}
 
 	_, err = rom.Run(r.Context())
@@ -214,6 +217,7 @@ func (h *Handler) CancelOrganizationInvite(w http.ResponseWriter, r *http.Reques
 		Queue:      h.A.Queue,
 		InviteRepo: organisation_invites.New(h.A.Logger, h.A.DB),
 		InviteID:   chi.URLParam(r, "inviteID"),
+		Logger:     h.A.Logger,
 	}
 
 	iv, err := cancelInvite.Run(r.Context())

--- a/api/handlers/security.go
+++ b/api/handlers/security.go
@@ -38,6 +38,7 @@ func (h *Handler) CreatePersonalAPIKey(w http.ResponseWriter, r *http.Request) {
 		APIKeyRepo:  api_keys.New(h.A.Logger, h.A.DB),
 		User:        user,
 		NewApiKey:   &newApiKey,
+		Logger:      h.A.Logger,
 	}
 
 	apiKey, keyString, err := cpk.Run(r.Context())
@@ -79,6 +80,7 @@ func (h *Handler) RevokePersonalAPIKey(w http.ResponseWriter, r *http.Request) {
 		APIKeyRepo:  api_keys.New(h.A.Logger, h.A.DB),
 		UID:         chi.URLParam(r, "keyID"),
 		User:        user,
+		Logger:      h.A.Logger,
 	}
 
 	err := rvk.Run(r.Context())
@@ -114,6 +116,7 @@ func (h *Handler) RegenerateProjectAPIKey(w http.ResponseWriter, r *http.Request
 		APIKeyRepo:  api_keys.New(h.A.Logger, h.A.DB),
 		Project:     project,
 		Member:      member,
+		Logger:      h.A.Logger,
 	}
 
 	apiKey, keyString, err := rgp.Run(r.Context())

--- a/api/handlers/source.go
+++ b/api/handlers/source.go
@@ -55,6 +55,7 @@ func (h *Handler) CreateSource(w http.ResponseWriter, r *http.Request) {
 		SourceRepo: sources.New(h.A.Logger, h.A.DB),
 		NewSource:  &newSource,
 		Project:    project,
+		Logger:     h.A.Logger,
 	}
 
 	source, err := cs.Run(r.Context())
@@ -183,6 +184,7 @@ func (h *Handler) UpdateSource(w http.ResponseWriter, r *http.Request) {
 		Project:      project,
 		SourceUpdate: &sourceUpdate,
 		Source:       source,
+		Logger:       h.A.Logger,
 	}
 
 	source, err = us.Run(r.Context())

--- a/api/handlers/subscription.go
+++ b/api/handlers/subscription.go
@@ -386,6 +386,7 @@ func (h *Handler) UpdateSubscription(w http.ResponseWriter, r *http.Request) {
 		ProjectId:      project.UID,
 		SubscriptionId: chi.URLParam(r, "subscriptionID"),
 		Update:         &update,
+		Logger:         h.A.Logger,
 	}
 
 	sub, err := us.Run(r.Context())

--- a/api/handlers/user.go
+++ b/api/handlers/user.go
@@ -95,6 +95,7 @@ func (h *Handler) ResendVerificationEmail(w http.ResponseWriter, r *http.Request
 		Queue:    h.A.Queue,
 		BaseURL:  baseUrl,
 		User:     user,
+		Logger:   h.A.Logger,
 	}
 
 	err = rs.Run(r.Context())
@@ -142,6 +143,7 @@ func (h *Handler) UpdateUser(w http.ResponseWriter, r *http.Request) {
 		UserRepo: users.New(h.A.Logger, h.A.DB),
 		Data:     &userUpdate,
 		User:     user,
+		Logger:   h.A.Logger,
 	}
 
 	user, err = u.Run(r.Context())
@@ -179,6 +181,7 @@ func (h *Handler) UpdatePassword(w http.ResponseWriter, r *http.Request) {
 		UserRepo: users.New(h.A.Logger, h.A.DB),
 		Data:     &updatePassword,
 		User:     user,
+		Logger:   h.A.Logger,
 	}
 
 	user, err = up.Run(r.Context())
@@ -221,6 +224,7 @@ func (h *Handler) ForgotPassword(w http.ResponseWriter, r *http.Request) {
 		Queue:    h.A.Queue,
 		BaseURL:  baseUrl,
 		Data:     &forgotPassword,
+		Logger:   h.A.Logger,
 	}
 
 	_ = gp.Run(r.Context())
@@ -231,6 +235,7 @@ func (h *Handler) VerifyEmail(w http.ResponseWriter, r *http.Request) {
 	ve := services.VerifyEmailService{
 		UserRepo: users.New(h.A.Logger, h.A.DB),
 		Token:    r.URL.Query().Get("token"),
+		Logger:   h.A.Logger,
 	}
 
 	err := ve.Run(r.Context())
@@ -262,6 +267,7 @@ func (h *Handler) ResetPassword(w http.ResponseWriter, r *http.Request) {
 		UserRepo: users.New(h.A.Logger, h.A.DB),
 		Token:    token,
 		Data:     &resetPassword,
+		Logger:   h.A.Logger,
 	}
 
 	user, err := rs.Run(r.Context())

--- a/services/project_service.go
+++ b/services/project_service.go
@@ -122,6 +122,7 @@ func (ps *ProjectService) CreateProject(ctx context.Context, newProject *models.
 		APIKeyRepo:  ps.ApiKeyRepo,
 		Member:      member,
 		NewApiKey:   newAPIKey,
+		Logger:      ps.Logger,
 	}
 
 	apiKey, keyString, err := cak.Run(ctx)

--- a/web/ui/dashboard/src/app/components/button/button.component.ts
+++ b/web/ui/dashboard/src/app/components/button/button.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core
 
 @Component({
     selector: 'convoy-button, [convoy-button]',
-    host: { class: 'flex items-center justify-center disabled:opacity-50 cursor-pointer', '[class]': 'classes' },
+    host: { class: 'flex items-center justify-center whitespace-nowrap disabled:opacity-50 cursor-pointer', '[class]': 'classes' },
     imports: [],
     templateUrl: './button.component.html',
     styleUrls: ['./button.component.scss'],

--- a/web/ui/dashboard/src/app/private/components/create-portal-link/create-portal-link.component.html
+++ b/web/ui/dashboard/src/app/private/components/create-portal-link/create-portal-link.component.html
@@ -2,7 +2,7 @@
   <h2 class="font-semibold text-14 capitalize">Portal Link</h2>
 </div>
 
-<div class="max-w-[770px] m-auto">
+<div class="max-w-[770px] m-auto desktop:px-24px">
   <h2 class="font-semibold mb-8px mt-30px">{{ action === 'update' ? 'Update' : 'Create' }} Portal Link</h2>
   <p class="text-neutral-10 font-normal text-14 max-w-max">A portal link is a dashboard for your for your
   customers to view and debug their webhooks sent from you.</p>

--- a/web/ui/dashboard/src/app/private/components/create-project-component/create-project-component.component.html
+++ b/web/ui/dashboard/src/app/private/components/create-project-component/create-project-component.component.html
@@ -1,5 +1,5 @@
 <form [formGroup]="projectForm" (submit)="action === 'update' ? updateProject() : createProject()" disabled id="project-form">
-  <div class="mt-24px flex gap-100px" [class]="action !== 'update' ? 'rounded-8px p-24px my-24px block border border-new.primary-50' : ''">
+  <div class="mt-24px flex flex-col md:flex-row gap-24px md:gap-100px" [class]="action !== 'update' ? 'rounded-8px p-24px my-24px block border border-new.primary-50' : ''">
     @if (action === 'update') {
       <div class="min-w-[170px]">
         <h3 class="mb-24px text-12 text-neutral-12 font-semibold">Project Settings</h3>
@@ -32,7 +32,7 @@
         </convoy-input-field>
         @if (action !== 'update') {
           <h3 class="mt-24px mb-16px font-medium text-14">Project type</h3>
-          <div class="project-types grid grid-cols-2 gap-24px">
+          <div class="project-types grid grid-cols-2 mobile:grid-cols-1 gap-24px">
             <convoy-radio formControlName="type" description="Create an incoming webhooks project to proxy events from third-party providers to your endpoints" label="Incoming webhooks" _name="type" value="incoming" _id="incoming"></convoy-radio>
             <convoy-radio formControlName="type" description="Create an outgoing webhooks project to publish events to your customer-provided endpoints" label="Outgoing webhooks" _name="type" value="outgoing" _id="outgoing"></convoy-radio>
           </div>
@@ -58,7 +58,7 @@
                     </svg>
                   </button>
                 </div>
-                <div formGroupName="signature" class="mb-24px" [ngClass]="{ 'grid grid-cols-2 gap-x-24px': action === 'create' }">
+                <div formGroupName="signature" class="mb-24px" [ngClass]="{ 'grid grid-cols-2 mobile:grid-cols-1 gap-x-24px': action === 'create' }">
                   <convoy-input-field>
                     <label for="header" required="true" convoy-label>Header</label>
                     <input type="text" id="header" convoy-input autocomplete="header" formControlName="header" placeholder="X-Convoy-Signature" />
@@ -100,7 +100,7 @@
                     </svg>
                   </button>
                 </div>
-                <div class="grid grid-cols-2 gap-x-24px" formGroupName="strategy">
+                <div class="grid grid-cols-2 mobile:grid-cols-1 gap-x-24px" formGroupName="strategy">
                   <convoy-select
                     label="Mechanism"
                     name="type"
@@ -142,7 +142,7 @@
                     </svg>
                   </button>
                 </div>
-                <div class="grid grid-cols-2 gap-24px" formGroupName="ratelimit">
+                <div class="grid grid-cols-2 mobile:grid-cols-1 gap-24px" formGroupName="ratelimit">
                   <convoy-input-field className="mb-0">
                     <label for="rate-limit-duration" convoy-label>Duration</label>
                     <div class="relative">
@@ -222,7 +222,7 @@
           <div class="flex justify-between items-start">
             <div class="max-w-[500px]">
               <h3 class="font-semibold mb-8px text-12">Disable Failing Endpoint</h3>
-              <p class="text-12 text-neutral-11 mt-10px w-[460px]">Toggling this configuration on will automatically disable all endpoints in this project with failure response untill request to them are manually retried</p>
+              <p class="text-12 text-neutral-11 mt-10px w-full max-w-[460px]">Toggling this configuration on will automatically disable all endpoints in this project with failure response untill request to them are manually retried</p>
             </div>
             <convoy-toggle name="disable_endpoint" formControlName="disable_endpoint" (onChange)="confirmToggleAction($event, 'endpoints')"></convoy-toggle>
           </div>
@@ -230,7 +230,7 @@
           <div class="flex justify-between items-start" formGroupName="ssl">
             <div class="max-w-[500px]">
               <h3 class="font-semibold mb-8px text-12">Allow Only HTTPS Secure Endpoints</h3>
-              <p class="text-12 text-neutral-11 mt-10px w-[460px]">Toggling this will allow only HTTPS secure endpoints, this allows only TLS connections to your endpoints.</p>
+              <p class="text-12 text-neutral-11 mt-10px w-full max-w-[460px]">Toggling this will allow only HTTPS secure endpoints, this allows only TLS connections to your endpoints.</p>
             </div>
             <convoy-toggle name="enforce_secure_endpoints" formControlName="enforce_secure_endpoints" (onChange)="confirmTLSToggleAction($event)"></convoy-toggle>
           </div>
@@ -298,7 +298,7 @@
             @if (projectForm.get('config.meta_event.is_enabled')?.value) {
               <hr class="border-neutral-5 mb-24px" />
               <h4 class="text-12 font-semibold mb-24px" [ngClass]="{ 'opacity-60 pointer-events-none': !projectForm.get('config.meta_event.is_enabled')?.value }">Meta Events Configurations</h4>
-              <div class="grid grid-cols-2 gap-24px">
+              <div class="grid grid-cols-2 mobile:grid-cols-1 gap-24px">
                 <convoy-input-field>
                   <label for="url" convoy-label required="true">Webhook URL</label>
                   <input type="url" id="url" convoy-input autocomplete="url" formControlName="url" placeholder="Enter URL" />
@@ -365,7 +365,7 @@
           </div>
         }
         @if (circuitBreakerFeatureEnabled) {
-          <div class="grid grid-cols-2 gap-24px">
+          <div class="grid grid-cols-2 mobile:grid-cols-1 gap-24px">
             <div>
               <label class="text-12 font-medium text-neutral-11 mb-8px block">Sample Rate (seconds)</label>
               <div class="h-50px bg-[#F7F9FC] border border-neutral-a3 rounded-[6px] px-16px flex items-center">

--- a/web/ui/dashboard/src/app/private/components/create-project-component/create-project-component.component.html
+++ b/web/ui/dashboard/src/app/private/components/create-project-component/create-project-component.component.html
@@ -420,7 +420,7 @@
       }
 
       @if (activeTab.label === 'event types') {
-        <div class="flex items-end justify-between mb-24px">
+        <div class="flex items-end justify-between flex-wrap gap-12px mb-24px">
           @if (action === 'update') {
             <h3 class="text-16 font-bold">Event Types</h3>
           }

--- a/web/ui/dashboard/src/app/private/components/create-project-component/create-project-component.component.html
+++ b/web/ui/dashboard/src/app/private/components/create-project-component/create-project-component.component.html
@@ -250,6 +250,7 @@
           </button>
         </div>
         <div convoy-card>
+          <div class="overflow-x-auto w-full">
           <table convoy-table>
             <thead convoy-table-head>
               @for (head of signatureTableHead; track $index; let i = $index) {
@@ -279,6 +280,7 @@
               }
             </tbody>
           </table>
+          </div>
         </div>
       }
 
@@ -463,6 +465,7 @@
             </div>
           }
           @if (validEventTypes().length > 0) {
+            <div class="overflow-x-auto w-full">
             <table convoy-table>
               <thead convoy-table-head>
                 @for (head of eventTypeTableHead; track $index; let i = $index) {
@@ -502,6 +505,7 @@
                 }
               </tbody>
             </table>
+            </div>
           }
         </div>
       }

--- a/web/ui/dashboard/src/app/private/components/create-project-component/create-project-component.component.html
+++ b/web/ui/dashboard/src/app/private/components/create-project-component/create-project-component.component.html
@@ -201,7 +201,7 @@
             }
           </div>
           @if (shouldShowBorder < configurations.length) {
-            <div class="flex gap-24px items-center">
+            <div class="flex flex-wrap gap-24px gap-y-12px items-center">
               @for (config of configurations; track $index; let i = $index) {
                 @if (!config.show) {
                   @if (i < 3 || this.projectForm.controls['type'].value === 'outgoing') {

--- a/web/ui/dashboard/src/app/private/components/event-delivery-filter/event-delivery-filter.component.html
+++ b/web/ui/dashboard/src/app/private/components/event-delivery-filter/event-delivery-filter.component.html
@@ -1,4 +1,4 @@
-<div class="flex py-20px items-start justify-between">
+<div class="flex flex-wrap gap-y-12px py-20px items-start justify-between">
   <div class="flex items-start gap-x-16px">
     <div class="flex gap-x-16px items-center">
       @if (type === 'logs' && licenseService.hasLicense('AdvancedWebhookFiltering')) {

--- a/web/ui/dashboard/src/app/private/pages/create-project/create-project.component.html
+++ b/web/ui/dashboard/src/app/private/pages/create-project/create-project.component.html
@@ -4,7 +4,7 @@
 	</div>
 
 	<div class="h-full w-full">
-		<div class="pt-40px pb-60px max-w-[770px] m-auto">
+		<div class="pt-40px pb-60px max-w-[770px] m-auto desktop:px-24px">
 			<p class="text-12 text-neutral-11 mb-24px max-w-[500px]">A project represents the top level namespace for grouping event sources, applications, endpoints and events.</p>
 
 			<app-create-project-component (onAction)="$event?.action == 'cancel' ? cancel() : createProject($event)"></app-create-project-component>

--- a/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.html
@@ -198,7 +198,7 @@
     <h2 class="font-semibold text-14 capitalize">{{ action === 'update' ? 'Edit Endpoint' : 'Create Endpoint' }}</h2>
   </div>
   <div class="h-full w-full">
-    <div class="max-w-[770px] m-auto">
+    <div class="max-w-[770px] m-auto desktop:px-24px">
       <convoy-create-endpoint showAction="true" (onAction)="$event.action === 'close' ? cancel() : getEndpoints(); cancel()" [editMode]="action === 'update'"></convoy-create-endpoint>
     </div>
   </div>

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.html
@@ -306,8 +306,8 @@
     }
     <!-- event delivery attempts  -->
     @if (eventDeliveryAtempts) {
-      <div class="flex justify-between gap-16px border-t border-new.primary-25">
-        <div class="w-[730px]">
+      <div class="flex flex-col md:flex-row justify-between gap-16px border-t border-new.primary-25">
+        <div class="w-full md:w-[730px]">
           @for (deliveryAttempt of eventDeliveryAtempts; track $index; let i = $index) {
             <button class="flex justify-between items-center py-12px w-full border-b border-new.primary-25" (click)="selectedDeliveryAttempt = deliveryAttempt">
               <div>
@@ -327,8 +327,8 @@
             </button>
           }
         </div>
-        <div class="w-[1px] bg-new.primary-25"></div>
-        <div class="w-[620px]">
+        <div class="hidden md:block w-[1px] bg-new.primary-25"></div>
+        <div class="w-full md:w-[620px] min-w-0">
           <div class="py-12px w-full">
             @if (isloadingDeliveryAttempts) {
               <div class="skeleton-loader code mt-16px"></div>

--- a/web/ui/dashboard/src/app/private/pages/project/meta-events/meta-events.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/meta-events/meta-events.component.html
@@ -8,7 +8,7 @@
     </div>
   </div>
   <div convoy-card class="flex">
-    <div class="min-w-[605px] w-full h-full overflow-hidden relative">
+    <div class="min-w-0 md:min-w-[605px] w-full h-full overflow-hidden relative">
       @if (isLoadingMetaEvents) {
         <convoy-table-loader id="meta_events_loader" [tableHead]="metaEventsTableHead"></convoy-table-loader>
       }

--- a/web/ui/dashboard/src/app/private/pages/project/portal-links/portal-links.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/portal-links/portal-links.component.html
@@ -66,14 +66,14 @@
   </div>
   <div class="min-h-[600px]">
     <div class="flex flex-wrap gap-24px">
-      <a convoy-card hover="true" class="w-full max-w-[440px] min-h-[160px] min-w-[300px] flex items-center justify-center border border-dashed border-new.primary-400 hover:!border-new.primary-400" convoy-permission="Portal Links|MANAGE" routerLink="./new">
+      <a convoy-card hover="true" class="w-full max-w-[440px] min-h-[160px] min-w-[300px] mobile:min-w-0 flex items-center justify-center border border-dashed border-new.primary-400 hover:!border-new.primary-400" convoy-permission="Portal Links|MANAGE" routerLink="./new">
         <svg width="22" height="22" class="mr-2 scale-75 fill-new.primary-400">
           <use xlink:href="#plus-icon"></use>
         </svg>
         <span class="text-new.primary-400 font-medium text-12">Create Portal Link</span>
       </a>
       @for (link of portalLinks?.content; track $index; let i = $index) {
-        <div convoy-card hover="true" class="w-full max-w-[440px] min-w-[300px]" [id]="'portal-link' + i">
+        <div convoy-card hover="true" class="w-full max-w-[440px] min-w-[300px] mobile:min-w-0" [id]="'portal-link' + i">
           <div class="px-24px py-20px border-b border-b-neutral-a3">
             <div class="flex justify-between items-center">
               <div class="text-14 font-medium overflow-hidden max-w-[260px] text-ellipsis whitespace-nowrap">

--- a/web/ui/dashboard/src/app/private/pages/project/project.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/project.component.html
@@ -108,7 +108,7 @@
           @for (nav of secondarySideBarItems; track $index) {
             <li class="transition-all duration-200 z-[1]">
               <a [routerLink]="'.' + nav.route" routerLinkActive="!text-new.primary-400 on hover:bg-transparent" #route="routerLinkActive" #navTab class="nav-tab text-neutral-10 rounded-22px py-8px px-16px transition-all duration-200 font-medium hover:bg-neutral-a2">
-              <span class="text-12 transition-all duration-200">{{ nav.name }}</span>
+              <span class="text-12 transition-all duration-200 whitespace-nowrap">{{ nav.name }}</span>
             </a>
           </li>
         }
@@ -119,7 +119,7 @@
           <svg width="18" height="18" class="mr-10px" [class]="route.isActive ? 'fill-primary-100' : 'fill-neutral-10'">
             <use xlink:href="#settings-icon"></use>
           </svg>
-          <span class="font-medium text-12 transition-all duration-200">Project Settings</span>
+          <span class="font-medium text-12 transition-all duration-200 whitespace-nowrap">Project Settings</span>
         </a>
       </li>
     </ul>

--- a/web/ui/dashboard/src/app/private/pages/project/settings/settings.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/settings/settings.component.html
@@ -1,4 +1,4 @@
-<div class="max-w-[1000px] m-auto">
+<div class="max-w-[1000px] m-auto desktop:px-24px">
   <div id="project-settings"></div>
   @if (isloading) {
     <convoy-loader></convoy-loader>
@@ -6,7 +6,7 @@
 
   <app-create-project-component [action]="'update'" class="block -mt-24px"></app-create-project-component>
 
-  <div class="w-[730px] ml-auto">
+  <div class="w-full max-w-[730px] ml-auto">
     <hr class="border-t border-neutral-a3 my-40px" />
     <div convoy-card color="error" class="p-26px my-24px">
       <h2 class="text-error-9 text-14 font-semibold mb-20px">Danger zone</h2>

--- a/web/ui/dashboard/src/app/private/pages/project/sources/sources.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/sources/sources.component.html
@@ -32,7 +32,7 @@
       <a
         convoy-permission="Sources|MANAGE"
         routerLink="./new"
-        class="w-full max-w-[440px] min-w-[300px] rounded-8px border border-dashed border-new.primary-400 flex items-center justify-center py-8 transition-all duration-300 hover:shadow-[0_4px_20px_-2px_rgba(50,50,71,0.08)]"
+        class="w-full max-w-[440px] min-w-[300px] mobile:min-w-0 rounded-8px border border-dashed border-new.primary-400 flex items-center justify-center py-8 transition-all duration-300 hover:shadow-[0_4px_20px_-2px_rgba(50,50,71,0.08)]"
         >
         <svg width="22" height="22" class="mr-2 scale-75" fill="#477db3">
           <use xlink:href="#plus-icon"></use>
@@ -40,7 +40,7 @@
         <span class="text-primary-100 font-medium text-12">Create new Source</span>
       </a>
       @for (source of sources.content; track $index; let i = $index) {
-        <div convoy-card [id]="'source' + i" class="w-full max-w-[440px] min-w-[300px] py-20px h-fit">
+        <div convoy-card [id]="'source' + i" class="w-full max-w-[440px] min-w-[300px] mobile:min-w-0 py-20px h-fit">
           <!-- outgoing project sources -->
           @if (privateService.getProjectDetails?.type === 'outgoing') {
             <div class="flex items-center justify-between px-24px">
@@ -152,7 +152,7 @@
   </div>
 
   <div class="w-full h-full">
-    <div class="max-w-[770px] pt-24px m-auto">
+    <div class="max-w-[770px] pt-24px m-auto desktop:px-24px">
       <convoy-create-source [showModal]="privateService.getProjectDetails?.type === 'incoming' ? 'true' : 'false'" showAction="true" (onAction)="closeCreateSourceModal($event)" [action]="action"></convoy-create-source>
     </div>
   </div>

--- a/web/ui/dashboard/src/app/private/pages/project/subscriptions/subscriptions.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/subscriptions/subscriptions.component.html
@@ -169,7 +169,7 @@
   </div>
 
   <div class="w-full h-full">
-    <div class="max-w-[770px] m-auto">
+    <div class="max-w-[770px] m-auto desktop:px-24px">
       <convoy-create-subscription showAction="true" (onAction)="createSubscription($event.action)" [action]="action === 'update' ? 'update' : 'create'"></convoy-create-subscription>
     </div>
   </div>

--- a/web/ui/dashboard/src/app/private/pages/settings/billing/billing-invoices.component.html
+++ b/web/ui/dashboard/src/app/private/pages/settings/billing/billing-invoices.component.html
@@ -9,6 +9,7 @@
 
   @if (!isFetchingInvoices) {
     <div convoy-card>
+      <div class="overflow-x-auto w-full">
       <table convoy-table>
         <thead convoy-table-head>
           @for (head of tableHead; track $index; let i = $index) {
@@ -38,6 +39,7 @@
           }
         </tbody>
       </table>
+      </div>
     </div>
   }
 </div>

--- a/web/ui/dashboard/src/app/private/pages/settings/billing/billing-usage.component.html
+++ b/web/ui/dashboard/src/app/private/pages/settings/billing/billing-usage.component.html
@@ -9,6 +9,7 @@
 
   @if (!isFetchingUsage) {
     <div convoy-card>
+      <div class="overflow-x-auto w-full">
       <table convoy-table>
         <thead convoy-table-head>
           @for (head of tableHead; track $index; let i = $index) {
@@ -26,6 +27,7 @@
           }
         </tbody>
       </table>
+      </div>
     </div>
   }
 </div>

--- a/web/ui/dashboard/src/app/private/pages/settings/teams/teams.component.html
+++ b/web/ui/dashboard/src/app/private/pages/settings/teams/teams.component.html
@@ -64,7 +64,7 @@
                 <td convoy-table-cell>All projects</td>
                 <td convoy-table-cell>
                   @if (team.user_id !== userDetails?.uid) {
-                    <div convoy-dropdown size="md" position="left">
+                    <div convoy-dropdown size="md" position="right">
                       <button dropdownTrigger convoy-button size="sm" fill="text">
                         <img src="/assets/img/nav-bar-more-primary.svg" alt="more icon" />
                       </button>

--- a/web/ui/dashboard/src/app/private/pages/setup-project/setup-project.component.html
+++ b/web/ui/dashboard/src/app/private/pages/setup-project/setup-project.component.html
@@ -4,7 +4,7 @@
   </div>
 
   <div class="h-full w-full">
-    <div class="max-w-[770px] m-auto mt-20px pb-60px flex flex-col">
+    <div class="max-w-[770px] m-auto mt-20px pb-60px flex flex-col desktop:px-24px">
       @if (showLoader) {
         <convoy-loader></convoy-loader>
       }


### PR DESCRIPTION
## Summary

Two related fixes from the same QA pass.

### Dashboard mobile responsiveness (follow-up to #2684)
- Project Settings + shared create-project form: edge padding, sidebar stacks above form on small screens, two-column config grids collapse to one on mobile, fluid description text, wrapping config buttons row.
- Create Project / Create Source / Create Subscription / Create Endpoint / Setup Project / Create Portal Link: desktop:px-24px so captions and primary buttons stop hugging the screen edges.
- Tables that can be wide (event types, signature history, billing usage/invoices) wrapped in overflow-x-auto so they scroll within their card instead of pushing the page off-screen. Tables with row popups (teams) intentionally not wrapped, since an overflow container clips the absolutely-positioned menu.
- Event Delivery Details two-pane layout stacks on mobile with fluid panes.
- Portal links / sources cards drop the 300px min-width on phones; meta events pane drops the 605px floor (inner table already scrolls).
- Nav + buttons: whitespace-nowrap on the shared convoy-button host and on the secondary project tab items / Project Settings so labels stop wrapping and overlapping. Event types header and event-delivery filter toolbar wrap as whole units.
- Active team member row menu opens leftward (position=right) so it no longer spills off the right edge.

### Service nil-logger panic fix
Several handlers constructed services that dereference their `Logger` field without setting it, so any error path that logs panicked with a nil pointer (reproduced when re-inviting an existing org member). Set `Logger` on all 29 affected construction sites across endpoint, event, event delivery, source, subscription, user, auth, security, organisation, configuration, meta event and organisation invite handlers, plus the internal `CreateAPIKeyService` built during project creation.

## Test plan
- [ ] Dashboard pages render without horizontal page overflow at 390/640/850/1050px; wide tables scroll inside their cards; row popups not clipped.
- [ ] Re-invite an existing org member: returns "an invite for this email already exists" with no server panic.
- [ ] Spot-check password reset, verify email, API key revoke/regenerate, source/subscription/org update error paths log instead of panicking.