### PR TITLE
fix(dataplane): delete retention attempts by delivery cutoff

### DIFF
--- a/internal/delivery_attempts/delete_delivery_attempts_test.go
+++ b/internal/delivery_attempts/delete_delivery_attempts_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/frain-dev/convoy/datastore"
+	"github.com/frain-dev/convoy/internal/event_deliveries"
 	log "github.com/frain-dev/convoy/pkg/logger"
 )
 
@@ -306,4 +307,63 @@ func TestDeleteProjectDeliveriesAttempts_MultipleProjects(t *testing.T) {
 	attempts2, err := service.FindDeliveryAttempts(ctx, eventDelivery2.UID)
 	require.NoError(t, err)
 	require.Len(t, attempts2, 3, "Project2 attempts should remain")
+}
+
+// Old delivery + newer retry attempt: hard-delete attempts by delivery created_at,
+// then hard-delete deliveries. Must succeed without
+// delivery_attempts_event_delivery_id_fkey.
+func TestDeleteProjectDeliveriesAttempts_HardDeleteByDeliveryCutoffClearsRetryAttempts(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close()
+
+	project := seedTestData(t, db, ctx)
+	endpoint := seedEndpoint(t, db, ctx, project)
+	eventDelivery := seedEventDelivery(t, db, ctx, project, endpoint)
+
+	service := New(log.New("convoy", log.LevelInfo), db)
+	edService := event_deliveries.New(log.New("convoy", log.LevelInfo), db)
+
+	attemptUID := ulid.Make().String()
+	require.NoError(t, service.CreateDeliveryAttempt(ctx, &datastore.DeliveryAttempt{
+		UID:              attemptUID,
+		EventDeliveryId:  eventDelivery.UID,
+		URL:              "https://example.com",
+		Method:           "POST",
+		ProjectId:        project.UID,
+		EndpointID:       endpoint.UID,
+		APIVersion:       "2024-01-01",
+		IPAddress:        "192.0.0.1",
+		RequestHeader:    map[string]string{"Content-Type": "application/json"},
+		ResponseHeader:   map[string]string{"Content-Type": "application/json"},
+		HttpResponseCode: "500",
+		ResponseData:     []byte(`{"status":"error"}`),
+		Status:           false,
+	}))
+
+	policy := 7 * 24 * time.Hour
+	cutoff := time.Now().Add(-policy)
+	_, err := db.GetDB().ExecContext(ctx,
+		`UPDATE convoy.event_deliveries SET created_at = $1 WHERE id = $2 AND project_id = $3`,
+		time.Now().Add(-10*24*time.Hour), eventDelivery.UID, project.UID)
+	require.NoError(t, err)
+	_, err = db.GetDB().ExecContext(ctx,
+		`UPDATE convoy.delivery_attempts SET created_at = $1 WHERE id = $2 AND project_id = $3`,
+		time.Now().Add(-24*time.Hour), attemptUID, project.UID)
+	require.NoError(t, err)
+
+	filter := &datastore.DeliveryAttemptsFilter{
+		CreatedAtStart: 0,
+		CreatedAtEnd:   cutoff.Unix(),
+	}
+	err = service.DeleteProjectDeliveriesAttempts(ctx, project.UID, filter, true)
+	require.NoError(t, err)
+
+	err = edService.DeleteProjectEventDeliveries(ctx, project.UID, &datastore.EventDeliveryFilter{
+		CreatedAtStart: 0,
+		CreatedAtEnd:   cutoff.Unix(),
+	}, true)
+	require.NoError(t, err)
+
+	_, err = service.FindDeliveryAttemptById(ctx, eventDelivery.UID, attemptUID)
+	require.ErrorIs(t, err, datastore.ErrDeliveryAttemptNotFound)
 }

