### PR TITLE
fix(dataplane): capture delivery attempt timestamps around the dispatch call

### DIFF
--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -355,7 +355,9 @@ func ProcessEventDelivery(deps EventDeliveryProcessorDeps) func(context.Context,
 			}
 		}
 
+		requestSentAt := time.Now()
 		resp, err := deps.Dispatcher.SendWebhookWithMTLS(ctx, targetURL, sig.Payload, project.Config.Signature.Header.String(), header, int64(cfg.MaxResponseSize), eventDelivery.Headers, eventDelivery.IdempotencyKey, httpDuration, contentType, mtlsCert)
+		responseReceivedAt := time.Now()
 
 		status := "-"
 		statusCode := 0
@@ -436,9 +438,9 @@ func ProcessEventDelivery(deps EventDeliveryProcessorDeps) func(context.Context,
 
 		respondedAt := time.Time{}
 		if resp != nil && resp.StatusCode >= 100 {
-			respondedAt = httpDispatchStart.Add(duration)
+			respondedAt = responseReceivedAt
 		}
-		attempt := parseAttemptFromResponse(eventDelivery, endpoint, resp, attemptStatus, httpDispatchStart, respondedAt)
+		attempt := parseAttemptFromResponse(eventDelivery, endpoint, resp, attemptStatus, requestSentAt, respondedAt)
 		eventDelivery.Metadata.NumTrials++
 
 		if eventDelivery.Metadata.NumTrials >= eventDelivery.Metadata.RetryLimit {

--- a/worker/task/process_event_delivery_test.go
+++ b/worker/task/process_event_delivery_test.go
@@ -1404,3 +1404,127 @@ func TestProcessEventDeliveryConfig(t *testing.T) {
 		})
 	}
 }
