### PR TITLE
fix(controlplane): unblock first Speakeasy SDK generation

### DIFF
--- a/scripts/sdk/bootstrap-sdk-repos.sh
+++ b/scripts/sdk/bootstrap-sdk-repos.sh
@@ -49,13 +49,39 @@ ensure_readme_note() {
 migrate_convoy_js() {
   local dest="$1"
 
-  # Hand-written API stays in place until the first Speakeasy generation PR replaces
-  # it as an intentional convoy.js 2.x break. Verify modules are protected via
-  # .genignore so crypto is never generator-owned.
+  # Remove the deprecated hand-written HTTP client now (intentional 2.x break):
+  # persistentEdits preserves any leftovers and they fail compilation under the
+  # generated node16 tsconfig (extensionless relative imports). Verify modules
+  # stay, protected via .genignore so crypto is never generator-owned.
+  rm -rf \
+    "${dest}/src/Api" \
+    "${dest}/src/client.ts" \
+    "${dest}/src/interfaces" \
+    "${dest}/src/utils/helpers" \
+    "${dest}/tests/convoy.test.ts" \
+    "${dest}/tests/routes.test.ts"
 
-  if [[ -f "${dest}/src/convoy.ts" ]] && ! grep -q "Speakeasy migration" "${dest}/src/convoy.ts"; then
-    sed -i '1s|^|/** Speakeasy migration: hand-written HTTP API is deprecated; next major replaces this with OpenAPI-generated clients. Webhook verify stays hand-written. */\n|' "${dest}/src/convoy.ts"
+  # Minimal entrypoint: keep `require('convoy.js').Webhook` working before and
+  # after generation. Explicit .js extensions compile under both the current
+  # commonjs tsconfig and Speakeasy's node16 moduleResolution.
+  cat > "${dest}/src/convoy.ts" <<'EOF'
+/** Speakeasy migration: the hand-written HTTP API was removed for the 2.x
+ * break; OpenAPI-generated clients replace it. Webhook verify stays
+ * hand-written (see MIGRATION.md). */
+export { Webhook } from './webhook.js';
+EOF
+
+  # Keep the protected verify import chain node16-compatible (explicit .js
+  # extensions resolve under both commonjs and node16 moduleResolution).
+  if [[ -f "${dest}/src/webhook.ts" ]]; then
+    sed -i "s|from './utils/errors';|from './utils/errors/index.js';|" "${dest}/src/webhook.ts"
   fi
+  local test_file
+  for test_file in "${dest}/tests/webhook.test.ts" "${dest}/tests/shared-vectors.test.ts"; do
+    if [[ -f "$test_file" ]]; then
+      sed -i "s|from '../src/webhook';|from '../src/webhook.js';|" "$test_file"
+    fi
+  done
 
   if [[ -f "${dest}/package.json" ]]; then
     python3 - <<'PY'

--- a/sdk/bootstrap/convoy-python/.speakeasy/gen.yaml
+++ b/sdk/bootstrap/convoy-python/.speakeasy/gen.yaml
@@ -35,7 +35,8 @@ python:
   license: MIT
   maxMethodParams: 999
   methodArguments: infer-optional-args
-  packageManager: setuptools
+  # Speakeasy only supports uv or poetry (setuptools is rejected at gen time).
+  packageManager: uv
   templateVersion: v2
   responseFormat: flat
   flattenGlobalSecurity: true

--- a/sdk/bootstrap/convoy.js/.genignore
+++ b/sdk/bootstrap/convoy.js/.genignore
@@ -6,6 +6,7 @@ src/utils/errors/**
 tests/signature-vectors.json
 tests/shared-vectors.test.ts
 tests/webhook.test.ts
+jestconfig.json
 
 # Project meta / contributor docs that Speakeasy should not clobber blindly.
 CONTRIBUTING.md

--- a/sdk/bootstrap/convoy.js/.speakeasy/gen.yaml
+++ b/sdk/bootstrap/convoy.js/.speakeasy/gen.yaml
@@ -33,9 +33,15 @@ typescript:
   responseFormat: flat
   flattenGlobalSecurity: true
   clientServerStatusCodesAsErrors: true
+  # Hand-written verify (protected by .genignore) needs these to keep building
+  # and testing once the generator owns package.json.
   additionalDependencies:
-    dependencies: {}
-    devDependencies: {}
+    dependencies:
+      http-status: ^1.7.3
+    devDependencies:
+      "@types/jest": ^29.5.8
+      jest: ^29.7.0
+      ts-jest: ^29.1.1
     peerDependencies: {}
   additionalPackageJSON: {}
   additionalScripts:

--- a/sdk/bootstrap/convoy.js/jestconfig.json
+++ b/sdk/bootstrap/convoy.js/jestconfig.json
@@ -1,0 +1,10 @@
+{
+    "transform": {
+        "^.+\\.(t|j)sx?$": "ts-jest"
+    },
+    "testRegex": "(/tests/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": ["js", "json", "ts"],
+    "moduleNameMapper": {
+        "^(\\.{1,2}/.*)\\.js$": "$1"
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The first auto-triggered generation (after #2728) failed differently in each SDK repo:

**convoy-python** — `gen.yaml` rejected outright:
```
ERROR field 'packageManager' does not match required format: "uv" or "poetry" only
```
Fixed: `packageManager: uv`.

**convoy.js** — generation succeeded but compilation failed: `persistentEdits` preserves the old hand-written HTTP client (`src/Api/**`, `client.ts`, `interfaces/**`), and those files use extensionless relative imports that don't compile under Speakeasy's generated `node16` tsconfig (`TS2835` ×many).

Fixed in the bootstrap overlay/script (the 2.x break, applied at bootstrap time instead of hoping the generation PR could do it):
- Delete the deprecated hand-written client (`src/Api`, `src/client.ts`, `src/interfaces`, `src/utils/helpers`, old client tests)
- Minimal `src/convoy.ts` entrypoint keeps `require('convoy.js').Webhook` working
- Protected verify chain switched to explicit `.js`-extension imports — verified compiling under **both** the current commonjs tsconfig and node16
- `jestconfig.json` gains a `moduleNameMapper` for ts-jest and is now `.genignore`-protected
- `gen.yaml` `additionalDependencies` keeps `http-status` + jest toolchain once the generator owns `package.json`

## Validation
- Dry-run bootstrap applied to a real convoy.js clone: `tsc --noEmit` clean, **all 31 verify vector tests pass**
- `.js`-extension imports compile under both `module: commonjs` and `module: node16` (tested both)
- shellcheck / YAML / local Bugbot clean

## After merge
1. Re-run **Bootstrap SDK Speakeasy repos** → refreshes both SDK repos (new bootstrap PRs to merge)
2. Dispatch **Speakeasy SDK regeneration** (or wait for the next OpenAPI change) → generated-client PRs

Related: PDE-755 / follow-up to #2724, #2728
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

