### PR TITLE
fix(controlplane): use explicit lease expectation in bootstrap re-push

### DIFF
--- a/scripts/sdk/bootstrap-sdk-repos.sh
+++ b/scripts/sdk/bootstrap-sdk-repos.sh
@@ -122,10 +122,15 @@ clone_and_apply() {
 
   cd "$dest"
 
-  # Re-runs must track the remote feature branch so --force-with-lease has a
-  # local expected ref. Shallow clone only fetches the default branch.
+  # Re-runs must build on the remote feature branch. Capture its SHA as an
+  # explicit lease expectation: bare --force-with-lease rejects with "stale
+  # info" here because the tracking ref written by an explicit-refspec fetch
+  # is not covered by the single-branch clone's remote.origin.fetch config.
+  # An empty expectation means "branch must not exist yet" (first run).
+  local expected_sha=""
   if git ls-remote --exit-code --heads origin -- "$BRANCH_NAME" >/dev/null 2>&1; then
     git fetch --depth 1 origin "refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
+    expected_sha="$(git rev-parse "origin/${BRANCH_NAME}")"
     git checkout -B "$BRANCH_NAME" "origin/${BRANCH_NAME}"
   else
     git checkout -B "$BRANCH_NAME"
@@ -168,7 +173,7 @@ EOF
     return 0
   fi
 
-  git push -u origin "$BRANCH_NAME" --force-with-lease
+  git push -u origin "$BRANCH_NAME" --force-with-lease="${BRANCH_NAME}:${expected_sha}"
 
   local pr_url
   pr_url="$(gh pr list --repo "frain-dev/${repo}" --head "$BRANCH_NAME" --json url --jq '.[0].url' || true)"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The bootstrap re-run failed pushing to `convoy-python` with:

```
! [rejected] feat/speakeasy-bootstrap-pde-755 -> feat/speakeasy-bootstrap-pde-755 (stale info)
```

Bare `--force-with-lease` uses the remote-tracking ref as its expectation, but git does not trust tracking refs written by an explicit-refspec fetch when they are not covered by the clone's `remote.origin.fetch` config — which is the case in the script's single-branch shallow clone. Reproduced locally and verified the fix on both paths.

Now the script captures the fetched branch SHA and passes an explicit `--force-with-lease=branch:sha` expectation (empty SHA on first runs, meaning the branch must not exist yet — still race-safe).

## After merge
Re-run **Bootstrap SDK Speakeasy repos** — it will refresh `convoy-python#16` with the `.genignore` fix from #2725 (`convoy.js#37` is already up to date and was skipped correctly).

Related: PDE-755 / follow-up to #2724, #2725
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

