### PR TITLE
fix(infra): define Configuration type before its methods

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,36 +36,6 @@ const (
 // OSS or self-hosted instance has not configured an explicit billing URL.
 const DefaultOverwatchHost = "https://overwatch.getconvoy.cloud"
 
-func (c Configuration) BillingMode(instanceLicenseKey string) BillingMode {
-	if strings.TrimSpace(c.Billing.APIKey) != "" {
-		return BillingModeCloud
-	}
-	if strings.TrimSpace(instanceLicenseKey) != "" {
-		return BillingModeLicensedSelfHosted
-	}
-	return BillingModeOSS
-}
-
-func (c Configuration) UsesOrgBilling() bool {
-	return c.BillingMode("") == BillingModeCloud
-}
-
-// BillingServiceURL returns the billing service base URL to use. OSS and
-// self-hosted instances (no billing API key) default to prod Overwatch so the
-// plan catalog, guest checkout, and license management work without operator
-// config, mirroring the SSO/license service defaults. Cloud (API key set) keeps
-// requiring an explicit URL: an empty URL there is a misconfiguration that
-// Billing.Validate already fails closed on, so this never invents a cloud host.
-func (c Configuration) BillingServiceURL() string {
-	if url := strings.TrimSpace(c.Billing.URL); url != "" {
-		return url
-	}
-	if strings.TrimSpace(c.Billing.APIKey) == "" {
-		return DefaultOverwatchHost
-	}
-	return ""
-}
-
 var cfgSingleton atomic.Value
 
 var DefaultConfiguration = Configuration{
@@ -568,6 +538,36 @@ type Configuration struct {
 	Dispatcher          DispatcherConfiguration      `json:"dispatcher"`
 	HCPVault            HCPVaultConfig               `json:"hcp_vault"`
 	Billing             BillingConfiguration         `json:"billing"`
+}
+
+func (c Configuration) BillingMode(instanceLicenseKey string) BillingMode {
+	if strings.TrimSpace(c.Billing.APIKey) != "" {
+		return BillingModeCloud
+	}
+	if strings.TrimSpace(instanceLicenseKey) != "" {
+		return BillingModeLicensedSelfHosted
+	}
+	return BillingModeOSS
+}
+
+func (c Configuration) UsesOrgBilling() bool {
+	return c.BillingMode("") == BillingModeCloud
+}
+
+// BillingServiceURL returns the billing service base URL to use. OSS and
+// self-hosted instances (no billing API key) default to prod Overwatch so the
+// plan catalog, guest checkout, and license management work without operator
+// config, mirroring the SSO/license service defaults. Cloud (API key set) keeps
+// requiring an explicit URL: an empty URL there is a misconfiguration that
+// Billing.Validate already fails closed on, so this never invents a cloud host.
+func (c Configuration) BillingServiceURL() string {
+	if url := strings.TrimSpace(c.Billing.URL); url != "" {
+		return url
+	}
+	if strings.TrimSpace(c.Billing.APIKey) == "" {
+		return DefaultOverwatchHost
+	}
+	return ""
 }
 
 type DispatcherConfiguration struct {


### PR DESCRIPTION
## Summary

- Move `BillingMode`, `UsesOrgBilling` and `BillingServiceURL` below the `Configuration` struct definition to satisfy gocritic `typeDefFirst`.

## Why

The methods were added above the `Configuration` struct, which trips `gocritic: typeDefFirst`. Normal PR lint hides it because `only-new-issues` diffs against the PR base. In the merge queue the linter cannot read the base ref to compute that diff, so it reports all issues and this pre-existing violation blocks every PR from merging.

This is a no-op refactor: only the position of three methods changes.

## Test plan

- [x] `gofmt -l config/config.go` clean
- [x] `go build ./config/`
- [x] `golangci-lint run --config=.golangci.yml ./config/...` reports no issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical code reorder in config with identical method bodies; no runtime or billing behavior impact.
> 
> **Overview**
> Relocates **`BillingMode`**, **`UsesOrgBilling`**, and **`BillingServiceURL`** on `Configuration` from above the struct to immediately after the `Configuration` type definition in `config/config.go`.
> 
> **No behavior change**—only declaration order. This satisfies **gocritic `typeDefFirst`**, which was failing in the merge queue when the linter could not diff against the PR base and reported the whole file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 038a08c6a7f3fde424a2ce406266317631512732. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->