### PR TITLE
fix(controlplane): drop dead HTTP client deps from convoy.js bootstrap

### DIFF
--- a/scripts/sdk/bootstrap-sdk-repos.sh
+++ b/scripts/sdk/bootstrap-sdk-repos.sh
@@ -71,6 +71,36 @@ migrate_convoy_js() {
 export { Webhook } from './webhook.js';
 EOF
 
+  # Trim errors to what verify actually uses: the HTTP API exception classes
+  # died with the hand-written client, and only they needed http-status.
+  cat > "${dest}/src/utils/errors/index.ts" <<'EOF'
+class BaseError extends Error {
+    public statusCode: number;
+
+    constructor(message?: string, status?: number) {
+        super();
+        Error.captureStackTrace(this, this.constructor);
+        this.name = this.constructor.name;
+        this.message = message as string;
+        this.statusCode = status as number;
+    }
+}
+
+class WebhookVerificationException extends BaseError {
+    constructor(message: string) {
+        super(message);
+    }
+}
+
+class ConfigException extends BaseError {
+    constructor(message: string) {
+        super(message);
+    }
+}
+
+export { WebhookVerificationException, ConfigException };
+EOF
+
   # Keep the protected verify import chain node16-compatible (explicit .js
   # extensions resolve under both commonjs and node16 moduleResolution).
   if [[ -f "${dest}/src/webhook.ts" ]]; then
@@ -93,6 +123,11 @@ data["version"] = "2.0.0-alpha.0"
 data["description"] = "Convoy JS SDK (Speakeasy-generated API client; hand-written webhook verify)"
 scripts = data.setdefault("scripts", {})
 scripts["test:verify"] = "jest --config jestconfig.json --testPathPattern='(webhook|shared-vectors)'"
+# Dead dependencies of the removed hand-written HTTP client; verify needs none
+# of them (crypto is node builtin).
+for dep in ("@aws-sdk/client-sqs", "axios", "base-64", "http-status", "kafkajs"):
+    data.get("dependencies", {}).pop(dep, None)
+data.get("devDependencies", {}).pop("@types/base-64", None)
 p.write_text(json.dumps(data, indent=4) + "\n")
 PY
   fi

--- a/sdk/bootstrap/convoy.js/.speakeasy/gen.yaml
+++ b/sdk/bootstrap/convoy.js/.speakeasy/gen.yaml
@@ -36,8 +36,7 @@ typescript:
   # Hand-written verify (protected by .genignore) needs these to keep building
   # and testing once the generator owns package.json.
   additionalDependencies:
-    dependencies:
-      http-status: ^1.7.3
+    dependencies: {}
     devDependencies:
       "@types/jest": ^29.5.8
       jest: ^29.7.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bugbot (Low) on [convoy.js#38](https://github.com/frain-dev/convoy.js/pull/38) noted that `http-status` was being pinned in `gen.yaml` `additionalDependencies` only because dead HTTP-API exception classes in `src/utils/errors` still imported it — `WebhookVerificationException` never used it.

Bootstrap now finishes the 2.x cleanup properly:
- `src/utils/errors/index.ts` trimmed to the verify-only exceptions (`WebhookVerificationException`, `ConfigException`) — no `http-status` import
- Dead runtime deps of the removed hand-written client dropped from `package.json`: `@aws-sdk/client-sqs`, `axios`, `base-64`, `http-status`, `kafkajs` (+ `@types/base-64`)
- `http-status` removed from `gen.yaml` `additionalDependencies`

Verify needs only node's built-in `crypto`.

## Validation
Dry-run bootstrap on a real convoy.js clone with **empty `dependencies`**: `tsc --noEmit` clean, all 31 verify vector tests pass. shellcheck + local Bugbot clean.

## After merge
Re-run **Bootstrap SDK Speakeasy repos** to refresh `convoy.js#38`, then merge both SDK PRs and dispatch regeneration.

Related: PDE-755 / follow-up to #2729
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

