### PR TITLE
ci(docs): dispatch convoy-go, convoy.rb and convoy-php SDK generation

### DIFF
--- a/.github/workflows/speakeasy-sdk.yml
+++ b/.github/workflows/speakeasy-sdk.yml
@@ -1,17 +1,19 @@
 name: Speakeasy SDK regeneration
 
 # When public OpenAPI artifacts change on main (or via manual dispatch), kick
-# SDK generation in convoy.js / convoy-python / convoy-java. SDK repos pull
-# docs/v3/openapi3.yaml from this repository. Each repo owns its generator
-# (convoy.js: Speakeasy; convoy-python: openapi-python-client; convoy-java:
-# OpenAPI Generator) behind the same sdk_generation.yaml filename and inputs.
+# SDK generation in the SDK repos (see the trigger-sdk-repos matrix). SDK
+# repos pull docs/v3/openapi3.yaml from this repository. Each repo owns its
+# generator (convoy.js: Speakeasy; convoy-python: openapi-python-client;
+# convoy-go: oapi-codegen; convoy-java / convoy.rb / convoy-php: OpenAPI
+# Generator) behind the same sdk_generation.yaml filename and inputs.
 #
 # Required repository secrets:
 #   SPEAKEASY_API_KEY   — Speakeasy workspace API key (also required on convoy.js)
 #   SDK_REPOS_PAT       — GitHub PAT (or fine-grained token) that can
-#                         workflow_dispatch and open/edit PRs on
-#                         frain-dev/convoy.js, frain-dev/convoy-python and
-#                         frain-dev/convoy-java
+#                         workflow_dispatch and open/edit PRs on every repo in
+#                         the trigger-sdk-repos matrix (convoy.js,
+#                         convoy-python, convoy-java, convoy-go, convoy.rb,
+#                         convoy-php)
 
 on:
   push:
@@ -99,6 +101,12 @@ jobs:
             repo: convoy-python
           - language: java
             repo: convoy-java
+          - language: go
+            repo: convoy-go
+          - language: ruby
+            repo: convoy.rb
+          - language: php
+            repo: convoy-php
     steps:
       - name: Prepare feature branch
         id: branch

