### PR TITLE
fix(controlplane): regenerate convoy.js lockfile during bootstrap

### DIFF
--- a/scripts/sdk/bootstrap-sdk-repos.sh
+++ b/scripts/sdk/bootstrap-sdk-repos.sh
@@ -92,13 +92,7 @@ class WebhookVerificationException extends BaseError {
     }
 }
 
-class ConfigException extends BaseError {
-    constructor(message: string) {
-        super(message);
-    }
-}
-
-export { WebhookVerificationException, ConfigException };
+export { WebhookVerificationException };
 EOF
 
   # Keep the protected verify import chain node16-compatible (explicit .js
@@ -130,6 +124,12 @@ for dep in ("@aws-sdk/client-sqs", "axios", "base-64", "http-status", "kafkajs")
 data.get("devDependencies", {}).pop("@types/base-64", None)
 p.write_text(json.dumps(data, indent=4) + "\n")
 PY
+
+    # package.json changed (version + removed deps): regenerate the lockfile
+    # or `npm ci` fails on the exact-match check.
+    if [[ -f "${dest}/package-lock.json" ]]; then
+      (cd "$dest" && npm install --package-lock-only --ignore-scripts --no-audit --no-fund)
+    fi
   fi
 
   ensure_readme_note "${dest}/README.md" "$(cat <<'EOF'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Bugbot on [convoy.js#38](https://github.com/frain-dev/convoy.js/pull/38) after the last refresh:

1. **Lockfile out of sync (High)** — bootstrap edits `package.json` (version bump, dead deps removed) but left `package-lock.json` recording `1.2.0` with `axios`/`kafkajs`/etc. `npm ci` (used in publish CI) fails on the exact-match check. Bootstrap now runs `npm install --package-lock-only --ignore-scripts` after editing `package.json`.
2. **Unused `ConfigException` (Low)** — the trimmed errors module now exports only `WebhookVerificationException` (the one class verify uses).

## Validation
Dry-run bootstrap on a real convoy.js clone: regenerated lockfile shows root `2.0.0-alpha.0` with no runtime deps, **`npm ci` passes**, `tsc --noEmit` clean, verify vector tests pass. shellcheck + local Bugbot clean.

## After merge
Re-run **Bootstrap SDK Speakeasy repos** to refresh `convoy.js#38` (convoy-python#17 is final and unaffected), then merge both SDK PRs and dispatch regeneration.

Related: PDE-755 / follow-up to #2730
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

