### PR TITLE
feat(controlplane): send version and instance id on validate

### DIFF
--- a/cmd/hooks/hooks.go
+++ b/cmd/hooks/hooks.go
@@ -210,11 +210,29 @@ func PreRun(app *cli.App, db *postgres.Postgres) func(cmd *cobra.Command, args [
 
 		app.Rate = rateLimiter
 
+		// Load the instance configuration UID before building the license client
+		// so validation requests can include the deployment_id. If configuration
+		// is unavailable (or this command skips config load) we proceed with an
+		// empty value rather than blocking startup.
+		if _, ok := skipConfigLoadCmd[cmd.Use]; !ok {
+			configRepo := configuration.New(app.Logger, app.DB)
+			instCfg, cfgErr := configRepo.LoadConfiguration(cmd.Context())
+			if cfgErr != nil {
+				lo.Error("Failed to load configuration", "error", cfgErr)
+			} else {
+				cfg.InstanceId = instCfg.UID
+				if err := config.Override(&cfg); err != nil {
+					return err
+				}
+			}
+		}
+
 		licenseClient := service.NewClient(service.Config{
 			Host:         cfg.LicenseService.Host,
 			ValidatePath: cfg.LicenseService.ValidatePath,
 			Timeout:      cfg.LicenseService.Timeout,
 			RetryCount:   cfg.LicenseService.RetryCount,
+			DeploymentID: cfg.InstanceId,
 			Logger:       lo,
 		})
 
@@ -242,20 +260,6 @@ func PreRun(app *cli.App, db *postgres.Postgres) func(cmd *cobra.Command, args [
 		if db.ReplicaSize() > 0 && !app.Licenser.ReadReplica() {
 			lo.Error("your instance does not have access to use read replicas, upgrade to access this feature")
 			db.UnsetReplicas()
-		}
-
-		// update config singleton with the instance id
-		if _, ok := skipConfigLoadCmd[cmd.Use]; !ok {
-			configRepo := configuration.New(app.Logger, app.DB)
-			instCfg, err := configRepo.LoadConfiguration(cmd.Context())
-			if err != nil {
-				lo.Error("Failed to load configuration", "error", err)
-			} else {
-				cfg.InstanceId = instCfg.UID
-				if err := config.Override(&cfg); err != nil {
-					return err
-				}
-			}
 		}
 
 		app.TracerBackend, err = tracer.Init(cfg.Tracer, cmd.Name(), app.Licenser)

--- a/internal/pkg/license/service/client.go
+++ b/internal/pkg/license/service/client.go
@@ -11,6 +11,7 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
+	"github.com/frain-dev/convoy"
 	"github.com/frain-dev/convoy/config"
 	log "github.com/frain-dev/convoy/pkg/logger"
 )
@@ -32,6 +33,8 @@ type Client struct {
 	validatePath string
 	timeout      time.Duration
 	retryCount   int
+	version      string
+	deploymentID string
 	httpClient   *http.Client
 	logger       log.Logger
 }
@@ -42,6 +45,11 @@ type Config struct {
 	ValidatePath string
 	Timeout      time.Duration
 	RetryCount   int
+	// Version is sent with validation requests; defaults to convoy.GetVersion() when empty.
+	Version string
+	// DeploymentID is the instance configuration UID sent with validation
+	// requests; empty when configuration is unavailable.
+	DeploymentID string
 	Logger       log.Logger
 }
 
@@ -72,12 +80,17 @@ func NewClient(cfg Config) *Client {
 	if cfg.RetryCount == 0 {
 		cfg.RetryCount = DefaultRetryCount
 	}
+	if cfg.Version == "" {
+		cfg.Version = convoy.GetVersion()
+	}
 
 	return &Client{
 		host:         cfg.Host,
 		validatePath: cfg.ValidatePath,
 		timeout:      cfg.Timeout,
 		retryCount:   cfg.RetryCount,
+		version:      cfg.Version,
+		deploymentID: cfg.DeploymentID,
 		httpClient: &http.Client{
 			Timeout:   cfg.Timeout,
 			Transport: otelhttp.NewTransport(http.DefaultTransport),
@@ -93,7 +106,9 @@ func (c *Client) ValidateLicense(ctx context.Context, licenseKey string) (*Licen
 	}
 
 	reqBody := ValidateLicenseRequest{
-		LicenseKey: licenseKey,
+		LicenseKey:   licenseKey,
+		Version:      c.version,
+		DeploymentID: c.deploymentID,
 	}
 
 	jsonData, err := json.Marshal(reqBody)

--- a/internal/pkg/license/service/client_test.go
+++ b/internal/pkg/license/service/client_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateLicenseSendsVersionAndDeploymentID(t *testing.T) {
+	var got map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &got))
+		_, _ = w.Write([]byte(`{"status":true,"data":{"valid":true,"status":"active","entitlements":[]}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(Config{
+		Host:         srv.URL,
+		ValidatePath: "/validate",
+		Version:      "9.9.9",
+		DeploymentID: "depl_test",
+	})
+
+	_, err := c.ValidateLicense(context.Background(), "some-key")
+	require.NoError(t, err)
+
+	require.Equal(t, "some-key", got["license_key"])
+	require.Equal(t, "9.9.9", got["version"])
+	require.Equal(t, "depl_test", got["deployment_id"])
+}
+
+func TestValidateLicenseOmitsEmptyDeploymentID(t *testing.T) {
+	var got map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &got))
+		_, _ = w.Write([]byte(`{"status":true,"data":{"valid":true,"status":"active","entitlements":[]}}`))
+	}))
+	defer srv.Close()
+
+	// No DeploymentID set: it must be omitted from the payload. Version defaults
+	// to convoy.GetVersion() and is always present.
+	c := NewClient(Config{
+		Host:         srv.URL,
+		ValidatePath: "/validate",
+	})
+
+	_, err := c.ValidateLicense(context.Background(), "some-key")
+	require.NoError(t, err)
+
+	_, hasDeployment := got["deployment_id"]
+	require.False(t, hasDeployment)
+	require.NotEmpty(t, got["version"])
+}

--- a/internal/pkg/license/service/models.go
+++ b/internal/pkg/license/service/models.go
@@ -6,9 +6,12 @@ import (
 	"time"
 )
 
-// ValidateLicenseRequest represents the request to validate a license
+// ValidateLicenseRequest represents the request to validate a license.
+// Version and DeploymentID are optional request metadata and are omitted when empty.
 type ValidateLicenseRequest struct {
-	LicenseKey string `json:"license_key"`
+	LicenseKey   string `json:"license_key"`
+	Version      string `json:"version,omitempty"`
+	DeploymentID string `json:"deployment_id,omitempty"`
 }
 
 // LicenseValidationResponse represents the response from the license service


### PR DESCRIPTION
## Summary
- Include build version and instance configuration uid on license validate requests
- Load instance config before the license client is built
- Omit instance id when configuration is unavailable

## Test plan
- [x] `go test ./internal/pkg/license/service/...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive metadata on license HTTP calls and a startup ordering change; validation behavior is unchanged aside from the request payload.
> 
> **Overview**
> License validation calls to Overwatch now include **build version** (defaulting to `convoy.GetVersion()` when not set) and optional **`deployment_id`** (the instance configuration UID).
> 
> **Startup (`cmd/hooks`)** loads instance configuration **before** constructing the license client so `cfg.InstanceId` can be passed as `DeploymentID`. If config load fails or the command skips it (e.g. `bootstrap`), startup continues without a deployment id rather than failing.
> 
> The validate JSON body gains `version` and `deployment_id` fields (`omitempty` on deployment id). Tests assert the payload includes both when set and omits `deployment_id` when empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ebda59b4c8f275cdd5d65e4d0b3b47b02472626. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->