+
+// TestProcessEventDelivery_AttemptTimingReflectsWireDelay proves the attempt's
+// requested_at/responded_at bracket the actual dispatch call: the gap tracks the
+// real round trip instead of collapsing to ~0 or including our pre-send prep time.
+func TestProcessEventDelivery_AttemptTimingReflectsWireDelay(t *testing.T) {
+	const wireDelay = 60 * time.Millisecond
+	slowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(wireDelay)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer slowServer.Close()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	endpointRepo := mocks.NewMockEndpointRepository(ctrl)
+	projectRepo := mocks.NewMockProjectRepository(ctrl)
+	msgRepo := mocks.NewMockEventDeliveryRepository(ctrl)
+	q := mocks.NewMockQueuer(ctrl)
+	rateLimiter := mocks.NewMockRateLimiter(ctrl)
+	attemptsRepo := mocks.NewMockDeliveryAttemptsRepository(ctrl)
+	licenser := mocks.NewMockLicenser(ctrl)
+	licenser.EXPECT().ProjectEnabled(gomock.Any()).Return(true).AnyTimes()
+	licenser.EXPECT().UseForwardProxy().Return(true).AnyTimes()
+	licenser.EXPECT().IpRules().Return(true).AnyTimes()
+	licenser.EXPECT().AdvancedEndpointMgmt().Return(false).AnyTimes()
+	licenser.EXPECT().CircuitBreaking().Return(false).AnyTimes()
+
+	require.NoError(t, config.LoadConfig("./testdata/Config/basic-convoy.json"))
+
+	endpointRepo.EXPECT().FindEndpointByID(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&datastore.Endpoint{
+			UID:               "endpoint-id-1",
+			ProjectID:         "123",
+			Url:               slowServer.URL,
+			RateLimit:         10,
+			RateLimitDuration: 60,
+			Secrets:           []datastore.Secret{{Value: "secret"}},
+			Status:            datastore.ActiveEndpointStatus,
+		}, nil)
+
+	rateLimiter.EXPECT().AllowWithDuration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	// At-most-once with a non-2xx response fails without a retry, so the flow
+	// returns nil with no retry enqueue: the minimal path that still records an
+	// attempt with both timestamps.
+	msgRepo.EXPECT().FindEventDeliveryByIDSlim(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&datastore.EventDelivery{
+			UID:            "evt-del-1",
+			EndpointID:     "endpoint-id-1",
+			SubscriptionID: "sub-id-1",
+			ProjectID:      "123",
+			Metadata: &datastore.Metadata{
+				Data:            []byte(`{"event":"x"}`),
+				Raw:             `{"event":"x"}`,
+				NumTrials:       0,
+				RetryLimit:      3,
+				IntervalSeconds: 20,
+			},
+			Status:       datastore.ScheduledEventStatus,
+			DeliveryMode: datastore.AtMostOnceDeliveryMode,
+		}, nil)
+
+	projectRepo.EXPECT().FetchProjectByID(gomock.Any(), gomock.Any()).
+		Return(&datastore.Project{
+			UID: "123",
+			Config: &datastore.ProjectConfig{
+				Signature: &datastore.SignatureConfiguration{
+					Header:   "X-Convoy-Signature",
+					Versions: []datastore.SignatureVersion{{UID: "abc", Hash: "SHA256", Encoding: datastore.HexEncoding}},
+				},
+				SSL:       &datastore.DefaultSSLConfig,
+				Strategy:  &datastore.StrategyConfiguration{Type: datastore.LinearStrategyProvider, Duration: 60, RetryCount: 3},
+				RateLimit: &datastore.DefaultRateLimitConfig,
+			},
+		}, nil)
+
+	msgRepo.EXPECT().UpdateStatusOfEventDelivery(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	var captured *datastore.DeliveryAttempt
+	attemptsRepo.EXPECT().CreateDeliveryAttempt(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, a *datastore.DeliveryAttempt) error {
+			captured = a
+			return nil
+		}).Times(1)
+
+	msgRepo.EXPECT().UpdateEventDeliveryMetadata(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	// Plain dispatcher: no IpRules flag, blocklist, or proxy, so the delivery
+	// reaches the loopback test server for a real, measurable round trip.
+	dispatcher, err := net.NewDispatcher(
+		licenser,
+		fflag.NewFFlag([]string{}),
+		net.LoggerOption(log.New("convoy", log.LevelInfo)),
+	)
+	require.NoError(t, err)
+
+	deps := EventDeliveryProcessorDeps{
+		EndpointRepo:      endpointRepo,
+		EventDeliveryRepo: msgRepo,
+		Licenser:          licenser,
+		ProjectRepo:       projectRepo,
+		Queue:             q,
+		RateLimiter:       rateLimiter,
+		Dispatcher:        dispatcher,
+		AttemptsRepo:      attemptsRepo,
+		FeatureFlag:       fflag.NewFFlag([]string{}),
+		Logger:            log.New("convoy", log.LevelInfo),
+	}
+
+	payload, err := json.Marshal(EventDelivery{EventDeliveryID: "evt-del-1", ProjectID: "123"})
+	require.NoError(t, err)
+	task := asynq.NewTask(string(convoy.EventProcessor), payload, asynq.Queue(string(convoy.EventQueue)))
+
+	require.NoError(t, ProcessEventDelivery(deps)(context.Background(), task))
+
+	require.NotNil(t, captured, "expected a delivery attempt to be created")
+	require.True(t, captured.RequestedAt.Valid, "requested_at should be set")
+	require.True(t, captured.RespondedAt.Valid, "responded_at should be set on a completed round trip")
+	require.False(t, captured.RespondedAt.Time.Before(captured.RequestedAt.Time), "responded_at must not precede requested_at")
+
+	gap := captured.RespondedAt.Time.Sub(captured.RequestedAt.Time)
+	require.GreaterOrEqual(t, gap, wireDelay/2, "responded_at - requested_at should reflect the real round trip, got %s", gap)
+}

--- a/worker/task/process_retry_event_delivery.go
+++ b/worker/task/process_retry_event_delivery.go
@@ -289,7 +289,9 @@ func ProcessRetryEventDelivery(deps EventDeliveryProcessorDeps) func(context.Con
 			}
 		}
 
+		requestSentAt := time.Now()
 		resp, err := deps.Dispatcher.SendWebhookWithMTLS(ctx, targetURL, sig.Payload, project.Config.Signature.Header.String(), header, int64(cfg.MaxResponseSize), eventDelivery.Headers, eventDelivery.IdempotencyKey, httpDuration, contentType, mtlsCert)
