### PR TITLE
fix(controlplane): rebuild bootstrap branch from main on re-runs

### DIFF
--- a/scripts/sdk/bootstrap-sdk-repos.sh
+++ b/scripts/sdk/bootstrap-sdk-repos.sh
@@ -183,19 +183,19 @@ clone_and_apply() {
 
   cd "$dest"
 
-  # Re-runs must build on the remote feature branch. Capture its SHA as an
-  # explicit lease expectation: bare --force-with-lease rejects with "stale
-  # info" here because the tracking ref written by an explicit-refspec fetch
-  # is not covered by the single-branch clone's remote.origin.fetch config.
-  # An empty expectation means "branch must not exist yet" (first run).
+  # Always rebuild the feature branch from the default branch: SDK PRs are
+  # squash-merged, so stacking on the stale feature branch makes every
+  # follow-up PR conflict with main's squashed copy of the same files.
+  # If the remote feature branch exists, capture its SHA as an explicit
+  # --force-with-lease expectation (bare lease rejects with "stale info"
+  # because the tracking ref from an explicit-refspec fetch is not covered
+  # by the single-branch clone's fetch config). Empty expectation means
+  # "branch must not exist yet" (first run).
   local expected_sha=""
   if git ls-remote --exit-code --heads origin -- "$BRANCH_NAME" >/dev/null 2>&1; then
-    git fetch --depth 1 origin "refs/heads/${BRANCH_NAME}:refs/remotes/origin/${BRANCH_NAME}"
-    expected_sha="$(git rev-parse "origin/${BRANCH_NAME}")"
-    git checkout -B "$BRANCH_NAME" "origin/${BRANCH_NAME}"
-  else
-    git checkout -B "$BRANCH_NAME"
+    expected_sha="$(git ls-remote origin "refs/heads/${BRANCH_NAME}" | awk '{print $1}')"
   fi
+  git checkout -B "$BRANCH_NAME"
 
   # Prefer rsync when available; fall back to cp for local dry-runs.
   if command -v rsync >/dev/null 2>&1; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`convoy-python#17` reports merge conflicts on `.speakeasy/gen.yaml`. Root cause: bootstrap PRs are **squash-merged**, but re-runs stacked new commits on the stale pre-merge feature branch. The branch's original commits then conflict with main's squashed copy of the same files.

Bootstrap now rebuilds `feat/speakeasy-bootstrap-pde-755` **from the default branch** on every run, so the PR diff is always exactly "overlay vs current main". The remote branch SHA is still captured via `ls-remote` as the `--force-with-lease` expectation, keeping re-runs race-safe.

Validated with a dry run against both real SDK repos: python branch = main + one commit (`gen.yaml` uv fix only), js branch = main + one commit (2.x client cleanup + lockfile).

## After merge
Re-run **Bootstrap SDK Speakeasy repos** — it will force-refresh both PR branches into conflict-free state.

Related: PDE-755 / follow-up to #2731
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

