### PR TITLE
fix(controlplane): pass Speakeasy type gate and install-check python verify

### DIFF
--- a/scripts/sdk/bootstrap-sdk-repos.sh
+++ b/scripts/sdk/bootstrap-sdk-repos.sh
@@ -155,24 +155,88 @@ migrate_convoy_python() {
     mkdir -p "${dest}/src/convoy/utils"
     mv "${dest}/convoy/utils/webhook.py" "${dest}/src/convoy/utils/webhook.py"
   fi
+  # setup.py goes with the old client: the generated pyproject.toml (version
+  # and metadata come from .speakeasy/gen.yaml) replaces packaging entirely.
   rm -rf \
     "${dest}/convoy" \
+    "${dest}/setup.py" \
     "${dest}/test/test_client.py" \
     "${dest}/test/test_routes.py"
 
-  if [[ -f "${dest}/setup.py" ]]; then
-    python3 - <<'PY'
+  # Type-level fixes so the protected verify file passes Speakeasy's mypy /
+  # pylint gate (no crypto logic changes): correct the exception *args
+  # annotation, chain re-raises, and fail closed instead of implicitly
+  # returning None on an unsupported encoding.
+  if [[ -f "${dest}/src/convoy/utils/webhook.py" ]]; then
+    python3 - "${dest}/src/convoy/utils/webhook.py" <<'PY'
+import sys
 from pathlib import Path
-import re
-text = Path("setup.py").read_text()
-text = re.sub(r'version="[^"]+"', 'version="1.0.0a0"', text, count=1)
-text = re.sub(
-    r'description="[^"]+"',
-    'description="Python SDK for Convoy (Speakeasy-generated API client; hand-written webhook verify)"',
-    text,
-    count=1,
-)
-Path("setup.py").write_text(text)
+
+p = Path(sys.argv[1])
+text = p.read_text()
+
+# (pattern, replacement, occurrences) — both exception classes share the
+# same __init__ signature line.
+replacements = [
+    (
+        "def __init__(self, *args: list) -> None:",
+        "def __init__(self, *args: str) -> None:",
+        2,
+    ),
+    (
+        """            except (ValueError, TypeError):
+                # A malformed signature is a mismatch, not a crash.
+                raise InvalidSignature("Invalid signature.")""",
+        """            except (ValueError, TypeError) as exc:
+                # A malformed signature is a mismatch, not a crash.
+                raise InvalidSignature("Invalid signature.") from exc""",
+        1,
+    ),
+    (
+        """        except (TypeError, ValueError):
+            raise InvalidTimestampError("Invalid timestamp format")""",
+        """        except (TypeError, ValueError) as exc:
+            raise InvalidTimestampError("Invalid timestamp format") from exc""",
+        1,
+    ),
+    (
+        """        if self.encoding == "base64":
+            sig = hmac.new(bytes(self.secret, "utf-8"), msg=bytes(encoded_payload, "utf-8"), digestmod=self.hash).digest()
+            return base64.b64encode(sig).decode()
+    """,
+        """        if self.encoding == "base64":
+            sig = hmac.new(bytes(self.secret, "utf-8"), msg=bytes(encoded_payload, "utf-8"), digestmod=self.hash).digest()
+            return base64.b64encode(sig).decode()
+
+        # Fail closed instead of implicitly returning None.
+        raise InvalidSignature("Invalid encoding.")
+    """,
+        1,
+    ),
+    (
+        """        if self.encoding == "base64":
+            sig = hmac.new(bytes(self.secret, "utf-8"), msg=bytes(signed_payload, "utf-8"), digestmod=self.hash).digest()
+            return base64.b64encode(sig).decode()
+        """,
+        """        if self.encoding == "base64":
+            sig = hmac.new(bytes(self.secret, "utf-8"), msg=bytes(signed_payload, "utf-8"), digestmod=self.hash).digest()
+            return base64.b64encode(sig).decode()
+
+        # Fail closed instead of implicitly returning None.
+        raise InvalidSignature("Invalid encoding.")
+        """,
+        1,
+    ),
+]
+
+for old, new, count in replacements:
+    if new.strip() in text:
+        continue  # already applied on a previous run
+    if text.count(old) < count:
+        sys.exit(f"webhook.py transform failed: pattern not found {count}x:\n{old}")
+    text = text.replace(old, new, count)
+
+p.write_text(text)
 PY
   fi
 

--- a/sdk/bootstrap/convoy-python/.github/workflows/run-tests.yml
+++ b/sdk/bootstrap/convoy-python/.github/workflows/run-tests.yml
@@ -21,9 +21,14 @@ jobs:
       - name: Install package
         run: |
           python -m pip install --upgrade pip
-          # Pre-generation the repo has no installable package yet; the verify
-          # tests import from src/ directly (PYTHONPATH below).
-          pip install -e . || echo "editable install unavailable (pre-generation); continuing"
+          # pyproject.toml arrives with the first Speakeasy generation. Once
+          # it exists, installation must succeed — a packaging regression
+          # (e.g. wheel omitting webhook verify) has to fail CI, not hide.
+          if [ -f pyproject.toml ]; then
+            pip install -e .
+          else
+            echo "pre-generation: no installable package yet; tests import from src/"
+          fi
           pip install pytest
 
       - name: Verify hand-written modules are present
@@ -32,9 +37,18 @@ jobs:
           test -f test/signature-vectors.json
           test -f test/test_shared_vectors.py
 
+      - name: Verify installed package exposes webhook verify
+        if: hashFiles('pyproject.toml') != ''
+        # No PYTHONPATH: this must resolve from the installed distribution.
+        run: python -c "from convoy.utils.webhook import Webhook"
+
       - name: Execute verify + shared vector tests
-        env:
-          # PEP 420 namespace packages: `convoy.utils.webhook` resolves from
-          # src/ before generation adds real __init__.py files.
-          PYTHONPATH: src
-        run: pytest test/test_webhook.py test/test_shared_vectors.py -q
+        run: |
+          if [ -f pyproject.toml ]; then
+            # Import from the installed distribution so packaging bugs surface.
+            pytest test/test_webhook.py test/test_shared_vectors.py -q
+          else
+            # PEP 420 namespace packages: resolve convoy.utils.webhook from
+            # src/ before generation adds real __init__.py files.
+            PYTHONPATH=src pytest test/test_webhook.py test/test_shared_vectors.py -q
+          fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Two things landed here — the Bugbot findings on the merged `convoy-python#18`, and the newest (Python-only) generation failure. **convoy.js generation already succeeded** and opened its first generated-client PR ([convoy.js#40](https://github.com/frain-dev/convoy.js/pull/40)).

**1. Bugbot on #18 (both valid):**
- *CI masks install failures* — `run-tests.yml` now requires `pip install -e .` to succeed once `pyproject.toml` exists (post-generation), and adds an explicit gate importing `convoy.utils.webhook` from the **installed distribution** (no `PYTHONPATH`), so a wheel that omits verify fails CI. The `PYTHONPATH=src` fallback applies only pre-generation.
- *Webhook package init / wheel packaging* — covered by the install-gate above: if hatchling drops the subpackage, the import gate turns red. `setup.py` is also removed at bootstrap since the generated `pyproject.toml` owns packaging.

**2. Python generation failure** — Speakeasy's mypy/pylint gate flagged the protected `src/convoy/utils/webhook.py`:
```
error: Argument 1 to "InvalidSignature" has incompatible type "str"; expected "list[Any]"
error: Missing return statement [return]
W0707 raise-missing-from
```
Bootstrap now applies type-level (non-crypto) transforms: `*args: list` → `*args: str` on both exception classes, exception chaining (`raise … from exc`), and fail-closed `raise` instead of implicitly returning `None` on an unsupported encoding. Transforms are idempotent and hard-fail if patterns drift.

## Validation
Dry-run bootstrap: `mypy` clean on the transformed file, `pylint` 10/10 (W0707/R1710), all 29 verify tests pass; post-generation emulation (fake hatchling package) confirms installed-distribution import works. Local Bugbot clean.

## After merge
Re-run **Bootstrap SDK Speakeasy repos** → merge the python refresh PR → dispatch **Speakeasy SDK regeneration** (or re-run just the python `sdk_generation.yaml`). JS is already done.

Related: PDE-755 / follow-up to #2733
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

