### PR TITLE
fix(controlplane): force CJS ts-jest compile for convoy.js verify tests

### DIFF
--- a/sdk/bootstrap/convoy.js/jestconfig.json
+++ b/sdk/bootstrap/convoy.js/jestconfig.json
@@ -1,6 +1,17 @@
 {
     "transform": {
-        "^.+\\.(t|j)sx?$": "ts-jest"
+        "^.+\\.(t|j)sx?$": [
+            "ts-jest",
+            {
+                "tsconfig": {
+                    "module": "commonjs",
+                    "moduleResolution": "node",
+                    "esModuleInterop": true,
+                    "target": "es2020",
+                    "strict": true
+                }
+            }
+        ]
     },
     "testRegex": "(/tests/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": ["js", "json", "ts"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Your Webhook re-export push triggered the verify tests on [convoy.js#40](https://github.com/frain-dev/convoy.js/pull/40) — and they failed with `SyntaxError: Cannot use import statement outside a module`. Root cause: the generated `package.json` sets `"type": "module"`, so jest executed the `.ts` test imports untransformed.

The protected `jestconfig.json` now passes ts-jest an inline commonjs tsconfig (`module: commonjs`, node resolution, `esModuleInterop`), forcing the verify tests to compile to CJS regardless of the package's module type.

## Validation
- On the generated branch `speakeasy-sdk-regen-20260719` (with `type: module`): **31/31 verify tests pass**
- On pre-generation `main`: **31/31 pass** — works in both worlds
- Local Bugbot clean

## Applying to the open generation PR
This overlay lands via bootstrap for future runs, but PR #40's branch needs it directly (see PR comment flow); the same content just needs to be committed to `jestconfig.json` on `speakeasy-sdk-regen-20260719`.

Related: PDE-755 / follow-up to #2734
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41e6f5a4-9b2c-4315-93c2-33e2db1bee6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

