### PR TITLE
fix(auth): return descriptive error when login fails with non-ServiceError

### DIFF
--- a/api/handlers/auth.go
+++ b/api/handlers/auth.go
@@ -234,6 +234,8 @@ func (h *Handler) LoginUser(w http.ResponseWriter, r *http.Request) {
 			default:
 				errMsg = "Invalid credentials"
 			}
+		} else {
+			errMsg = "Authentication failed"
 		}
 
 		_ = render.Render(w, r, util.NewErrorResponse(errMsg, http.StatusForbidden))


### PR DESCRIPTION
LoginUser handler returned empty error message when the login error was not a *services.ServiceError, since errMsg was never set outside the type assertion. Adds fallback to "Authentication failed" for unexpected error types.

Fixes #2658

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-handler error-message fallback with no auth logic or credential-check changes.
> 
> **Overview**
> Fixes **empty error messages** on failed password login when `LoginUserService` returns an error that is not a `*services.ServiceError`.
> 
> In `LoginUser`, the handler now sets **`Authentication failed`** in an `else` branch after the existing `ServiceError` handling (license-expired message vs **Invalid credentials**). Clients always get a non-blank `403` message for unexpected failure types instead of an empty string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d36bd83947e654af13c5a3402de1a1a4d57d6c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->