### PR TITLE
feat(dataplane): retry budget sync, delivery description, and attempt IP

### DIFF
--- a/internal/event_deliveries/helpers.go
+++ b/internal/event_deliveries/helpers.go
@@ -143,7 +143,7 @@ func rowToEventDelivery(row interface{}) (*datastore.EventDelivery, error) {
 			ID: r.ID, ProjectID: r.ProjectID, EventID: r.EventID, SubscriptionID: r.SubscriptionID,
 			Headers: r.Headers, Attempts: r.Attempts, Status: r.Status, Metadata: r.Metadata,
 			CliMetadata: r.CliMetadata, TargetUrl: r.TargetUrl, UrlQueryParams: r.UrlQueryParams, IdempotencyKey: r.IdempotencyKey,
-			EventType: r.EventType, DeviceID: r.DeviceID, EndpointID: r.EndpointID,
+			Description: r.Description, EventType: r.EventType, DeviceID: r.DeviceID, EndpointID: r.EndpointID,
 			DeliveryMode: r.DeliveryMode,
 			CreatedAt:    r.CreatedAt, UpdatedAt: r.UpdatedAt, AcknowledgedAt: r.AcknowledgedAt,
 		}), nil

--- a/internal/event_deliveries/impl.go
+++ b/internal/event_deliveries/impl.go
@@ -280,6 +280,7 @@ func (s *Service) UpdateEventDeliveryMetadata(ctx context.Context, projectID str
 		Status:         common.StringToPgText(string(delivery.Status)),
 		Metadata:       metadataToJSONB(delivery.Metadata),
 		LatencySeconds: float64ToNumeric(delivery.LatencySeconds),
+		Description:    common.StringToPgText(delivery.Description),
 		ID:             common.StringToPgTextNullable(delivery.UID),
 		ProjectID:      common.StringToPgTextNullable(projectID),
 	}

--- a/internal/event_deliveries/impl_test.go
+++ b/internal/event_deliveries/impl_test.go
@@ -448,6 +448,9 @@ func TestFindEventDeliveryByIDSlim(t *testing.T) {
 		require.Equal(t, delivery.ProjectID, found.ProjectID)
 		require.Equal(t, delivery.EventID, found.EventID)
 
+		// Slim still loads description so write-backs do not clobber it.
+		require.Equal(t, delivery.Description, found.Description)
+
 		// Slim should NOT have JOINed metadata
 		require.Nil(t, found.Endpoint)
 		require.Nil(t, found.Event)
@@ -704,6 +707,22 @@ func TestUpdateEventDeliveryMetadata(t *testing.T) {
 		require.Equal(t, uint64(5), found.Metadata.RetryLimit)
 		require.Equal(t, uint64(120), found.Metadata.IntervalSeconds)
 		require.InDelta(t, 1.5, found.LatencySeconds, 0.01)
+	})
+
+	t.Run("PersistsDescription", func(t *testing.T) {
+		delivery := createTestEventDelivery(t, project.UID, event.UID, endpoint.UID, sub.UID)
+		require.NoError(t, service.CreateEventDelivery(ctx, delivery))
+
+		delivery.Status = datastore.FailureEventStatus
+		delivery.Description = "Retry limit exceeded"
+		delivery.Metadata = &datastore.Metadata{NumTrials: 5, RetryLimit: 5, IntervalSeconds: 1}
+
+		require.NoError(t, service.UpdateEventDeliveryMetadata(ctx, project.UID, delivery))
+
+		found, err := service.FindEventDeliveryByID(ctx, project.UID, delivery.UID)
+		require.NoError(t, err)
+		require.Equal(t, datastore.FailureEventStatus, found.Status)
+		require.Equal(t, "Retry limit exceeded", found.Description)
 	})
 }
 