+		responseReceivedAt := time.Now()
 
 		status := "-"
 		statusCode := 0
@@ -359,9 +361,9 @@ func ProcessRetryEventDelivery(deps EventDeliveryProcessorDeps) func(context.Con
 
 		respondedAt := time.Time{}
 		if resp != nil && resp.StatusCode >= 100 {
-			respondedAt = httpDispatchStart.Add(duration)
+			respondedAt = responseReceivedAt
 		}
-		attempt = parseAttemptFromResponse(eventDelivery, endpoint, resp, attemptStatus, httpDispatchStart, respondedAt)
+		attempt = parseAttemptFromResponse(eventDelivery, endpoint, resp, attemptStatus, requestSentAt, respondedAt)
 
 		eventDelivery.Metadata.NumTrials++
 

--- a/worker/task/process_retry_event_delivery_test.go
+++ b/worker/task/process_retry_event_delivery_test.go
@@ -1304,3 +1304,124 @@ func TestProcessRetryEventDeliveryConfig(t *testing.T) {
 		})
 	}
 }
+
+// TestProcessRetryEventDelivery_AttemptTimingReflectsWireDelay mirrors the
+// primary-path timing test for the retry worker: the recorded attempt's
+// requested_at/responded_at must bracket the real dispatch call.
+func TestProcessRetryEventDelivery_AttemptTimingReflectsWireDelay(t *testing.T) {
+	const wireDelay = 60 * time.Millisecond
+	slowServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(wireDelay)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer slowServer.Close()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	endpointRepo := mocks.NewMockEndpointRepository(ctrl)
+	projectRepo := mocks.NewMockProjectRepository(ctrl)
+	msgRepo := mocks.NewMockEventDeliveryRepository(ctrl)
+	q := mocks.NewMockQueuer(ctrl)
+	rateLimiter := mocks.NewMockRateLimiter(ctrl)
+	attemptsRepo := mocks.NewMockDeliveryAttemptsRepository(ctrl)
+	licenser := mocks.NewMockLicenser(ctrl)
+	licenser.EXPECT().ProjectEnabled(gomock.Any()).Return(true).AnyTimes()
+	licenser.EXPECT().UseForwardProxy().Return(true).AnyTimes()
+	licenser.EXPECT().IpRules().Return(true).AnyTimes()
+	licenser.EXPECT().AdvancedEndpointMgmt().Return(false).AnyTimes()
+	licenser.EXPECT().CircuitBreaking().Return(false).AnyTimes()
+
+	require.NoError(t, config.LoadConfig("./testdata/Config/basic-convoy.json"))
+
+	endpointRepo.EXPECT().FindEndpointByID(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&datastore.Endpoint{
+			UID:               "endpoint-id-1",
+			ProjectID:         "123",
+			Url:               slowServer.URL,
+			RateLimit:         10,
+			RateLimitDuration: 60,
+			Secrets:           []datastore.Secret{{Value: "secret"}},
+			Status:            datastore.ActiveEndpointStatus,
+		}, nil)
+
+	rateLimiter.EXPECT().AllowWithDuration(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	msgRepo.EXPECT().FindEventDeliveryByID(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&datastore.EventDelivery{
+			UID:            "evt-del-1",
+			EndpointID:     "endpoint-id-1",
+			SubscriptionID: "sub-id-1",
+			ProjectID:      "123",
+			Metadata: &datastore.Metadata{
+				Data:            []byte(`{"event":"x"}`),
+				Raw:             `{"event":"x"}`,
+				NumTrials:       0,
+				RetryLimit:      3,
+				IntervalSeconds: 20,
+			},
+			Status:       datastore.ScheduledEventStatus,
+			DeliveryMode: datastore.AtMostOnceDeliveryMode,
+		}, nil)
+
+	projectRepo.EXPECT().FetchProjectByID(gomock.Any(), gomock.Any()).
+		Return(&datastore.Project{
+			UID: "123",
+			Config: &datastore.ProjectConfig{
+				Signature: &datastore.SignatureConfiguration{
+					Header:   "X-Convoy-Signature",
+					Versions: []datastore.SignatureVersion{{UID: "abc", Hash: "SHA256", Encoding: datastore.HexEncoding}},
+				},
+				SSL:       &datastore.DefaultSSLConfig,
+				Strategy:  &datastore.StrategyConfiguration{Type: datastore.LinearStrategyProvider, Duration: 60, RetryCount: 3},
+				RateLimit: &datastore.DefaultRateLimitConfig,
+			},
+		}, nil)
+
+	msgRepo.EXPECT().UpdateStatusOfEventDelivery(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	var captured *datastore.DeliveryAttempt
+	attemptsRepo.EXPECT().CreateDeliveryAttempt(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, a *datastore.DeliveryAttempt) error {
+			captured = a
+			return nil
+		}).Times(1)
+
+	msgRepo.EXPECT().UpdateEventDeliveryMetadata(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	// Plain dispatcher: no IpRules flag, blocklist, or proxy, so the delivery
+	// reaches the loopback test server for a real, measurable round trip.
+	dispatcher, err := net.NewDispatcher(
+		licenser,
+		fflag.NewFFlag([]string{}),
+		net.LoggerOption(log.New("convoy", log.LevelInfo)),
+	)
+	require.NoError(t, err)
+
+	deps := EventDeliveryProcessorDeps{
+		EndpointRepo:      endpointRepo,
+		EventDeliveryRepo: msgRepo,
+		Licenser:          licenser,
+		ProjectRepo:       projectRepo,
+		Queue:             q,
+		RateLimiter:       rateLimiter,
+		Dispatcher:        dispatcher,
+		AttemptsRepo:      attemptsRepo,
+		FeatureFlag:       fflag.NewFFlag([]string{}),
+		Logger:            log.New("convoy", log.LevelInfo),
+	}
+
+	payload, err := json.Marshal(EventDelivery{EventDeliveryID: "evt-del-1", ProjectID: "123"})
+	require.NoError(t, err)
+	task := asynq.NewTask(string(convoy.EventProcessor), payload, asynq.Queue(string(convoy.EventQueue)))
+
+	require.NoError(t, ProcessRetryEventDelivery(deps)(context.Background(), task))
+
+	require.NotNil(t, captured, "expected a delivery attempt to be created")
+	require.True(t, captured.RequestedAt.Valid, "requested_at should be set")
+	require.True(t, captured.RespondedAt.Valid, "responded_at should be set on a completed round trip")
+	require.False(t, captured.RespondedAt.Time.Before(captured.RequestedAt.Time), "responded_at must not precede requested_at")
+
+	gap := captured.RespondedAt.Time.Sub(captured.RequestedAt.Time)
+	require.GreaterOrEqual(t, gap, wireDelay/2, "responded_at - requested_at should reflect the real round trip, got %s", gap)
+}


### PR DESCRIPTION
## Summary

- `requested_at` on a delivery attempt was stamped at `httpDispatchStart`, captured before signature/header/mTLS prep, and `responded_at` was `httpDispatchStart + elapsed duration`. So `responded_at - requested_at` overstated real endpoint latency by our own pre-send prep time.
- Capture `requestSentAt` immediately before the `SendWebhookWithMTLS` call and `responseReceivedAt` immediately after it returns, in both `process_event_delivery.go` and `process_retry_event_delivery.go`, and pass those to `parseAttemptFromResponse`.
- The `resp != nil && resp.StatusCode >= 100` guard is unchanged, so `responded_at` stays null on no-response. `httpDispatchStart`/`duration` remain for the existing latency logging (no orphans).

## Test plan

- [x] `gofmt`, `go vet`, `golangci-lint` clean on `worker/task`
- [x] Full `worker/task` package green (122 tests)
- [x] New flow tests `TestProcess{Event,RetryEvent}Delivery_AttemptTimingReflectsWireDelay` drive a slow loopback server through a real dispatcher and assert `responded_at - requested_at` reflects the actual round trip (guards against regressing to prep-inclusive timing)