### PR TITLE
feat(controlplane): print user/org ids and optionally mint an api key on bootstrap

### DIFF
--- a/cmd/bootstrap/bootstrap.go
+++ b/cmd/bootstrap/bootstrap.go
@@ -10,20 +10,70 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/spf13/cobra"
 
+	"github.com/frain-dev/convoy/api/models"
 	"github.com/frain-dev/convoy/datastore"
+	"github.com/frain-dev/convoy/internal/api_keys"
 	"github.com/frain-dev/convoy/internal/organisation_members"
 	"github.com/frain-dev/convoy/internal/organisations"
 	"github.com/frain-dev/convoy/internal/pkg/cli"
+	"github.com/frain-dev/convoy/internal/projects"
 	"github.com/frain-dev/convoy/internal/users"
+	log "github.com/frain-dev/convoy/pkg/logger"
 	"github.com/frain-dev/convoy/services"
 	"github.com/frain-dev/convoy/util"
 )
+
+type bootstrapOutput struct {
+	FirstName       string `json:"first_name,omitempty"`
+	LastName        string `json:"last_name,omitempty"`
+	Email           string `json:"email,omitempty"`
+	Password        string `json:"password,omitempty"`
+	UserID          string `json:"user_id,omitempty"`
+	OrganisationID  string `json:"organisation_id,omitempty"`
+	APIKey          string `json:"api_key,omitempty"`
+	APIKeyID        string `json:"api_key_id,omitempty"`
+	APIKeyExpiresAt string `json:"api_key_expires_at,omitempty"`
+}
+
+// printBootstrapOutput writes the seeded credentials to stdout. Secrets
+// (password, api_key) are emitted here only, never through the logger.
+func printBootstrapOutput(format string, out *bootstrapOutput, logger log.Logger) error {
+	switch format {
+	case "json":
+		data, err := json.MarshalIndent(out, "", "    ")
+		if err != nil {
+			logger.Error("Error printing config", "error", err)
+			return err
+		}
+
+		fmt.Println(string(data))
+	case "human":
+		fmt.Printf("Email: %s\n", out.Email)
+		fmt.Printf("Password: %s\n", out.Password)
+		fmt.Printf("First Name: %s\n", out.FirstName)
+		fmt.Printf("Last Name: %s\n", out.LastName)
+		fmt.Printf("User ID: %s\n", out.UserID)
+		fmt.Printf("Organisation ID: %s\n", out.OrganisationID)
+		if out.APIKey != "" {
+			fmt.Printf("API Key: %s\n", out.APIKey)
+			fmt.Printf("API Key ID: %s\n", out.APIKeyID)
+			fmt.Printf("API Key Expires At: %s\n", out.APIKeyExpiresAt)
+		}
+	default:
+		return errors.New("unsupported output format")
+	}
+
+	return nil
+}
 
 func AddBootstrapCommand(a *cli.App) *cobra.Command {
 	var firstName string
 	var lastName string
 	var format string
 	var email string
+	var withAPIKey bool
+	var apiKeyName string
+	var apiKeyExpiration int
 
 	cmd := &cobra.Command{
 		Use:   "bootstrap",
@@ -32,6 +82,27 @@ func AddBootstrapCommand(a *cli.App) *cobra.Command {
 			"ShouldBootstrap": "false",
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if format != "json" && format != "human" {
+				return errors.New("unsupported output format")
+			}
+
+			if util.IsStringEmpty(email) {
+				return errors.New("email is required")
+			}
+
+			// Validate the API key flags up front, before any license check or
+			// record creation, so a bad flag combination fails fast and cannot
+			// leave a half-seeded user/organisation.
+			if !withAPIKey && (cmd.Flags().Changed("api-key-name") || cmd.Flags().Changed("api-key-expiration")) {
+				return errors.New("--api-key-name and --api-key-expiration require --with-api-key")
+			}
+
+			// An explicit expiration must be positive; when unset (0) the key
+			// service applies its own default (24h).
+			if cmd.Flags().Changed("api-key-expiration") && apiKeyExpiration <= 0 {
+				return errors.New("--api-key-expiration must be greater than 0 (days)")
+			}
+
 			ok, err := a.Licenser.CheckUserLimit(context.Background())
 			if err != nil {
 				return err
@@ -39,14 +110,6 @@ func AddBootstrapCommand(a *cli.App) *cobra.Command {
 
 			if !ok {
 				return services.ErrUserLimit
-			}
-
-			if format != "json" && format != "human" {
-				return errors.New("unsupported output format")
-			}
-
-			if util.IsStringEmpty(email) {
-				return errors.New("email is required")
 			}
 
 			password, err := util.GenerateSecret()
@@ -92,51 +155,69 @@ func AddBootstrapCommand(a *cli.App) *cobra.Command {
 				a.Logger,
 			)
 
-			_, err = co.Run(context.Background())
+			org, err := co.Run(context.Background())
 			if err != nil {
 				return err
 			}
 
-			type JsonUser struct {
-				FirstName string `json:"first_name,omitempty"`
-				LastName  string `json:"last_name,omitempty"`
-				Email     string `json:"email,omitempty"`
-				Password  string `json:"password,omitempty"`
+			// The user and organisation are now persisted. The generated
+			// password lives only in memory, and a rerun with the same email
+			// exits on duplicate email without re-emitting it, so any later
+			// failure must still print these credentials or the account is
+			// stranded.
+			out := &bootstrapOutput{
+				Email:          user.Email,
+				Password:       p.Plaintext,
+				FirstName:      user.FirstName,
+				LastName:       user.LastName,
+				UserID:         user.UID,
+				OrganisationID: org.UID,
 			}
 
-			jsUser := &JsonUser{
-				Email:     user.Email,
-				Password:  p.Plaintext,
-				FirstName: user.FirstName,
-				LastName:  user.LastName,
-			}
-
-			switch format {
-			case "json":
-				data, err := json.MarshalIndent(jsUser, "", "    ")
-				if err != nil {
-					a.Logger.Error("Error printing config", "error", err)
-					return err
+			// Optionally mint a personal API key for the bootstrapped user so
+			// the instance can be seeded fully via the API with no login step.
+			// The key is a durable, org-admin credential; it is printed to
+			// stdout only (never logged) and is revocable via api_key_id.
+			if withAPIKey {
+				cpk := &services.CreatePersonalAPIKeyService{
+					ProjectRepo: projects.New(a.Logger, a.DB),
+					UserRepo:    userRepo,
+					APIKeyRepo:  api_keys.New(a.Logger, a.DB),
+					User:        user,
+					NewApiKey:   &models.PersonalAPIKey{Name: apiKeyName, Expiration: apiKeyExpiration},
+					Logger:      a.Logger,
 				}
 
-				fmt.Println(string(data))
-			case "human":
-				fmt.Printf("Email: %s\n", jsUser.Email)
-				fmt.Printf("Password: %s\n", jsUser.Password)
-				fmt.Printf("First Name: %s\n", jsUser.FirstName)
-				fmt.Printf("Last Name: %s\n", jsUser.LastName)
-			default:
-				return errors.New("unsupported output format")
+				apiKey, keyString, keyErr := cpk.Run(context.Background())
+				if keyErr != nil {
+					// Fail closed on the exit code, but still emit the user
+					// credentials first so the already-created admin account is
+					// recoverable via login even though the key mint failed.
+					a.Logger.Error("bootstrap: api key minting failed after user/org creation", "error", keyErr)
+					if printErr := printBootstrapOutput(format, out, a.Logger); printErr != nil {
+						return printErr
+					}
+					return keyErr
+				}
+
+				out.APIKey = keyString
+				out.APIKeyID = apiKey.UID
+				if apiKey.ExpiresAt.Valid {
+					out.APIKeyExpiresAt = apiKey.ExpiresAt.Time.UTC().Format(time.RFC3339)
+				}
 			}
 
-			return nil
+			return printBootstrapOutput(format, out, a.Logger)
 		},
 	}
 
 	cmd.Flags().StringVar(&email, "email", "", "Email")
-	cmd.Flags().StringVar(&firstName, "first-name", "admin", "Email")
-	cmd.Flags().StringVar(&lastName, "last-name", "admin", "Email")
+	cmd.Flags().StringVar(&firstName, "first-name", "admin", "First name")
+	cmd.Flags().StringVar(&lastName, "last-name", "admin", "Last name")
 	cmd.Flags().StringVar(&format, "format", "json", "Output Format")
+	cmd.Flags().BoolVar(&withAPIKey, "with-api-key", false, "Also mint and print a personal API key for the user")
+	cmd.Flags().StringVar(&apiKeyName, "api-key-name", "bootstrap-key", "Name for the minted API key (requires --with-api-key)")
+	cmd.Flags().IntVar(&apiKeyExpiration, "api-key-expiration", 0, "API key lifetime in days; 0 uses the default (24h). Rerun on an existing user will not re-mint (requires --with-api-key)")
 
 	return cmd
 }

--- a/cmd/bootstrap/bootstrap_test.go
+++ b/cmd/bootstrap/bootstrap_test.go
@@ -1,0 +1,67 @@
+package bootstrap
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/frain-dev/convoy/internal/pkg/cli"
+)
+
+// These cases all return during up-front argument validation, before the
+// command touches the licenser or the database, so a zero-value cli.App is
+// sufficient to exercise them.
+func TestBootstrapCommand_FlagValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "unsupported format",
+			args:    []string{"--format", "xml"},
+			wantErr: "unsupported output format",
+		},
+		{
+			name:    "missing email",
+			args:    []string{"--format", "json"},
+			wantErr: "email is required",
+		},
+		{
+			name:    "api-key-expiration without with-api-key",
+			args:    []string{"--email", "seed@example.com", "--api-key-expiration", "90"},
+			wantErr: "--api-key-name and --api-key-expiration require --with-api-key",
+		},
+		{
+			name:    "api-key-name without with-api-key",
+			args:    []string{"--email", "seed@example.com", "--api-key-name", "seed"},
+			wantErr: "--api-key-name and --api-key-expiration require --with-api-key",
+		},
+		{
+			name:    "zero expiration is rejected when explicit",
+			args:    []string{"--email", "seed@example.com", "--with-api-key", "--api-key-expiration", "0"},
+			wantErr: "--api-key-expiration must be greater than 0 (days)",
+		},
+		{
+			name:    "negative expiration is rejected",
+			args:    []string{"--email", "seed@example.com", "--with-api-key", "--api-key-expiration", "-5"},
+			wantErr: "--api-key-expiration must be greater than 0 (days)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := AddBootstrapCommand(&cli.App{})
+			cmd.SetArgs(tc.args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			require.EqualError(t, err, tc.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `convoy bootstrap` now always prints `user_id` and `organisation_id` in both `json` and `human` output.
- Adds an opt-in `--with-api-key` flag that mints a personal API key for the bootstrapped user and prints it, so an instance can be seeded fully via the CLI and API with no login step and no dashboard.
- `--api-key-name` (default `bootstrap-key`) and `--api-key-expiration` (days) tune the key. An explicit expiration must be positive; unset (`0`) inherits the key service default (24h).

## Behavior and safety

- Flag validation runs up front, before any license check or record creation, so a bad flag combination fails fast and cannot leave a half-seeded user/organisation. `--api-key-name` / `--api-key-expiration` require `--with-api-key`.
- The minted key is a durable org-admin credential, printed to stdout only, never logged. It is revocable via the returned `api_key_id`.
- Failure policy: if key minting fails after the user and organisation are already persisted, the user credentials are still emitted, then the command returns a non-zero exit. This avoids stranding an admin account whose generated password would otherwise be lost (a rerun exits on duplicate email without re-minting).

## Sample

```
convoy bootstrap --email you@example.com --with-api-key --api-key-expiration 90 --format json
```

```json
{
    "email": "you@example.com",
    "password": "...",
    "user_id": "01J...",
    "organisation_id": "01J...",
    "api_key": "CO....",
    "api_key_id": "01J...",
    "api_key_expires_at": "2026-10-08T07:24:00Z"
}
```

## Test plan

- [x] `go test ./cmd/bootstrap/...` (flag validation: bad format, missing email, key flags without `--with-api-key`, zero/negative explicit expiration)
- [x] `gofmt` / `go vet` / `golangci-lint` clean on `cmd/bootstrap/...`
- [ ] Manual: run against a local instance, then use the printed `api_key` to create a project with no login

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Creates durable org-admin API keys and prints them to stdout during instance seeding; behavior is opt-in but touches credential issuance and bootstrap failure paths.
> 
> **Overview**
> **`convoy bootstrap`** now prints **`user_id`** and **`organisation_id`** in both `json` and `human` output, and can optionally mint a personal API key so a fresh instance can be wired up via the API without logging in.
> 
> Output is centralized in **`printBootstrapOutput`**, which is the only path that writes secrets (password and API key) to stdout—not the logger. New flags: **`--with-api-key`**, **`--api-key-name`** (default `bootstrap-key`), and **`--api-key-expiration`** (days; `0` defers to the key service’s 24h default). API-key-related flags are validated **before** license checks or DB writes; **`--api-key-name`** / **`--api-key-expiration`** require **`--with-api-key`**, and an explicitly set expiration must be &gt; 0.
> 
> If key minting fails after the user and org already exist, the command still prints the user credentials, then exits non-zero so the admin password is not lost. Flag validation is covered by new tests in **`bootstrap_test.go`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 887d81de06983144b94dbd667062a2c211092d6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->