--- a/internal/event_deliveries/queries.sql
+++ b/internal/event_deliveries/queries.sql
@@ -21,7 +21,7 @@ VALUES (@id, @project_id, @event_id, @endpoint_id, @device_id, @subscription_id,
 
 -- name: UpdateEventDeliveryMetadata :exec
 UPDATE convoy.event_deliveries
-SET status = @status, metadata = @metadata, latency_seconds = @latency_seconds, updated_at = NOW()
+SET status = @status, metadata = @metadata, latency_seconds = @latency_seconds, description = @description, updated_at = NOW()
 WHERE id = @id AND project_id = @project_id AND deleted_at IS NULL;
 
 -- name: UpdateStatusOfEventDeliveries :exec
@@ -72,11 +72,13 @@ LEFT JOIN convoy.sources s ON s.id = ev.source_id
 WHERE ed.deleted_at IS NULL
   AND ed.id = @id AND ed.project_id = @project_id;
 
--- Slim variant: omits description and does not JOIN endpoint/event/source/device tables.
+-- Slim variant: does not JOIN endpoint/event/source/device tables. It still loads
+-- description so the worker's write-back via UpdateEventDeliveryMetadata stays
+-- faithful and does not clobber a stored description with an empty value.
 -- name: FindEventDeliveryByIDSlim :one
 SELECT
     id, project_id, event_id, subscription_id,
-    headers, attempts, status, metadata, cli_metadata,
+    headers, attempts, status, metadata, cli_metadata, description,
 	COALESCE(target_url, '') AS target_url,
     COALESCE(url_query_params, '') AS url_query_params,
     COALESCE(idempotency_key, '') AS idempotency_key,

--- a/internal/event_deliveries/repo/querier.go
+++ b/internal/event_deliveries/repo/querier.go
@@ -39,7 +39,9 @@ type Querier interface {
 	// Group 2: Find Operations
 	// ============================================================================
 	FindEventDeliveryByID(ctx context.Context, arg FindEventDeliveryByIDParams) (FindEventDeliveryByIDRow, error)
-	// Slim variant: omits description and does not JOIN endpoint/event/source/device tables.
+	// Slim variant: does not JOIN endpoint/event/source/device tables. It still loads
+	// description so the worker's write-back via UpdateEventDeliveryMetadata stays
+	// faithful and does not clobber a stored description with an empty value.
 	FindEventDeliveryByIDSlim(ctx context.Context, arg FindEventDeliveryByIDSlimParams) (FindEventDeliveryByIDSlimRow, error)
 	FindStuckEventDeliveriesByStatus(ctx context.Context, status pgtype.Text) ([]FindStuckEventDeliveriesByStatusRow, error)
 	HardDeleteProjectEventDeliveries(ctx context.Context, arg HardDeleteProjectEventDeliveriesParams) error

--- a/internal/event_deliveries/repo/queries.sql.go
+++ b/internal/event_deliveries/repo/queries.sql.go
@@ -651,7 +651,7 @@ func (q *Queries) FindEventDeliveryByID(ctx context.Context, arg FindEventDelive
 const findEventDeliveryByIDSlim = `-- name: FindEventDeliveryByIDSlim :one
 SELECT
     id, project_id, event_id, subscription_id,
-    headers, attempts, status, metadata, cli_metadata,
+    headers, attempts, status, metadata, cli_metadata, description,
 	COALESCE(target_url, '') AS target_url,
     COALESCE(url_query_params, '') AS url_query_params,
     COALESCE(idempotency_key, '') AS idempotency_key,
@@ -681,6 +681,7 @@ type FindEventDeliveryByIDSlimRow struct {
 	Status         string
 	Metadata       []byte
 	CliMetadata    []byte
+	Description    string
 	TargetUrl      pgtype.Text
 	UrlQueryParams pgtype.Text
 	IdempotencyKey pgtype.Text
@@ -693,7 +694,9 @@ type FindEventDeliveryByIDSlimRow struct {
 	AcknowledgedAt pgtype.Timestamptz
 }
 
-// Slim variant: omits description and does not JOIN endpoint/event/source/device tables.
+// Slim variant: does not JOIN endpoint/event/source/device tables. It still loads
+// description so the worker's write-back via UpdateEventDeliveryMetadata stays
+// faithful and does not clobber a stored description with an empty value.
 func (q *Queries) FindEventDeliveryByIDSlim(ctx context.Context, arg FindEventDeliveryByIDSlimParams) (FindEventDeliveryByIDSlimRow, error) {
 	row := q.db.QueryRow(ctx, findEventDeliveryByIDSlim, arg.ProjectID, arg.ID)
 	var i FindEventDeliveryByIDSlimRow
@@ -707,6 +710,7 @@ func (q *Queries) FindEventDeliveryByIDSlim(ctx context.Context, arg FindEventDe
 		&i.Status,
 		&i.Metadata,
 		&i.CliMetadata,
+		&i.Description,
 		&i.TargetUrl,
 		&i.UrlQueryParams,
 		&i.IdempotencyKey,
@@ -1284,14 +1288,15 @@ func (q *Queries) SoftDeleteProjectEventDeliveries(ctx context.Context, arg Soft
 
 const updateEventDeliveryMetadata = `-- name: UpdateEventDeliveryMetadata :exec
 UPDATE convoy.event_deliveries
-SET status = $1, metadata = $2, latency_seconds = $3, updated_at = NOW()
-WHERE id = $4 AND project_id = $5 AND deleted_at IS NULL
+SET status = $1, metadata = $2, latency_seconds = $3, description = $4, updated_at = NOW()
+WHERE id = $5 AND project_id = $6 AND deleted_at IS NULL
 `
 
 type UpdateEventDeliveryMetadataParams struct {
 	Status         pgtype.Text
 	Metadata       []byte
 	LatencySeconds pgtype.Numeric
+	Description    pgtype.Text
 	ID             pgtype.Text
 	ProjectID      pgtype.Text
 }
@@ -1301,6 +1306,7 @@ func (q *Queries) UpdateEventDeliveryMetadata(ctx context.Context, arg UpdateEve
 		arg.Status,
 		arg.Metadata,
 		arg.LatencySeconds,
+		arg.Description,
 		arg.ID,
 		arg.ProjectID,
 	)

--- a/net/dispatcher.go
+++ b/net/dispatcher.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptrace"
 	"net/netip"
@@ -587,7 +588,40 @@ func (d *Dispatcher) do(req *http.Request, res *Response, maxResponseSize int64,
 	// time — see dispatcherOtelOpts in this file. Registering them here from
 	// the dispatcher's outer ctx would attach the events to the caller's
 	// (worker.task.*) span instead of the otelhttp child span where they
-	// belong, so we deliberately do not call httptrace.WithClientTrace here.
+	// belong, so we deliberately do not record span events here.
+	//
+	// The one hook we do attach captures the resolved remote address into
+	// res.IP. GotConn's RemoteAddr is the address the transport actually dialed,
+	// which is the forward proxy (not the endpoint) when one applies to this
+	// request. res.IP is meant to be the endpoint's address, so we skip
+	// recording it when a proxy applies and let it stay empty rather than
+	// persist a misleading proxy IP. GotConn also does not fire when no
+	// connection is established (DNS failure, connection refused, timeout), so
+	// res.IP stays empty on those no-response paths too. It records data only
+	// (no span events), so the span-attribution concern above does not apply.
+	recordIP := true
+	if d.transport != nil && d.transport.Proxy != nil {
+		if proxyURL, proxyErr := d.transport.Proxy(req); proxyErr == nil && proxyURL != nil {
+			recordIP = false
+		}
+	}
+	req = req.WithContext(httptrace.WithClientTrace(req.Context(), &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) {
+			if !recordIP || info.Conn == nil {
+				return
+			}
+			addr := info.Conn.RemoteAddr()
+			if addr == nil {
+				return
+			}
+			if host, _, splitErr := net.SplitHostPort(addr.String()); splitErr == nil {
+				res.IP = host
+			} else {
+				res.IP = addr.String()
+			}
+		},
+	}))
+
 	response, err := client.Do(req)
 	if err != nil {
 		d.logger.Error("error sending request to API endpoint", "error", err)

--- a/net/dispatcher_test.go
+++ b/net/dispatcher_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -1077,6 +1078,92 @@ func TestDispatcherWithBlockedIP(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, netjail.ErrDenied)
 	require.Contains(t, err.Error(), "127.0.0.1: address not allowed")
+}
+
+// TestDispatcherPopulatesRemoteIP verifies the dispatcher records the resolved
+// remote address of the endpoint connection into Response.IP when no proxy applies.
+func TestDispatcherPopulatesRemoteIP(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status": "success"}`))
+	}))
+	defer server.Close()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	licenser := mocks.NewMockLicenser(ctrl)
+
+	dispatcher, err := NewDispatcher(
+		licenser,
+		fflag.NewFFlag([]string{}),
+		LoggerOption(log.New("convoy", log.LevelInfo)),
+	)
+	require.NoError(t, err)
+
+	resp, err := dispatcher.SendWebhook(
+		context.Background(),
+		server.URL,
+		json.RawMessage(`{"key": "value"}`),
+		"X-Signature",
+		"test-hmac",
+		1024,
+		nil,
+		"",
+		5*time.Second,
+		constants.ContentTypeJSON,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotEmpty(t, resp.IP, "expected remote IP to be populated")
+	parsed := net.ParseIP(resp.IP)
+	require.NotNil(t, parsed, "expected resp.IP to be a valid IP, got %q", resp.IP)
+	require.True(t, parsed.IsLoopback(), "expected loopback IP from httptest server, got %q", resp.IP)
+}
+
+// TestDispatcherSkipsRemoteIPWhenProxyApplies verifies that when a forward proxy
+// applies to the request, Response.IP is left empty rather than recording the
+// proxy's address (which is not the endpoint).
+func TestDispatcherSkipsRemoteIPWhenProxyApplies(t *testing.T) {
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status": "via-proxy"}`))
+	}))
+	defer proxy.Close()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	licenser := mocks.NewMockLicenser(ctrl)
+	licenser.EXPECT().UseForwardProxy().Return(true)
+
+	dispatcher, err := NewDispatcher(
+		licenser,
+		fflag.NewFFlag([]string{}),
+		LoggerOption(log.New("convoy", log.LevelInfo)),
+		ProxyOption(proxy.URL),
+	)
+	require.NoError(t, err)
+
+	// http target so the configured HTTP proxy applies and the request is routed
+	// through the proxy server above instead of dialing the endpoint directly.
+	resp, err := dispatcher.SendWebhook(
+		context.Background(),
+		"http://example.com/webhook",
+		json.RawMessage(`{"key": "value"}`),
+		"X-Signature",
+		"test-hmac",
+		1024,
+		nil,
+		"",
+		5*time.Second,
+		constants.ContentTypeJSON,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Empty(t, resp.IP, "expected IP to be empty when a forward proxy applies")
 }
 
 // TestDispatcherWithMTLSRespectsIPRules ensures that when an mTLS certificate is provided,

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -25,6 +25,12 @@ type Job struct {
 	Payload []byte        `json:"payload"`
 	Delay   time.Duration `json:"delay"`
 
+	// MaxRetry, when set, caps how many times asynq will retry this task
+	// before archiving it. It is used to sync asynq's per-task retry budget
+	// with Convoy's configured retry limit so deliveries are not silently
+	// retried up to asynq's default (25). Nil leaves the asynq default.
+	MaxRetry *int `json:"-"`
+
 	// Headers carries the W3C trace context. The Queuer driver fills this
 	// from the active OTel span on the producer's ctx and feeds it into
 	// asynq.NewTaskWithHeaders so it rides alongside the payload. Callers

--- a/queue/redis/client.go
+++ b/queue/redis/client.go
@@ -63,8 +63,11 @@ func (q *RedisQueue) Write(ctx context.Context, taskName convoy.TaskName, queueN
 	// span on the consumer side becomes a child of the producer's. No-op
 	// when ctx has no active span, so untraced callers stay zero-cost.
 	tracectx.InjectIntoJob(ctx, job)
-	t := asynq.NewTaskWithHeaders(string(taskName), job.Payload, job.Headers,
-		asynq.Queue(s), asynq.TaskID(job.ID), asynq.ProcessIn(job.Delay))
+	opts := []asynq.Option{asynq.Queue(s), asynq.TaskID(job.ID), asynq.ProcessIn(job.Delay)}
+	if job.MaxRetry != nil {
+		opts = append(opts, asynq.MaxRetry(*job.MaxRetry))
+	}
+	t := asynq.NewTaskWithHeaders(string(taskName), job.Payload, job.Headers, opts...)
 
 	// Optimization: Try to enqueue directly first (optimistic path)
 	// This reduces from 3 Redis calls to 1 in the common case (no duplicate)
@@ -96,8 +99,11 @@ func (q *RedisQueue) WriteWithoutTimeout(ctx context.Context, taskName convoy.Ta
 	}
 
 	tracectx.InjectIntoJob(ctx, job)
-	t := asynq.NewTaskWithHeaders(string(taskName), job.Payload, job.Headers,
-		asynq.Queue(s), asynq.TaskID(job.ID), asynq.Timeout(0), asynq.ProcessIn(job.Delay))
+	opts := []asynq.Option{asynq.Queue(s), asynq.TaskID(job.ID), asynq.Timeout(0), asynq.ProcessIn(job.Delay)}
+	if job.MaxRetry != nil {
+		opts = append(opts, asynq.MaxRetry(*job.MaxRetry))
+	}
+	t := asynq.NewTaskWithHeaders(string(taskName), job.Payload, job.Headers, opts...)
 
 	// Optimization: Try to enqueue directly first (optimistic path)
 	// This reduces from 3 Redis calls to 1 in the common case (no duplicate)

--- a/web/ui/dashboard/src/app/private/components/prism/prism.component.html
+++ b/web/ui/dashboard/src/app/private/components/prism/prism.component.html
@@ -25,12 +25,13 @@
 @if (type === 'headers') {
   <div class="border border-new.primary-25 rounded-8px mb-26px">
     @for (header of getHeaders()?.headers; track $index; let i = $index) {
-      <div class="flex border-b border-new.primary-25 last-of-type:border-none p-12px text-12 text-neutral-12">
+      <div class="group flex border-b border-new.primary-25 last-of-type:border-none p-12px text-12 text-neutral-12">
         <div class="w-2/5 font-medium uppercase text-neutral-11">
           {{ header.header }}
         </div>
-        <div class="w-3/5 whitespace-nowrap overflow-hidden text-ellipsis">
-          {{ header.value }}
+        <div class="w-3/5 min-w-0 flex items-center gap-4px">
+          <span class="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap" [title]="header.value">{{ header.value }}</span>
+          <convoy-copy-button [text]="header.value" size="sm" [notificationText]="header.header + ' value copied to clipboard'" class="shrink-0 opacity-0 transition-opacity group-hover:opacity-100"></convoy-copy-button>
         </div>
       </div>
     }

--- a/web/ui/dashboard/src/app/private/components/prism/prism.module.ts
+++ b/web/ui/dashboard/src/app/private/components/prism/prism.module.ts
@@ -2,10 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PrismComponent } from './prism.component';
 import { ButtonComponent } from 'src/app/components/button/button.component';
+import { CopyButtonComponent } from 'src/app/components/copy-button/copy-button.component';
 
 @NgModule({
 	declarations: [PrismComponent],
-	imports: [CommonModule, ButtonComponent],
+	imports: [CommonModule, ButtonComponent, CopyButtonComponent],
 	exports: [PrismComponent]
 })
 export class PrismModule {}

--- a/web/ui/dashboard/src/app/services/general/general.service.ts
+++ b/web/ui/dashboard/src/app/services/general/general.service.ts
@@ -147,6 +147,21 @@ export class GeneralService {
 				break;
 		}
 
+		// Response bodies and error text arrive as raw strings (already
+		// JSON-encoded by the endpoint, or a plain message). Running
+		// JSON.stringify on a string double-encodes it (wraps in quotes, escapes
+		// inner quotes), so parse it first and only pretty-print when it is valid
+		// JSON; otherwise show the raw string as-is.
+		if ((type === 'res_body' || type === 'error') && typeof data === 'string') {
+			const raw = data.trim();
+			if (!raw) return displayMessage;
+			try {
+				return JSON.stringify(JSON.parse(raw), null, 4).replaceAll(/"([^"]+)":/g, '$1:');
+			} catch {
+				return data;
+			}
+		}
+
 		if (data) return JSON.stringify(data, null, 4).replaceAll(/"([^"]+)":/g, '$1:');
 		return displayMessage;
 	}

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -34,6 +34,11 @@ const (
 	errMutualTLSFeatureUnavailable = "mutual TLS feature unavailable, please upgrade your license"
 )
 
