### PR TITLE
fix(controlplane): protect helpers.py in convoy-python genignore

### DIFF
--- a/sdk/bootstrap/convoy-python/.genignore
+++ b/sdk/bootstrap/convoy-python/.genignore
@@ -1,5 +1,8 @@
 # Hand-written webhook signature verification — never overwrite with generated code.
+# helpers.py must stay too: utils/__init__.py eagerly imports it, so dropping it
+# would break `from convoy.utils.webhook import Webhook` at package init.
 convoy/utils/webhook.py
+convoy/utils/helpers.py
 convoy/utils/__init__.py
 
 # Shared signature contract + verify unit tests (hand-authored).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bugbot on [convoy-python#16](https://github.com/frain-dev/convoy-python/pull/16) found that `.genignore` protects `convoy/utils/__init__.py` (which eagerly imports `helpers.py`) but not `helpers.py` itself. After Speakeasy generation drops unprotected files, `from convoy.utils.webhook import Webhook` would fail at package init with `ImportError`.

This adds `convoy/utils/helpers.py` to the bootstrap overlay's `.genignore`.

## After merge
Re-run **Bootstrap SDK Speakeasy repos** to refresh the open bootstrap PRs on the SDK repos (the script is idempotent and force-updates the feature branch).

Related: PDE-755 / follow-up to #2724
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