--- a/docs/md/SPEAKEASY_SDK.md
+++ b/docs/md/SPEAKEASY_SDK.md
@@ -8,17 +8,17 @@ pattern, per-language generator picks:
 | `convoy.js` | [Speakeasy](https://www.speakeasy.com/) (free tier) | Free tier allows exactly one generated SDK per workspace; JS holds the slot |
 | `convoy-python` | [openapi-python-client](https://github.com/openapi-generators/openapi-python-client) (OSS, pinned) | Speakeasy slot taken; OSS output proven idiomatic and complete. Speakeasy pipeline kept dormant in-repo for a provider switch |
 | `convoy-java` | [OpenAPI Generator](https://openapi-generator.tech/) (OSS, pinned; `java`/`native` library) | Same OSS pattern as Python; native `java.net.http` + Jackson, no framework deps |
+| `convoy-go` | [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen) (OSS, pinned) | Go-native generator; single-file `client/` subpackage beside the hand-written client |
+| `convoy.rb` | OpenAPI Generator (OSS, pinned; `ruby`) | Generated `ConvoyApi` namespace beside the hand-written `Convoy` gem code |
+| `convoy-php` | OpenAPI Generator (OSS, pinned; `php`) | Generated `Convoy\Client` namespace under `src/Client/` beside the hand-written SDK |
 
 ## Scope
 
 | Surface | Ownership |
 | --- | --- |
-| Public API client (JS, Python, Java) | Generated from OpenAPI |
+| Public API client (JS, Python, Java, Go, Ruby, PHP) | Generated from OpenAPI |
 | Webhook signature verify | **Hand-written** in every language (`signature-vectors.json`) |
 | Dashboard `/ui` auth/billing/org | Out of scope for PDE-755 |
-
-Follow-up tickets cover Go / Ruby / PHP API codegen (Go candidate:
-`oapi-codegen`; Ruby/PHP deferred until demand signal).
 
 ## Pipeline
 
@@ -28,6 +28,9 @@ Follow-up tickets cover Go / Ruby / PHP API codegen (Go candidate:
               convoy.js:      Speakeasy action → regen PR
               convoy-python:  openapi-python-client → regen PR (only on diff)
               convoy-java:    OpenAPI Generator → regen PR (only on diff)
+              convoy-go:      oapi-codegen → regen PR (only on diff)
+              convoy.rb:      OpenAPI Generator → regen PR (only on diff)
+              convoy-php:     OpenAPI Generator → regen PR (only on diff)
 signature-vectors.json → hand-written verify tests (unchanged)
 ```
 
@@ -47,8 +50,8 @@ and inputs (`force`, `feature_branch`); each repo owns its generator.
 | Secret | Where | Purpose |
 | --- | --- | --- |
 | `SPEAKEASY_API_KEY` | `convoy`, `convoy.js` | Speakeasy generation (JS only now) |
-| `SDK_REPOS_PAT` | `convoy` | Dispatch workflows / open PRs on SDK repos |
-| `SDK_BOT_PAT` | `convoy.js`, `convoy-python`, `convoy-java` | Open generation PRs so verify CI triggers — PRs opened with `GITHUB_TOKEN` do not fire `pull_request` workflows. Can be the same fine-grained token as `SDK_REPOS_PAT` (which must also cover `convoy-java`). |
+| `SDK_REPOS_PAT` | `convoy` | Dispatch workflows / open PRs on every SDK repo in the matrix |
+| `SDK_BOT_PAT` | every SDK repo (`convoy.js`, `convoy-python`, `convoy-java`, `convoy-go`, `convoy.rb`, `convoy-php`) | Open generation PRs so verify CI triggers — PRs opened with `GITHUB_TOKEN` do not fire `pull_request` workflows. Can be the same fine-grained token as `SDK_REPOS_PAT` (which must cover all matrix repos). |
 
 ## Speakeasy plan limit
 


### PR DESCRIPTION
## Summary
- Adds `convoy-go`, `convoy.rb`, and `convoy-php` to the SDK regeneration dispatch matrix. Each repo owns its generator behind the shared `sdk_generation.yaml` filename and inputs (convoy-go: oapi-codegen; convoy.rb / convoy-php: OpenAPI Generator), so the dispatcher contract is unchanged.
- Updates the header comment: `SDK_REPOS_PAT` must be able to dispatch workflows and open PRs on all six SDK repos.

Companion PRs adding the pipelines: frain-dev/convoy-go#60, frain-dev/convoy.rb#20, frain-dev/convoy-php#11.

## Test plan
- [ ] After the three SDK repo PRs merge and `SDK_REPOS_PAT` covers the new repos, a dispatcher run should fan out to all six repos (no-diff repos skip PR creation).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and CI matrix only; no runtime code. Operational risk is ensuring `SDK_REPOS_PAT` permissions include the three new repos before the next dispatch.
> 
> **Overview**
> Extends the **OpenAPI → SDK regeneration dispatcher** so `speakeasy-sdk.yml` fans out to **six** language repos instead of three, adding **`convoy-go`**, **`convoy.rb`**, and **`convoy-php`** to the `trigger-sdk-repos` matrix. Each new repo is expected to implement the same **`sdk_generation.yaml`** contract (`force`, `feature_branch`); generators are documented as **oapi-codegen** for Go and **OpenAPI Generator** for Ruby/PHP.
> 
> **`SPEAKEASY_SDK.md`** is updated to match: generator/scope tables, pipeline diagram, and secret guidance now state that **`SDK_REPOS_PAT`** / **`SDK_BOT_PAT`** must cover all matrix repos. The note deferring Go/Ruby/PHP codegen is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12d886c89c9a739cb301bd3f75e40c28c02f4629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->