--- a/internal/delivery_attempts/impl.go
+++ b/internal/delivery_attempts/impl.go
@@ -140,6 +140,8 @@ func (s *Service) DeleteProjectDeliveriesAttempts(ctx context.Context, projectID
 	var result pgconn.CommandTag
 	var err error
 
+	// Hard delete: filter dates apply to event_deliveries.created_at (see SQL comment).
+	// Soft delete: filter dates apply to delivery_attempts.created_at.
 	if hardDelete {
 		result, err = s.repo.HardDeleteProjectDeliveryAttempts(ctx, repo.HardDeleteProjectDeliveryAttemptsParams{
 			ProjectID:      common.StringToPgText(projectID),

--- a/internal/delivery_attempts/queries.sql
+++ b/internal/delivery_attempts/queries.sql
@@ -77,10 +77,19 @@ WHERE project_id = @project_id
     AND deleted_at IS NULL;
 
 -- name: HardDeleteProjectDeliveryAttempts :execresult
-DELETE FROM convoy.delivery_attempts
-WHERE project_id = @project_id
-    AND created_at >= @created_at_start
-    AND created_at <= @created_at_end;
+-- Hard delete keys off the parent event_delivery.created_at (not attempt.created_at).
+-- Retention deletes deliveries by delivery age next; retry attempts can be newer than
+-- the cutoff while their delivery is older. Deleting by attempt age leaves those rows
+-- and trips delivery_attempts_event_delivery_id_fkey (NO ACTION). Fail closed: remove
+-- every attempt for deliveries in the cutoff window before the delivery delete runs.
+-- Soft delete still filters on attempt.created_at; only hard delete uses this join.
+DELETE FROM convoy.delivery_attempts AS da
+USING convoy.event_deliveries AS ed
+WHERE da.event_delivery_id = ed.id
+  AND da.project_id = @project_id
+  AND ed.project_id = @project_id
+  AND ed.created_at >= @created_at_start
+  AND ed.created_at <= @created_at_end;
 
 -- name: GetFailureAndSuccessCounts :many
 -- Get failure and success counts for endpoints within the lookback duration

--- a/internal/delivery_attempts/repo/querier.go
+++ b/internal/delivery_attempts/repo/querier.go
@@ -23,6 +23,12 @@ type Querier interface {
 	// Get counts for a specific endpoint from a specific reset time
 	// This is used when circuit breaker has been reset for specific endpoints
 	GetFailureAndSuccessCountsWithResetTime(ctx context.Context, arg GetFailureAndSuccessCountsWithResetTimeParams) (GetFailureAndSuccessCountsWithResetTimeRow, error)
+	// Hard delete keys off the parent event_delivery.created_at (not attempt.created_at).
+	// Retention deletes deliveries by delivery age next; retry attempts can be newer than
+	// the cutoff while their delivery is older. Deleting by attempt age leaves those rows
+	// and trips delivery_attempts_event_delivery_id_fkey (NO ACTION). Fail closed: remove
+	// every attempt for deliveries in the cutoff window before the delivery delete runs.
+	// Soft delete still filters on attempt.created_at; only hard delete uses this join.
 	HardDeleteProjectDeliveryAttempts(ctx context.Context, arg HardDeleteProjectDeliveryAttemptsParams) (pgconn.CommandTag, error)
 	SoftDeleteProjectDeliveryAttempts(ctx context.Context, arg SoftDeleteProjectDeliveryAttemptsParams) (pgconn.CommandTag, error)
 }

--- a/internal/delivery_attempts/repo/queries.sql.go
+++ b/internal/delivery_attempts/repo/queries.sql.go
@@ -328,10 +328,13 @@ func (q *Queries) GetFailureAndSuccessCountsWithResetTime(ctx context.Context, a
 }
 
 const hardDeleteProjectDeliveryAttempts = `-- name: HardDeleteProjectDeliveryAttempts :execresult
-DELETE FROM convoy.delivery_attempts
-WHERE project_id = $1
-    AND created_at >= $2
-    AND created_at <= $3
+DELETE FROM convoy.delivery_attempts AS da
+USING convoy.event_deliveries AS ed
+WHERE da.event_delivery_id = ed.id
+  AND da.project_id = $1
+  AND ed.project_id = $1
+  AND ed.created_at >= $2
+  AND ed.created_at <= $3
 `
 
 type HardDeleteProjectDeliveryAttemptsParams struct {
@@ -340,6 +343,12 @@ type HardDeleteProjectDeliveryAttemptsParams struct {
 	CreatedAtEnd   pgtype.Timestamptz
 }
 
+// Hard delete keys off the parent event_delivery.created_at (not attempt.created_at).
+// Retention deletes deliveries by delivery age next; retry attempts can be newer than
+// the cutoff while their delivery is older. Deleting by attempt age leaves those rows
+// and trips delivery_attempts_event_delivery_id_fkey (NO ACTION). Fail closed: remove
+// every attempt for deliveries in the cutoff window before the delivery delete runs.
+// Soft delete still filters on attempt.created_at; only hard delete uses this join.
 func (q *Queries) HardDeleteProjectDeliveryAttempts(ctx context.Context, arg HardDeleteProjectDeliveryAttemptsParams) (pgconn.CommandTag, error) {
 	return q.db.Exec(ctx, hardDeleteProjectDeliveryAttempts, arg.ProjectID, arg.CreatedAtStart, arg.CreatedAtEnd)
 }

--- a/internal/pkg/retention/retention.go
+++ b/internal/pkg/retention/retention.go
@@ -208,33 +208,42 @@ func (d *DeleteRetentionPolicy) Perform(ctx context.Context) error {
 	}
 
 	for _, p := range projects {
+		cutoff := time.Now().Add(-policy).Unix()
+
+		// Hard-delete attempts for deliveries in [0, cutoff] (keyed by delivery
+		// created_at). See HardDeleteProjectDeliveryAttempts.
 		deliveryFilter := &datastore.DeliveryAttemptsFilter{
 			CreatedAtStart: 0,
-			CreatedAtEnd:   time.Now().Add(-policy).Unix(),
+			CreatedAtEnd:   cutoff,
 		}
 
 		err = deliveryAttemptsRepo.DeleteProjectDeliveriesAttempts(ctx, p.UID, deliveryFilter, true)
-		if err != nil {
+		// Fail closed: do not delete deliveries if attempt cleanup hit a real error.
+		// ErrDeliveryAttemptsNotDeleted means nothing matched (no attempts to remove).
+		if err != nil && !errors.Is(err, datastore.ErrDeliveryAttemptsNotDeleted) {
 			d.logger.Error("failed to delete project delivery attempts", "error", err)
+			continue
 		}
 
 		eventDeliveryFilter := &datastore.EventDeliveryFilter{
 			CreatedAtStart: 0,
-			CreatedAtEnd:   time.Now().Add(-policy).Unix(),
+			CreatedAtEnd:   cutoff,
 		}
 
 		err = eventDeliveryRepo.DeleteProjectEventDeliveries(ctx, p.UID, eventDeliveryFilter, true)
 		if err != nil {
 			d.logger.Error("failed to delete project event deliveries", "error", err)
+			continue
 		}
 
 		eventFilter := &datastore.EventFilter{
 			CreatedAtStart: 0,
-			CreatedAtEnd:   time.Now().Add(-policy).Unix(),
+			CreatedAtEnd:   cutoff,
 		}
 		err = eventRepo.DeleteProjectEvents(ctx, p.UID, eventFilter, true)
 		if err != nil {
 			d.logger.Error("failed to delete project events", "error", err)
+			continue
 		}
 
 		err = eventRepo.DeleteProjectTokenizedEvents(ctx, p.UID, eventFilter)


### PR DESCRIPTION
## Summary
- Hard-delete retention attempts by parent `event_delivery.created_at` (not attempt age) so newer retries cannot block delivery cleanup via `delivery_attempts_event_delivery_id_fkey`.
- Fail closed in `DeleteRetentionPolicy`: skip delivery/event deletes for a project when attempt cleanup hits a real error (`ErrDeliveryAttemptsNotDeleted` is empty-match, not failure).
- Regression test for old delivery + newer retry attempt.

Customer patch already shipped as `v25.7.1-patch` / `getconvoy/convoy:v25.7.1-patch`.

## Test plan
- [x] `CONVOY_JWT_SECRET=… CONVOY_JWT_REFRESH_SECRET=… go test ./internal/delivery_attempts/ -run 'HardDeleteByDeliveryCutoff|HardDelete$' -count=1`
- [ ] Confirm retention job on a project with old deliveries + recent retries deletes both without FK 23503
- [ ] Soft-delete path unchanged (still filters on attempt `created_at`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retention data deletion semantics and FK ordering; incorrect behavior could delete too much/little or leave retention stuck, but scope is limited to hard-delete retention paths with tests and documented SQL.
> 
> **Overview**
> Fixes retention hard-deletes so **delivery attempts** are removed when their parent **event delivery** falls inside the retention window, not when the attempt row’s own `created_at` does. That closes a gap where **newer retry attempts** on **old deliveries** were left behind and blocked delivery deletes via `delivery_attempts_event_delivery_id_fkey`.
> 
> **Hard delete** now joins `delivery_attempts` to `event_deliveries` and filters on `ed.created_at`; **soft delete** still uses attempt `created_at`. `DeleteRetentionPolicy` uses a single **cutoff** timestamp, treats `ErrDeliveryAttemptsNotDeleted` as a no-op, and **skips** delivery/event deletes for a project when attempt cleanup fails for any other reason. A regression test covers old delivery + recent retry attempt through attempt and delivery hard-delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc341a2a5bc46fac3d04b985db84ebe65f944ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->