### PR TITLE
fix(dashboard): route templated endpoint test events through dynamic api

### DIFF
--- a/services/create_dynamic_event.go
+++ b/services/create_dynamic_event.go
@@ -46,9 +46,12 @@ func (e *CreateDynamicEventService) Run(ctx context.Context) (err error) {
 	e.DynamicEvent.ProjectID = e.Project.UID
 	e.DynamicEvent.AcknowledgedAt = time.Now()
 
-	if len(e.DynamicEvent.EventTypes) == 0 {
-		e.DynamicEvent.EventTypes = []string{"*"}
-	}
+	// Do not default EventTypes to ["*"] here. An empty list must reach the worker as
+	// empty so it can distinguish "caller did not specify a filter" (leave an existing
+	// subscription's filter untouched, and default only a brand-new subscription to
+	// catch-all) from "caller explicitly set a filter" (sync it onto the subscription).
+	// Defaulting here would make every dynamic event that omits event_types silently
+	// overwrite the matched subscription's filter with ["*"].
 
 	taskName := convoy.CreateDynamicEventProcessor
 

--- a/web/ui/dashboard/src/app/models/event.model.ts
+++ b/web/ui/dashboard/src/app/models/event.model.ts
@@ -55,6 +55,7 @@ export interface EVENT_DELIVERY {
 	device_metadata: DEVICE;
 	endpoint_id: string;
 	latency_seconds?: number;
+	target_url?: string;
 }
 
 export interface EVENT_DELIVERY_ATTEMPT {

--- a/web/ui/dashboard/src/app/pipes/url-template-parts/url-template-parts.pipe.ts
+++ b/web/ui/dashboard/src/app/pipes/url-template-parts/url-template-parts.pipe.ts
@@ -1,0 +1,23 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+export interface UrlTemplatePart {
+	text: string;
+	token: boolean;
+}
+
+// Splits a URL into segments so templated tokens like {reference} can be rendered
+// distinctly from the static parts of the URL. Token names follow the backend
+// endpoint URL template rules: {name} where name is [A-Za-z_][A-Za-z0-9_]*.
+@Pipe({
+	name: 'urlTemplateParts',
+	standalone: true
+})
+export class UrlTemplatePartsPipe implements PipeTransform {
+	transform(value?: string | null): UrlTemplatePart[] {
+		if (!value) return [];
+		return value
+			.split(/(\{[A-Za-z_][A-Za-z0-9_]*\})/g)
+			.filter(part => part !== '')
+			.map(part => ({ text: part, token: /^\{[A-Za-z_][A-Za-z0-9_]*\}$/.test(part) }));
+	}
+}

--- a/web/ui/dashboard/src/app/private/components/create-endpoint/create-endpoint.component.html
+++ b/web/ui/dashboard/src/app/private/components/create-endpoint/create-endpoint.component.html
@@ -11,11 +11,8 @@
         </convoy-input-field>
 
         <convoy-input-field>
-          <label for="endpoint_url" convoy-label required="true">Enter URL</label>
+          <label for="endpoint_url" convoy-label required="true" class="flex items-center">Enter URL@if (endpointURLTemplatesFeatureEnabled) {<convoy-tooltip size="sm" position="top-right" class="ml-4px" tooltipContent="Use single-segment placeholders like {reference} in the path or query for dynamic callback URLs."></convoy-tooltip>}</label>
           <input type="url" id="endpoint_url" convoy-input autocomplete="url" formControlName="url" [placeholder]="endpointURLTemplatesFeatureEnabled ? 'https://example.com/orders/{reference}/callback' : 'Enter endpoint URL here'" />
-          @if (endpointURLTemplatesFeatureEnabled) {
-            <p class="text-10 text-neutral-10 mt-6px">Use single-segment placeholders like <code>{{ '{' }}reference{{ '}' }}</code> in the path or query for dynamic callback URLs.</p>
-          }
           @if (addNewEndpointForm.get('url')?.touched && addNewEndpointForm.get('url')?.invalid) {
             <convoy-input-error>Invalid endpoint URL</convoy-input-error>
           }

--- a/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.html
@@ -83,7 +83,7 @@
                 </td>
                 <td convoy-table-cell class="relative">
                   <div convoy-tag class="!gap-10px flex items-center">
-                    <span class="w-[200px] truncate">{{ endpoint.url || endpoint.target_url }}</span>
+                    <span class="w-[200px] overflow-x-auto whitespace-nowrap">@if (endpointURLTemplatesFeatureEnabled) {@for (part of (endpoint.url || endpoint.target_url | urlTemplateParts); track $index) {<span [class]="part.token ? 'text-new.primary-400 font-medium bg-new.primary-25 rounded-[3px] px-[3px]' : ''">{{ part.text }}</span>}} @else {{{ endpoint.url || endpoint.target_url }}}</span>
                     <convoy-copy-button size="sm" [notificationText]="endpoint.name || endpoint.title + ' Url has been copied to clipboard'" [text]="endpoint.url || endpoint.target_url"></convoy-copy-button>
                   </div>
                 </td>

--- a/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.html
@@ -83,7 +83,7 @@
                 </td>
                 <td convoy-table-cell class="relative">
                   <div convoy-tag class="!gap-10px flex items-center">
-                    <span class="w-[200px] overflow-x-auto whitespace-nowrap">@if (endpointURLTemplatesFeatureEnabled) {@for (part of (endpoint.url || endpoint.target_url | urlTemplateParts); track $index) {<span [class]="part.token ? 'text-new.primary-400 font-medium bg-new.primary-25 rounded-[3px] px-[3px]' : ''">{{ part.text }}</span>}} @else {{{ endpoint.url || endpoint.target_url }}}</span>
+                    <span class="w-[200px] overflow-x-auto whitespace-nowrap">@if (endpointURLTemplatesFeatureEnabled) {@for (part of ((endpoint.url || endpoint.target_url) | urlTemplateParts); track $index) {<span [class]="part.token ? 'text-new.primary-400 font-medium bg-new.primary-25 rounded-[3px] px-[3px]' : ''">{{ part.text }}</span>}} @else {{{ endpoint.url || endpoint.target_url }}}</span>
                     <convoy-copy-button size="sm" [notificationText]="endpoint.name || endpoint.title + ' Url has been copied to clipboard'" [text]="endpoint.url || endpoint.target_url"></convoy-copy-button>
                   </div>
                 </td>

--- a/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.ts
@@ -24,6 +24,8 @@ import { EndpointSecretComponent } from './endpoint-secret/endpoint-secret.compo
 import { EndpointsService } from './endpoints.service';
 import { LoaderModule } from 'src/app/private/components/loader/loader.module';
 import { LicensesService } from '../../../../services/licenses/licenses.service';
+import { SettingsService } from '../../settings/settings.service';
+import { UrlTemplatePartsPipe } from 'src/app/pipes/url-template-parts/url-template-parts.pipe';
 
 @Component({
     selector: 'convoy-endpoints',
@@ -52,7 +54,8 @@ import { LicensesService } from '../../../../services/licenses/licenses.service'
         EndpointSecretComponent,
         DeleteModalComponent,
         LoaderModule,
-        DialogDirective
+        DialogDirective,
+        UrlTemplatePartsPipe
     ],
     templateUrl: './endpoints.component.html',
     styleUrls: ['./endpoints.component.scss']
@@ -76,8 +79,10 @@ export class EndpointsComponent implements OnInit {
 	endpointSearchString!: string;
 	action: 'create' | 'update' = 'create';
 	userSearch = false;
+	endpointURLTemplatesFeatureEnabled = false;
+	private featureFlagReady?: Promise<void>;
 
-	constructor(public router: Router, public privateService: PrivateService, public projectService: ProjectService, private endpointService: EndpointsService, private generalService: GeneralService, public route: ActivatedRoute, public licenseService: LicensesService) {}
+	constructor(public router: Router, public privateService: PrivateService, public projectService: ProjectService, private endpointService: EndpointsService, private generalService: GeneralService, public route: ActivatedRoute, public licenseService: LicensesService, private settingsService: SettingsService) {}
 
 	ngOnInit() {
 		const urlParam = this.route.snapshot.params.id;
@@ -87,7 +92,24 @@ export class EndpointsComponent implements OnInit {
 		}
 		this.endpointsTableHead[4] = this.licenseService.hasLicense('CircuitBreaking') ? 'Failure Rate' : '';
 
+		this.featureFlagReady = this.checkEndpointURLTemplatesFeatureFlag();
 		this.getEndpoints();
+	}
+
+	async checkEndpointURLTemplatesFeatureFlag() {
+		// Only the org-scoped early-adopter feature flag is checked here; the license
+		// side is verified separately in sendTestEvent. Both must hold for the backend
+		// to run template matching, so we mirror that before using the dynamic path.
+		const org = localStorage.getItem('CONVOY_ORG');
+		if (!org) return;
+		try {
+			this.endpointURLTemplatesFeatureEnabled = await this.settingsService.checkFeatureFlagEnabled({
+				org_id: JSON.parse(org).uid,
+				feature_key: 'endpoint-url-templates'
+			});
+		} catch {
+			this.endpointURLTemplatesFeatureEnabled = false;
+		}
 	}
 
 	async getEndpoints(requestDetails?: CURSOR & { search?: string; hideLoader?: boolean }) {
@@ -162,20 +184,57 @@ export class EndpointsComponent implements OnInit {
 	}
 
 	async sendTestEvent() {
-		const testEvent = {
-			data: { data: 'test event from Convoy', convoy: 'https://getconvoy.io', amount: 1000 },
-			endpoint_id: this.selectedEndpoint?.uid,
-			event_type: 'test.convoy'
-		};
+		// Under the dashboard version header the endpoint URL comes back as target_url,
+		// so read both before deciding there is nothing to test against.
+		const url = this.selectedEndpoint?.url || this.selectedEndpoint?.target_url;
+		if (!url) {
+			this.generalService.showNotification({ message: 'Endpoint has no URL to test against', style: 'error' });
+			return;
+		}
+
+		const data = { data: 'test event from Convoy', convoy: 'https://getconvoy.io', amount: 1000 };
+
+		// Only templated endpoints (e.g. /tx/{reference}/callback) use the dynamic path:
+		// it resolves the concrete URL against the endpoint template and bypasses
+		// subscription event-type filters. Concrete endpoints keep the endpoint-bound
+		// path so the test stays tied to the selected endpoint (its secrets, auth and
+		// state); routing them through dynamic would bind by URL match and could
+		// auto-create an orphan endpoint when the URL does not match exactly.
+		//
+		// The dynamic worker only runs template matching when both the license and the
+		// org feature flag are on. If either is off it skips the lookup and mints a new
+		// orphan endpoint for the URL, so we require both here and otherwise fall back
+		// to the endpoint-bound path.
+		const isTemplated = /\{[A-Za-z_][A-Za-z0-9_]*\}/.test(url);
 
 		this.isSendingTestEvent = true;
 		try {
-			const response = await this.endpointService.sendEvent({ body: testEvent });
+			// Wait for the feature flag check kicked off in ngOnInit so a fast click does
+			// not misroute a templated endpoint to the endpoint-bound path (which cannot
+			// resolve the template) just because the check is still in flight.
+			await this.featureFlagReady;
+			const useDynamic = isTemplated && this.endpointURLTemplatesFeatureEnabled && this.licenseService.hasLicense('EndpointURLTemplates');
+
+			// For the templated path, substitute each {token} with a dummy value so the
+			// URL is concrete; event_types (plural) is intentionally omitted so the
+			// endpoint's real subscription filter is not overwritten.
+			const response = useDynamic
+				? await this.endpointService.sendDynamicEvent({
+						body: { url: url.replace(/\{[A-Za-z_][A-Za-z0-9_]*\}/g, () => this.generateTestToken()), data, event_type: 'test.convoy' }
+				  })
+				: await this.endpointService.sendEvent({ body: { data, endpoint_id: this.selectedEndpoint?.uid, event_type: 'test.convoy' } });
 			this.generalService.showNotification({ message: response.message, style: 'success' });
 			this.isSendingTestEvent = false;
 		} catch {
 			this.isSendingTestEvent = false;
 		}
+	}
+
+	private generateTestToken(): string {
+		if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+			return crypto.randomUUID().replace(/-/g, '');
+		}
+		return `test${Date.now()}${Math.random().toString(36).slice(2)}`;
 	}
 
 	viewSubscription() {

--- a/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.service.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.service.ts
@@ -74,6 +74,23 @@ export class EndpointsService {
 		});
 	}
 
+	sendDynamicEvent(requestDetails: { body: any }): Promise<HTTP_RESPONSE> {
+		return new Promise(async (resolve, reject) => {
+			try {
+				const response = await this.http.request({
+					url: `/events/dynamic`,
+					body: requestDetails.body,
+					method: 'post',
+					level: 'org_project'
+				});
+
+				return resolve(response);
+			} catch (error) {
+				return reject(error);
+			}
+		});
+	}
+
 	toggleEndpoint(endpointId: string): Promise<HTTP_RESPONSE> {
 		return new Promise(async (resolve, reject) => {
 			try {

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.html
@@ -74,8 +74,9 @@
             <p class="text-neutral-10 text-12 font-light mb-6px">EVENT RECEIVED</p>
             @if (eventDelsDetails?.event_metadata?.created_at) {
               <convoy-copy-button [text]="formatPreciseTimestamp(eventDelsDetails?.event_metadata?.created_at)" show-icon="false" notificationText="Event received timestamp copied to clipboard">
-                <span class="relative inline-flex text-12 font-medium group" [title]="formatPreciseTimestamp(eventDelsDetails?.event_metadata?.created_at)">
+                <span class="relative inline-flex items-center text-12 font-medium group" [title]="formatPreciseTimestamp(eventDelsDetails?.event_metadata?.created_at)">
                   <span>{{ formatLocalTimestamp(eventDelsDetails?.event_metadata?.created_at) }}</span>
+                  <svg class="ml-4px h-12px w-12px shrink-0 opacity-0 transition-opacity group-hover:opacity-100 stroke-neutral-10"><use xlink:href="#copy-icon-3"></use></svg>
                   <span class="pointer-events-none absolute left-1/2 bottom-[calc(100%+8px)] z-50 -translate-x-1/2 whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
                     {{ formatPreciseTimestamp(eventDelsDetails?.event_metadata?.created_at) }}
                   </span>
@@ -92,8 +93,9 @@
             <p class="text-neutral-10 text-12 font-light mb-6px">ACKNOWLEDGED</p>
             @if (eventDelsDetails?.acknowledged_at) {
               <convoy-copy-button [text]="formatPreciseTimestamp(eventDelsDetails?.acknowledged_at)" show-icon="false" notificationText="Acknowledged timestamp copied to clipboard">
-                <span class="relative inline-flex text-12 font-medium group" [title]="formatPreciseTimestamp(eventDelsDetails?.acknowledged_at)">
+                <span class="relative inline-flex items-center text-12 font-medium group" [title]="formatPreciseTimestamp(eventDelsDetails?.acknowledged_at)">
                   <span>{{ formatLocalTimestamp(eventDelsDetails?.acknowledged_at) }}</span>
+                  <svg class="ml-4px h-12px w-12px shrink-0 opacity-0 transition-opacity group-hover:opacity-100 stroke-neutral-10"><use xlink:href="#copy-icon-3"></use></svg>
                   <span class="pointer-events-none absolute left-1/2 bottom-[calc(100%+8px)] z-50 -translate-x-1/2 whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
                     {{ formatPreciseTimestamp(eventDelsDetails?.acknowledged_at) }}
                   </span>
@@ -110,8 +112,9 @@
             <p class="text-neutral-10 text-12 font-light mb-6px">DELIVERY QUEUED</p>
             @if (eventDelsDetails?.created_at) {
               <convoy-copy-button [text]="formatPreciseTimestamp(eventDelsDetails?.created_at)" show-icon="false" notificationText="Delivery queued timestamp copied to clipboard">
-                <span class="relative inline-flex text-12 font-medium group" [title]="formatPreciseTimestamp(eventDelsDetails?.created_at)">
+                <span class="relative inline-flex items-center text-12 font-medium group" [title]="formatPreciseTimestamp(eventDelsDetails?.created_at)">
                   <span>{{ formatLocalTimestamp(eventDelsDetails?.created_at) }}</span>
+                  <svg class="ml-4px h-12px w-12px shrink-0 opacity-0 transition-opacity group-hover:opacity-100 stroke-neutral-10"><use xlink:href="#copy-icon-3"></use></svg>
                   <span class="pointer-events-none absolute left-1/2 bottom-[calc(100%+8px)] z-50 -translate-x-1/2 whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
                     {{ formatPreciseTimestamp(eventDelsDetails?.created_at) }}
                   </span>
@@ -128,8 +131,9 @@
             <p class="text-neutral-10 text-12 font-light mb-6px">LATEST ATTEMPT</p>
             @if (eventDeliveryAtempt?.created_at) {
               <convoy-copy-button [text]="formatPreciseTimestamp(eventDeliveryAtempt?.created_at)" show-icon="false" notificationText="Latest attempt timestamp copied to clipboard">
-                <span class="relative inline-flex text-12 font-medium group" [title]="formatPreciseTimestamp(eventDeliveryAtempt?.created_at)">
+                <span class="relative inline-flex items-center text-12 font-medium group" [title]="formatPreciseTimestamp(eventDeliveryAtempt?.created_at)">
                   <span>{{ formatLocalTimestamp(eventDeliveryAtempt?.created_at) }}</span>
+                  <svg class="ml-4px h-12px w-12px shrink-0 opacity-0 transition-opacity group-hover:opacity-100 stroke-neutral-10"><use xlink:href="#copy-icon-3"></use></svg>
                   <span class="pointer-events-none absolute left-1/2 bottom-[calc(100%+8px)] z-50 -translate-x-1/2 whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
                     {{ formatPreciseTimestamp(eventDeliveryAtempt?.created_at) }}
                   </span>
@@ -238,12 +242,22 @@
       }
     </div>
 
-    <div class="text-12 text-neutral-12 truncate max-w-[370px]">{{ eventDelsDetails?.endpoint_metadata?.url || '-' }}</div>
+    <convoy-copy-button [text]="eventDelsDetails?.target_url || eventDelsDetails?.endpoint_metadata?.url || ''" show-icon="false" notificationText="Endpoint URL copied to clipboard">
+      <span class="relative inline-flex items-center max-w-[370px] group cursor-pointer">
+        <span class="truncate text-12 text-neutral-12">{{ eventDelsDetails?.target_url || eventDelsDetails?.endpoint_metadata?.url || '-' }}</span>
+        <svg class="ml-6px h-12px w-12px shrink-0 opacity-0 transition-opacity group-hover:opacity-100 stroke-neutral-10">
+          <use xlink:href="#copy-icon-3"></use>
+        </svg>
+        <span class="pointer-events-none absolute left-0 bottom-[calc(100%+8px)] z-50 max-w-[560px] truncate whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
+          {{ eventDelsDetails?.target_url || eventDelsDetails?.endpoint_metadata?.url }}
+        </span>
+      </span>
+    </convoy-copy-button>
 
     <div class="flex items-center gap-24px">
       <convoy-copy-button [text]="eventDelsDetails?.endpoint_metadata?.url || ''" color="primary" show-icon="false" [notificationText]="eventDelsDetails?.endpoint_metadata?.name + ' URL has been copied to clipboard'">
         <div convoy-tag color="primary" class="flex items-center !gap-12px">
-          <span class="max-w-[230px] truncate">{{ eventDelsDetails?.endpoint_metadata?.url || '-' }}</span>
+          <span class="max-w-[230px] overflow-x-auto whitespace-nowrap">@if (eventDelsDetails?.endpoint_metadata?.url) {@for (part of (eventDelsDetails?.endpoint_metadata?.url | urlTemplateParts); track $index) {<span [class]="part.token ? 'text-new.primary-400 font-medium bg-new.primary-25 rounded-[3px] px-[3px]' : ''">{{ part.text }}</span>}} @else {-}</span>
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" class="scale-[.6]" xmlns="http://www.w3.org/2000/svg">
             <path d="M8 12.2002H15" stroke="#292D32" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
             <path d="M8 16.2002H12.38" stroke="#292D32" stroke-width="1.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.module.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.module.ts
@@ -10,9 +10,10 @@ import { TagComponent } from 'src/app/components/tag/tag.component';
 import { SkeletonLoaderComponent } from 'src/app/components/skeleton-loader/skeleton-loader.component';
 import { StatusColorModule } from 'src/app/pipes/status-color/status-color.module';
 import { CopyButtonComponent } from 'src/app/components/copy-button/copy-button.component';
+import { UrlTemplatePartsPipe } from 'src/app/pipes/url-template-parts/url-template-parts.pipe';
 @NgModule({
 	declarations: [EventDeliveryDetailsComponent],
-	imports: [CommonModule, RouterModule, PrismModule, LoaderModule, CardComponent, ButtonComponent, TagComponent, StatusColorModule, SkeletonLoaderComponent, CopyButtonComponent],
+	imports: [CommonModule, RouterModule, PrismModule, LoaderModule, CardComponent, ButtonComponent, TagComponent, StatusColorModule, SkeletonLoaderComponent, CopyButtonComponent, UrlTemplatePartsPipe],
 	exports: [EventDeliveryDetailsComponent]
 })
 export class EventDeliveryDetailsModule {}

--- a/worker/task/process_dynamic_event_creation.go
+++ b/worker/task/process_dynamic_event_creation.go
@@ -394,6 +394,13 @@ func findDynamicSubscription(ctx context.Context, dynamicEvent *models.DynamicEv
 			return nil, err
 		}
 	case errors.Is(err, datastore.ErrSubscriptionNotFound):
+		// A brand-new dynamic subscription needs a catch-all filter so future
+		// (non-dynamic) events to this endpoint still match when the caller did not
+		// specify event_types. Callers that supply explicit event_types keep them.
+		newSubEventTypes := dynamicEvent.EventTypes
+		if len(newSubEventTypes) == 0 {
+			newSubEventTypes = []string{"*"}
+		}
 		subscription = &datastore.Subscription{
 			UID:        ulid.Make().String(),
 			ProjectID:  project.UID,
@@ -401,7 +408,7 @@ func findDynamicSubscription(ctx context.Context, dynamicEvent *models.DynamicEv
 			Type:       datastore.SubscriptionTypeAPI,
 			EndpointID: endpoint.UID,
 			FilterConfig: &datastore.FilterConfiguration{
-				EventTypes: dynamicEvent.EventTypes,
+				EventTypes: newSubEventTypes,
 			},
 			RetryConfig:     &datastore.DefaultRetryConfig,
 			AlertConfig:     &datastore.DefaultAlertConfig,

--- a/worker/task/process_dynamic_event_creation_test.go
+++ b/worker/task/process_dynamic_event_creation_test.go
@@ -185,6 +185,55 @@ func TestFindDynamicSubscription_UsesAtomicDynamicFindOrCreate(t *testing.T) {
 	require.Equal(t, existing.UID, got.UID)
 }
 
+func TestFindDynamicSubscription_PreservesExistingFilterWhenNoEventTypes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	project := &datastore.Project{UID: "project-id-1"}
+	endpoint := &datastore.Endpoint{UID: "endpoint-id-1"}
+	existing := datastore.Subscription{
+		UID:          "subscription-id-1",
+		ProjectID:    project.UID,
+		EndpointID:   endpoint.UID,
+		Name:         "dynamic-subscription-endpoint-id-1",
+		FilterConfig: &datastore.FilterConfiguration{EventTypes: []string{"invoice.paid"}},
+	}
+
+	subRepo := mocks.NewMockSubscriptionRepository(ctrl)
+	subRepo.EXPECT().FindSubscriptionsByEndpointID(gomock.Any(), project.UID, endpoint.UID).
+		Return([]datastore.Subscription{existing}, nil)
+	// No UpdateSubscription expected: an event with no event_types must not overwrite
+	// the existing subscription filter (e.g. dashboard "Send test event").
+
+	got, err := findDynamicSubscription(context.Background(), &models.DynamicEvent{}, subRepo, project, endpoint)
+	require.NoError(t, err)
+	require.Equal(t, existing.UID, got.UID)
+	require.ElementsMatch(t, []string{"invoice.paid"}, got.FilterConfig.EventTypes)
+}
+
+func TestFindDynamicSubscription_NewSubscriptionDefaultsToCatchAllWhenNoEventTypes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	project := &datastore.Project{UID: "project-id-1"}
+	endpoint := &datastore.Endpoint{UID: "endpoint-id-1"}
+
+	subRepo := mocks.NewMockSubscriptionRepository(ctrl)
+	subRepo.EXPECT().FindSubscriptionsByEndpointID(gomock.Any(), project.UID, endpoint.UID).
+		Return([]datastore.Subscription{}, nil)
+	subRepo.EXPECT().FindOrCreateDynamicSubscription(gomock.Any(), project.UID, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, sub *datastore.Subscription) (*datastore.Subscription, error) {
+			require.ElementsMatch(t, []string{"*"}, sub.FilterConfig.EventTypes)
+			return sub, nil
+		})
+	// No UpdateSubscription expected: sync is a no-op for empty event_types, the
+	// catch-all default is applied at creation time only.
+
+	got, err := findDynamicSubscription(context.Background(), &models.DynamicEvent{}, subRepo, project, endpoint)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"*"}, got.FilterConfig.EventTypes)
+}
+
 func TestFindEndpoint_TemplateMatching(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary

Fixes "Send test event" for templated endpoints and surfaces URL templates in the dashboard.

- **Test event routing (dashboard):** templated endpoints (URLs containing `{token}`) now send through `/events/dynamic`, and only when both the `EndpointURLTemplates` license and the org feature flag are on (mirroring the backend gate). Concrete endpoints keep the endpoint-bound `/events` path tied to the selected endpoint. The feature-flag check started in `ngOnInit` is awaited before routing so a fast click cannot misroute. The endpoint URL is read from `url || target_url` (the dashboard version header renames `url` to `target_url`).
- **Subscription filter safety (backend, root-cause fix):** a dynamic event with no `event_types` no longer overwrites the matched endpoint's subscription filter. Previously `CreateDynamicEventService` forced an empty list to `["*"]` and the worker persisted it onto the existing subscription, silently widening a restrictive filter (e.g. `invoice.paid`) to all event types. Now an omitted list stays empty through to the worker: existing subscriptions are left untouched, and only a brand-new dynamic subscription defaults to `["*"]` so future non-dynamic events still match. Explicit `event_types` still sync as before. The dynamic channel bypasses filter matching, so test delivery is unaffected for restrictive filters.
- **URL template visibility (dashboard):** a shared `urlTemplateParts` pipe tints `{token}` segments in the endpoints list (feature-gated) and on event delivery details, the resolved `target_url` is shown on delivery details, and hover copy affordances were added for the URL and timing cells plus a URL-template tooltip on the endpoint form.

## Why

Templated endpoints (e.g. `/tx/{reference}/callback`) could not receive test events: the fixed test payload never resolved the template, and `test.convoy` did not match typed subscription filters (`CODE: 1011`). Routing every test to the dynamic path also misbound concrete endpoints and could silently overwrite subscription filters. This change distinguishes templated vs concrete endpoints and fixes the filter-overwrite at its source in the backend.

## Tests

- Backend: existing subscription filter preserved when `event_types` is empty; brand-new dynamic subscription defaults to `["*"]`; explicit `event_types` still sync.
- `gofmt`, `go vet`, `golangci-lint` clean on touched packages; focused `go test` for `worker/task` and `services` pass.

## Test plan

- [ ] Templated endpoint with feature + license on: Send test event delivers to the resolved concrete URL, no orphan endpoint created, subscription filter unchanged.
- [ ] Concrete endpoint: Send test event still routes through `/events` bound to the selected endpoint.
- [ ] Feature flag/license off: templated endpoint falls back to the endpoint-bound path (no orphan).
- [ ] Endpoints list tints `{token}` only when the feature is enabled; plain URLs render normally.
- [ ] Event delivery details shows resolved `target_url` and tints template tokens; copy icons appear on hover for URL and timing cells.