### PR TITLE
fix(controlplane): fix SDK generation compile failures in both repos

### DIFF
--- a/scripts/sdk/bootstrap-sdk-repos.sh
+++ b/scripts/sdk/bootstrap-sdk-repos.sh
@@ -96,9 +96,12 @@ export { WebhookVerificationException };
 EOF
 
   # Keep the protected verify import chain node16-compatible (explicit .js
-  # extensions resolve under both commonjs and node16 moduleResolution).
+  # extensions resolve under both commonjs and node16 moduleResolution), and
+  # satisfy the generated tsconfig's noUncheckedIndexedAccess: array
+  # destructuring yields string | undefined.
   if [[ -f "${dest}/src/webhook.ts" ]]; then
     sed -i "s|from './utils/errors';|from './utils/errors/index.js';|" "${dest}/src/webhook.ts"
+    sed -i "s|if (key.trim() === 't') {|if ((key ?? '').trim() === 't') {|" "${dest}/src/webhook.ts"
   fi
   local test_file
   for test_file in "${dest}/tests/webhook.test.ts" "${dest}/tests/shared-vectors.test.ts"; do
@@ -143,9 +146,19 @@ EOF
 migrate_convoy_python() {
   local dest="$1"
 
-  if [[ -f "${dest}/convoy/convoy.py" ]] && ! grep -q "Speakeasy migration" "${dest}/convoy/convoy.py"; then
-    sed -i '1s|^|"""Speakeasy migration: hand-written HTTP API is deprecated; next major replaces this with OpenAPI-generated clients. Webhook verify stays hand-written."""\n|' "${dest}/convoy/convoy.py"
+  # The generated SDK lives at src/convoy/; the old root convoy/ package
+  # shadows it (mypy resolves convoy.utils to the old tree and fails on
+  # generated imports like FieldMetadata). Move hand-written verify into the
+  # generated tree — import path stays `from convoy.utils.webhook import
+  # Webhook` — and remove the deprecated hand-written client (1.x break).
+  if [[ -f "${dest}/convoy/utils/webhook.py" ]]; then
+    mkdir -p "${dest}/src/convoy/utils"
+    mv "${dest}/convoy/utils/webhook.py" "${dest}/src/convoy/utils/webhook.py"
   fi
+  rm -rf \
+    "${dest}/convoy" \
+    "${dest}/test/test_client.py" \
+    "${dest}/test/test_routes.py"
 
   if [[ -f "${dest}/setup.py" ]]; then
     python3 - <<'PY'

--- a/sdk/bootstrap/convoy-python/.genignore
+++ b/sdk/bootstrap/convoy-python/.genignore
@@ -1,9 +1,7 @@
-# Hand-written webhook signature verification — never overwrite with generated code.
-# helpers.py must stay too: utils/__init__.py eagerly imports it, so dropping it
-# would break `from convoy.utils.webhook import Webhook` at package init.
-convoy/utils/webhook.py
-convoy/utils/helpers.py
-convoy/utils/__init__.py
+# Hand-written webhook signature verification — never overwrite with generated
+# code. It lives inside the generated src/convoy tree so the import path stays
+# `from convoy.utils.webhook import Webhook`; only this file is hand-owned.
+src/convoy/utils/webhook.py
 
 # Shared signature contract + verify unit tests (hand-authored).
 test/signature-vectors.json

--- a/sdk/bootstrap/convoy-python/.github/workflows/run-tests.yml
+++ b/sdk/bootstrap/convoy-python/.github/workflows/run-tests.yml
@@ -21,14 +21,20 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          # Pre-generation the repo has no installable package yet; the verify
+          # tests import from src/ directly (PYTHONPATH below).
+          pip install -e . || echo "editable install unavailable (pre-generation); continuing"
           pip install pytest
 
       - name: Verify hand-written modules are present
         run: |
-          test -f convoy/utils/webhook.py
+          test -f src/convoy/utils/webhook.py
           test -f test/signature-vectors.json
           test -f test/test_shared_vectors.py
 
       - name: Execute verify + shared vector tests
+        env:
+          # PEP 420 namespace packages: `convoy.utils.webhook` resolves from
+          # src/ before generation adds real __init__.py files.
+          PYTHONPATH: src
         run: pytest test/test_webhook.py test/test_shared_vectors.py -q

--- a/sdk/bootstrap/convoy-python/MIGRATION.md
+++ b/sdk/bootstrap/convoy-python/MIGRATION.md
@@ -3,14 +3,14 @@
 ## What changed
 
 - The **public HTTP API client** will be generated from Convoy's OpenAPI spec (`docs/v3/openapi3.yaml`) via [Speakeasy](https://www.speakeasy.com/).
-- **Webhook signature verification stays hand-written.** Generators do not own crypto. `convoy/utils/webhook.py` and the shared `test/signature-vectors.json` contract remain the source of truth for verify (see `.genignore`).
+- **Webhook signature verification stays hand-written.** Generators do not own crypto. `src/convoy/utils/webhook.py` and the shared `test/signature-vectors.json` contract remain the source of truth for verify (see `.genignore`).
 
 ## Breaking change policy
 
 Shipping the Speakeasy client is an intentional **1.x** break from the hand-written `0.x` surfaces. Method shapes are **not** silently preserved.
 
-1. This bootstrap PR wires Speakeasy + protects verify.
-2. The first `sdk_generation.yaml` run opens a PR that replaces the hand-written HTTP client with generated code and publishes as `1.x`. Generation keeps the `convoy` import root (`moduleName: convoy` in `.speakeasy/gen.yaml`); that PR **must relocate `convoy/utils/webhook.py` into the generated module tree unchanged** so `from convoy.utils.webhook import Webhook` keeps resolving.
+1. This bootstrap PR wires Speakeasy, removes the deprecated hand-written HTTP client, and relocates verify to `src/convoy/utils/webhook.py` (inside the generated module tree, so `from convoy.utils.webhook import Webhook` keeps resolving — `moduleName: convoy` in `.speakeasy/gen.yaml`).
+2. The first `sdk_generation.yaml` run opens a PR that adds the OpenAPI-generated client and publishes as `1.x`.
 3. Consumers pin `0.x` until they migrate call sites.
 
 ## Verify (unchanged)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The first full generation run got past linting and **generated complete SDKs in both repos**, then failed at the compile/type-check step. Two root causes:

**convoy.js** — one real TS error in the protected verify file under the generated tsconfig's `noUncheckedIndexedAccess`:
```
src/webhook.ts(100,17): error TS18048: 'key' is possibly 'undefined'.
```
Fixed with `(key ?? '').trim()`. Validated under both the current commonjs tsconfig and an emulated node16-strict generated tsconfig; all 31 verify vector tests pass.

**convoy-python** — a package-shadowing problem: the generated SDK lives at `src/convoy/`, but the old hand-written root `convoy/` package shadows it, so mypy resolved `convoy.utils` to the old tree and produced thousands of `attr-defined` errors across every generated module (plus missing `requests` stubs from old `helpers.py`).

Fixed by completing the 1.x break at bootstrap time (mirroring what we did for JS):
- Old root `convoy/` package and its client tests removed
- Hand-written verify moved to `src/convoy/utils/webhook.py` — **import path unchanged** (`from convoy.utils.webhook import Webhook`), resolving via PEP 420 namespace packages pre-generation and the generated package post-generation
- `.genignore` protects the relocated file; `run-tests.yml` uses `PYTHONPATH=src` and tolerates the pre-generation editable-install gap; MIGRATION.md updated
- 29 verify tests pass from the relocated tree

## After merge
1. Re-run **Bootstrap SDK Speakeasy repos** → refresh PRs on both SDK repos → merge them
2. Dispatch **Speakeasy SDK regeneration** → generated-client PRs should now compile

Related: PDE-755 / follow-up to #2732
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