+// defaultAsynqMaxRetries mirrors asynq's built-in default max retry count
+// (asynq.DefaultMaxRetry, which the library does not export). The retry-queue
+// task's asynq retry budget is never set below this value.
+const defaultAsynqMaxRetries = 25
+
 var errEndpointURLTemplateTargetMissing = errors.New("endpoint URL template requires a concrete target URL")
 
 func resolveEventDeliveryTargetURL(endpoint *datastore.Endpoint, eventDelivery *datastore.EventDelivery) (string, error) {
@@ -83,6 +88,10 @@ func ProcessEventDelivery(deps EventDeliveryProcessorDeps) func(context.Context,
 
 		var data EventDelivery
 		var delayDuration time.Duration
+		// retryLimit caps how many times asynq retries the retry-queue task. It
+		// stays nil until the event delivery is loaded; early failures fall back
+		// to asynq's default budget.
+		var retryLimit *int
 
 		defer func() {
 			// retrieve the value of err
@@ -98,9 +107,10 @@ func ProcessEventDelivery(deps EventDeliveryProcessorDeps) func(context.Context,
 			}
 
 			job := &queue.Job{
-				Payload: t.Payload(),
-				Delay:   delayDuration,
-				ID:      data.EventDeliveryID,
+				Payload:  t.Payload(),
+				Delay:    delayDuration,
+				ID:       data.EventDeliveryID,
+				MaxRetry: retryLimit,
 			}
 
 			// write it to the retry queue.
@@ -134,6 +144,21 @@ func ProcessEventDelivery(deps EventDeliveryProcessorDeps) func(context.Context,
 			return &DeliveryError{Err: err}
 		}
 		eventDelivery.Metadata.MaxRetrySeconds = cfg.MaxRetrySeconds
+
+		// Sync the retry-queue task's asynq retry budget with the configured retry
+		// limit so large limits are not silently capped at asynq's default of 25.
+		// We only ever raise the budget, never lower it: limits at or below the
+		// default are already enforced by the NumTrials check below, and keeping
+		// the default budget preserves headroom for transient pre-dispatch errors.
+		// Those return an EndpointError that consumes an asynq retry without
+		// advancing NumTrials, so a tighter budget could archive the task before
+		// the configured attempts run. Rate-limit and circuit-breaker errors are
+		// excluded from this budget by the consumer's IsFailure policy.
+		rl := int(eventDelivery.Metadata.RetryLimit)
+		if rl < defaultAsynqMaxRetries {
+			rl = defaultAsynqMaxRetries
+		}
+		retryLimit = &rl
 
 		delayDuration = retrystrategies.NewRetryStrategyFromMetadata(*eventDelivery.Metadata).NextDuration(eventDelivery.Metadata.NumTrials)
 

--- a/worker/task/process_event_delivery_test.go
+++ b/worker/task/process_event_delivery_test.go
@@ -1201,6 +1201,143 @@ func TestProcessEventDelivery(t *testing.T) {
 	}
 }
 
+func TestProcessEventDelivery_SyncsAsynqMaxRetryToRetryLimit(t *testing.T) {
+	cases := []struct {
+		name         string
+		retryLimit   uint64
+		wantMaxRetry int
+	}{
+		{
+			// Above asynq's default of 25: the configured value must win so the
+			// delivery is not silently capped at 25.
+			name:         "retry limit above asynq default is honored",
+			retryLimit:   30,
+			wantMaxRetry: 30,
+		},
+		{
+			// At or below the default: the budget is floored at 25 to preserve
+			// headroom for transient pre-dispatch errors. The configured count is
+			// still enforced by the NumTrials check.
+			name:         "retry limit below asynq default is floored",
+			retryLimit:   5,
+			wantMaxRetry: defaultAsynqMaxRetries,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			endpointRepo := mocks.NewMockEndpointRepository(ctrl)
+			projectRepo := mocks.NewMockProjectRepository(ctrl)
+			msgRepo := mocks.NewMockEventDeliveryRepository(ctrl)
+			q := mocks.NewMockQueuer(ctrl)
+			rateLimiter := mocks.NewMockRateLimiter(ctrl)
+			attemptsRepo := mocks.NewMockDeliveryAttemptsRepository(ctrl)
+			licenser := mocks.NewMockLicenser(ctrl)
+			licenser.EXPECT().ProjectEnabled(gomock.Any()).Return(true).AnyTimes()
+			licenser.EXPECT().UseForwardProxy().Return(true).AnyTimes()
+			licenser.EXPECT().IpRules().Return(true).AnyTimes()
+			licenser.EXPECT().AdvancedEndpointMgmt().Return(false).AnyTimes()
+			licenser.EXPECT().CircuitBreaking().Return(false).AnyTimes()
+
+			require.NoError(t, config.LoadConfig("./testdata/Config/basic-convoy.json"))
+
+			httpmock.Activate()
+			defer httpmock.DeactivateAndReset()
+			httpmock.RegisterResponder("POST", "https://google.com", httpmock.NewStringResponder(400, ``))
+
+			endpointRepo.EXPECT().FindEndpointByID(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&datastore.Endpoint{
+					UID:               "endpoint-id-1",
+					ProjectID:         "123",
+					Url:               "https://google.com",
+					RateLimit:         10,
+					RateLimitDuration: 60,
+					Secrets:           []datastore.Secret{{Value: "secret"}},
+					Status:            datastore.ActiveEndpointStatus,
+				}, nil)
+
+			rateLimiter.EXPECT().AllowWithDuration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+			msgRepo.EXPECT().FindEventDeliveryByIDSlim(gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(&datastore.EventDelivery{
+					UID:            "evt-del-1",
+					EndpointID:     "endpoint-id-1",
+					SubscriptionID: "sub-id-1",
+					ProjectID:      "123",
+					Metadata: &datastore.Metadata{
+						Data:            []byte(`{"event":"x"}`),
+						Raw:             `{"event":"x"}`,
+						NumTrials:       0,
+						RetryLimit:      tc.retryLimit,
+						IntervalSeconds: 20,
+					},
+					Status:       datastore.ScheduledEventStatus,
+					DeliveryMode: datastore.AtLeastOnceDeliveryMode,
+				}, nil)
+
+			projectRepo.EXPECT().FetchProjectByID(gomock.Any(), gomock.Any()).
+				Return(&datastore.Project{
+					UID: "123",
+					Config: &datastore.ProjectConfig{
+						Signature: &datastore.SignatureConfiguration{
+							Header:   "X-Convoy-Signature",
+							Versions: []datastore.SignatureVersion{{UID: "abc", Hash: "SHA256", Encoding: datastore.HexEncoding}},
+						},
+						SSL:       &datastore.DefaultSSLConfig,
+						Strategy:  &datastore.StrategyConfiguration{Type: datastore.LinearStrategyProvider, Duration: 60, RetryCount: tc.retryLimit},
+						RateLimit: &datastore.DefaultRateLimitConfig,
+					},
+				}, nil)
+
+			msgRepo.EXPECT().UpdateStatusOfEventDelivery(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			attemptsRepo.EXPECT().CreateDeliveryAttempt(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+			msgRepo.EXPECT().UpdateEventDeliveryMetadata(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+			var captured *queue.Job
+			q.EXPECT().Write(gomock.Any(), convoy.RetryEventProcessor, convoy.RetryEventQueue, gomock.Any()).
+				DoAndReturn(func(_ context.Context, _ convoy.TaskName, _ convoy.QueueName, job *queue.Job) error {
+					captured = job
+					return nil
+				}).Times(1)
+
+			dispatcher, err := net.NewDispatcher(
+				licenser,
+				fflag.NewFFlag([]string{string(fflag.IpRules)}),
+				net.LoggerOption(log.New("convoy", log.LevelInfo)),
+				net.BlockListOption([]string{"10.0.0.0/8"}),
+				net.ProxyOption("nil"),
+			)
+			require.NoError(t, err)
+
+			deps := EventDeliveryProcessorDeps{
+				EndpointRepo:      endpointRepo,
+				EventDeliveryRepo: msgRepo,
+				Licenser:          licenser,
+				ProjectRepo:       projectRepo,
+				Queue:             q,
+				RateLimiter:       rateLimiter,
+				Dispatcher:        dispatcher,
+				AttemptsRepo:      attemptsRepo,
+				FeatureFlag:       fflag.NewFFlag([]string{}),
+				Logger:            log.New("convoy", log.LevelInfo),
+			}
+
+			payload, err := json.Marshal(EventDelivery{EventDeliveryID: "evt-del-1", ProjectID: "123"})
+			require.NoError(t, err)
+			task := asynq.NewTask(string(convoy.EventProcessor), payload, asynq.Queue(string(convoy.EventQueue)))
+
+			require.NoError(t, ProcessEventDelivery(deps)(context.Background(), task))
+
+			require.NotNil(t, captured, "expected a retry job to be enqueued")
+			require.NotNil(t, captured.MaxRetry, "retry job should carry a synced asynq max retry")
+			assert.Equal(t, tc.wantMaxRetry, *captured.MaxRetry)
+		})
+	}
+}
+
 func TestProcessEventDeliveryConfig(t *testing.T) {
 	tt := []struct {
 		name                string


### PR DESCRIPTION
## Summary

Aligns event delivery retry behavior with the configured retry limit, and fixes several dataplane/dashboard gaps surfaced alongside it.

### Retry budget sync
Event delivery retries run on the retry queue, which relies on asynq's auto-retry. asynq applies a default max retry of 25 per task, so deliveries configured with a retry count above 25 were silently capped at 25 instead of honoring the configured value. The retry-queue task is now stamped with an asynq max retry derived from the delivery's configured retry limit:

- The limit is only ever raised above asynq's default, never lowered. Limits at or below the default keep asynq's headroom for transient pre-dispatch errors (which return an error that consumes an asynq retry without advancing `NumTrials`) and are still enforced by the existing `NumTrials >= RetryLimit` check.
- Rate-limit and circuit-breaker errors remain excluded from the asynq retry budget via the consumer's `IsFailure` policy.
- Mechanically: `queue.Job` gains an optional `MaxRetry`, the Redis queue driver applies it as `asynq.MaxRetry` when set, and `ProcessEventDelivery` populates it from the loaded delivery before re-enqueueing to the retry queue.

### Delivery description persistence
`UpdateEventDeliveryMetadata` did not write the `description` column, so failure text such as "Retry limit exceeded" was set in memory but never persisted. The update now includes `description`, and the slim finder (`FindEventDeliveryByIDSlim`) loads it again so worker write-backs stay faithful instead of overwriting stored text with an empty value.

### Delivery attempt remote IP
`Response.IP` was declared but never populated, so delivery attempts always stored an empty `ip_address`. The dispatcher now records the dialed remote address via an `httptrace.GotConn` hook, and skips it when a forward proxy applies (and on no-connection errors) so a proxy egress address is never persisted as the endpoint IP.

### Dashboard
- Header values in the attempt view (for example `X-Convoy-Signature`) get a hover copy button so long, truncated values can be copied in full.
- Response body and error strings are parsed before pretty-printing, so JSON payloads are no longer double-encoded and plain messages render without surrounding quotes.

## Test plan

- [x] `go test ./worker/task` (asynq max-retry sync table test; retry/delivery processors)
- [x] `go test ./net` (remote IP populated without a proxy, skipped when a proxy applies)
- [x] `go test ./internal/event_deliveries` (description persists on metadata update; slim finder loads description)
- [x] `go vet` + `golangci-lint` on `net/...`, `queue/...`, `worker/task/...`, `internal/event_deliveries/...`
- [x] Dashboard lint
