### PR TITLE
fix(controlplane): return empty endpoints_metadata for portal links with no endpoints

### DIFF
--- a/internal/portal_links/get_portal_link_test.go
+++ b/internal/portal_links/get_portal_link_test.go
@@ -1,6 +1,7 @@
 package portal_links
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/oklog/ulid/v2"
@@ -76,6 +77,89 @@ func TestGetPortalLink_WithEndpoints(t *testing.T) {
 	require.NotNil(t, portalLink)
 	require.Equal(t, 2, portalLink.EndpointCount)
 	require.NotNil(t, portalLink.Endpoints)
+}
+
+func TestGetPortalLink_EndpointsMetadata_EmptyWhenNoEndpoints(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	project := seedTestData(t, db)
+
+	logger := log.New("convoy", log.LevelInfo)
+	service := New(logger, db)
+
+	// Create a portal link with no endpoints
+	createRequest := &datastore.CreatePortalLinkRequest{
+		Name:              "Portal Link Without Endpoints",
+		OwnerID:           ulid.Make().String(),
+		AuthType:          string(datastore.PortalAuthTypeStaticToken),
+		CanManageEndpoint: true,
+		Endpoints:         []string{},
+	}
+
+	createdPortalLink, err := service.CreatePortalLink(ctx, project.UID, createRequest)
+	require.NoError(t, err)
+
+	// Fetch by id
+	portalLink, err := service.GetPortalLink(ctx, project.UID, createdPortalLink.UID)
+	require.NoError(t, err)
+	require.NotNil(t, portalLink.EndpointsMetadata)
+	require.Empty(t, portalLink.EndpointsMetadata, "endpoints_metadata must be [] not [null] for a link with no endpoints")
+
+	metadataJSON, err := json.Marshal(portalLink.EndpointsMetadata)
+	require.NoError(t, err)
+	require.Equal(t, "[]", string(metadataJSON))
+
+	// Fetch by token
+	byToken, err := service.GetPortalLinkByToken(ctx, portalLink.Token)
+	require.NoError(t, err)
+	require.NotNil(t, byToken.EndpointsMetadata)
+	require.Empty(t, byToken.EndpointsMetadata)
+
+	// Fetch by owner id
+	byOwner, err := service.GetPortalLinkByOwnerID(ctx, project.UID, createRequest.OwnerID)
+	require.NoError(t, err)
+	require.NotNil(t, byOwner.EndpointsMetadata)
+	require.Empty(t, byOwner.EndpointsMetadata)
+
+	// Fetch many by owner id
+	byOwnerMany, err := service.FindPortalLinksByOwnerID(ctx, createRequest.OwnerID)
+	require.NoError(t, err)
+	require.Len(t, byOwnerMany, 1)
+	require.NotNil(t, byOwnerMany[0].EndpointsMetadata)
+	require.Empty(t, byOwnerMany[0].EndpointsMetadata)
+}
+
+func TestGetPortalLink_EndpointsMetadata_WithEndpoints(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	project := seedTestData(t, db)
+
+	logger := log.New("convoy", log.LevelInfo)
+	service := New(logger, db)
+
+	ownerID := ulid.Make().String()
+	endpoint1 := seedEndpoint(t, db, project, "")
+	endpoint2 := seedEndpoint(t, db, project, "")
+
+	createRequest := &datastore.CreatePortalLinkRequest{
+		Name:              "Portal Link Metadata With Endpoints",
+		OwnerID:           ownerID,
+		AuthType:          string(datastore.PortalAuthTypeStaticToken),
+		CanManageEndpoint: false,
+		Endpoints:         []string{endpoint1.UID, endpoint2.UID},
+	}
+
+	createdPortalLink, err := service.CreatePortalLink(ctx, project.UID, createRequest)
+	require.NoError(t, err)
+
+	portalLink, err := service.GetPortalLink(ctx, project.UID, createdPortalLink.UID)
+	require.NoError(t, err)
+	require.Len(t, portalLink.EndpointsMetadata, 2)
+
+	metadataUIDs := make([]string, 0, len(portalLink.EndpointsMetadata))
+	for _, endpoint := range portalLink.EndpointsMetadata {
+		require.NotNil(t, endpoint, "endpoints_metadata must not contain null elements")
+		metadataUIDs = append(metadataUIDs, endpoint.UID)
+	}
+	require.ElementsMatch(t, []string{endpoint1.UID, endpoint2.UID}, metadataUIDs)
 }
 
 func TestGetPortalLink_NotFound(t *testing.T) {

--- a/internal/portal_links/load_portal_links_paged_test.go
+++ b/internal/portal_links/load_portal_links_paged_test.go
@@ -33,6 +33,62 @@ func TestLoadPortalLinksPaged_Success_EmptyList(t *testing.T) {
 	require.Equal(t, 0, paginationData.PrevRowCount.Count)
 }
 
+func TestLoadPortalLinksPaged_EndpointsMetadata(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	project := seedTestData(t, db)
+
+	logger := log.New("convoy", log.LevelInfo)
+	service := New(logger, db)
+
+	// One portal link with no endpoints
+	emptyRequest := &datastore.CreatePortalLinkRequest{
+		Name:              "Paged Portal Link Without Endpoints",
+		OwnerID:           ulid.Make().String(),
+		AuthType:          string(datastore.PortalAuthTypeStaticToken),
+		CanManageEndpoint: true,
+		Endpoints:         []string{},
+	}
+	emptyLink, err := service.CreatePortalLink(ctx, project.UID, emptyRequest)
+	require.NoError(t, err)
+
+	// One portal link with an endpoint
+	endpoint := seedEndpoint(t, db, project, "")
+	withEndpointsRequest := &datastore.CreatePortalLinkRequest{
+		Name:              "Paged Portal Link With Endpoints",
+		OwnerID:           ulid.Make().String(),
+		AuthType:          string(datastore.PortalAuthTypeStaticToken),
+		CanManageEndpoint: false,
+		Endpoints:         []string{endpoint.UID},
+	}
+	withEndpointsLink, err := service.CreatePortalLink(ctx, project.UID, withEndpointsRequest)
+	require.NoError(t, err)
+
+	filter := &datastore.FilterBy{}
+	pageable := datastore.Pageable{
+		PerPage:   10,
+		Direction: datastore.Next,
+	}
+	pageable.SetCursors()
+
+	portalLinks, _, err := service.LoadPortalLinksPaged(ctx, project.UID, filter, pageable)
+	require.NoError(t, err)
+	require.Len(t, portalLinks, 2)
+
+	byUID := make(map[string]datastore.PortalLink, len(portalLinks))
+	for _, pl := range portalLinks {
+		byUID[pl.UID] = pl
+	}
+
+	emptyResult := byUID[emptyLink.UID]
+	require.NotNil(t, emptyResult.EndpointsMetadata)
+	require.Empty(t, emptyResult.EndpointsMetadata, "endpoints_metadata must be [] not [null] for a link with no endpoints")
+
+	withEndpointsResult := byUID[withEndpointsLink.UID]
+	require.Len(t, withEndpointsResult.EndpointsMetadata, 1)
+	require.NotNil(t, withEndpointsResult.EndpointsMetadata[0], "endpoints_metadata must not contain null elements")
+	require.Equal(t, endpoint.UID, withEndpointsResult.EndpointsMetadata[0].UID)
+}
+
 func TestLoadPortalLinksPaged_Success_MultiplePortalLinks(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	project := seedTestData(t, db)

--- a/internal/portal_links/queries.sql
+++ b/internal/portal_links/queries.sql
@@ -52,11 +52,9 @@ SELECT
     END AS endpoint_count,
     p.created_at,
     p.updated_at,
-    ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
-        CASE WHEN e.id IS NOT NULL THEN
-            cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
-        END
-    )) AS endpoints_metadata
+    COALESCE(ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
+        cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
+    ) FILTER (WHERE e.id IS NOT NULL)), '[]'::json) AS endpoints_metadata
 FROM convoy.portal_links p
 LEFT JOIN convoy.portal_links_endpoints pe
     ON p.id = pe.portal_link_id
@@ -81,11 +79,9 @@ SELECT
     END AS endpoint_count,
     p.created_at,
     p.updated_at,
-    ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
-        CASE WHEN e.id IS NOT NULL THEN
-            cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
-        END
-    )) AS endpoints_metadata
+    COALESCE(ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
+        cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
+    ) FILTER (WHERE e.id IS NOT NULL)), '[]'::json) AS endpoints_metadata
 FROM convoy.portal_links p
 LEFT JOIN convoy.portal_links_endpoints pe
     ON p.id = pe.portal_link_id
@@ -110,11 +106,9 @@ SELECT
     END AS endpoint_count,
     p.created_at,
     p.updated_at,
-    ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
-        CASE WHEN e.id IS NOT NULL THEN
-            cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
-        END
-    )) AS endpoints_metadata
+    COALESCE(ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
+        cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
+    ) FILTER (WHERE e.id IS NOT NULL)), '[]'::json) AS endpoints_metadata
 FROM convoy.portal_links p
 LEFT JOIN convoy.portal_links_endpoints pe
     ON p.id = pe.portal_link_id
@@ -161,11 +155,9 @@ SELECT
     END AS endpoint_count,
     p.created_at,
     p.updated_at,
-    ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
-        CASE WHEN e.id IS NOT NULL THEN
-            cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
-        END
-    )) AS endpoints_metadata
+    COALESCE(ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
+        cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
+    ) FILTER (WHERE e.id IS NOT NULL)), '[]'::json) AS endpoints_metadata
 FROM convoy.portal_links p
 LEFT JOIN convoy.portal_links_endpoints pe
     ON p.id = pe.portal_link_id
@@ -201,11 +193,9 @@ WITH filtered_portal_links AS (
         END AS endpoint_count,
         p.created_at,
         p.updated_at,
-        ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
-            CASE WHEN e.id IS NOT NULL THEN
-                cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
-            END
-        )) AS endpoints_metadata
+        COALESCE(ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
+            cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
+        ) FILTER (WHERE e.id IS NOT NULL)), '[]'::json) AS endpoints_metadata
     FROM convoy.portal_links p
     LEFT JOIN convoy.portal_links_endpoints pe
         ON p.id = pe.portal_link_id

--- a/internal/portal_links/repo/queries.sql.go
+++ b/internal/portal_links/repo/queries.sql.go
@@ -196,11 +196,9 @@ SELECT
     END AS endpoint_count,
     p.created_at,
     p.updated_at,
-    ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
-        CASE WHEN e.id IS NOT NULL THEN
-            cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
-        END
-    )) AS endpoints_metadata
+    COALESCE(ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
+        cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
+    ) FILTER (WHERE e.id IS NOT NULL)), '[]'::json) AS endpoints_metadata
 FROM convoy.portal_links p
 LEFT JOIN convoy.portal_links_endpoints pe
     ON p.id = pe.portal_link_id
@@ -326,11 +324,9 @@ SELECT
     END AS endpoint_count,
     p.created_at,
     p.updated_at,
-    ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
-        CASE WHEN e.id IS NOT NULL THEN
-            cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
-        END
-    )) AS endpoints_metadata
+    COALESCE(ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
+        cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
+    ) FILTER (WHERE e.id IS NOT NULL)), '[]'::json) AS endpoints_metadata
 FROM convoy.portal_links p
 LEFT JOIN convoy.portal_links_endpoints pe
     ON p.id = pe.portal_link_id
@@ -396,11 +392,9 @@ SELECT
     END AS endpoint_count,
     p.created_at,
     p.updated_at,
-    ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
-        CASE WHEN e.id IS NOT NULL THEN
-            cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
-        END
-    )) AS endpoints_metadata
+    COALESCE(ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
+        cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
+    ) FILTER (WHERE e.id IS NOT NULL)), '[]'::json) AS endpoints_metadata
 FROM convoy.portal_links p
 LEFT JOIN convoy.portal_links_endpoints pe
     ON p.id = pe.portal_link_id
@@ -461,11 +455,9 @@ SELECT
     END AS endpoint_count,
     p.created_at,
     p.updated_at,
-    ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
-        CASE WHEN e.id IS NOT NULL THEN
-            cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
-        END
-    )) AS endpoints_metadata
+    COALESCE(ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
+        cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
+    ) FILTER (WHERE e.id IS NOT NULL)), '[]'::json) AS endpoints_metadata
 FROM convoy.portal_links p
 LEFT JOIN convoy.portal_links_endpoints pe
     ON p.id = pe.portal_link_id
@@ -541,11 +533,9 @@ WITH filtered_portal_links AS (
         END AS endpoint_count,
         p.created_at,
         p.updated_at,
-        ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
-            CASE WHEN e.id IS NOT NULL THEN
-                cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
-            END
-        )) AS endpoints_metadata
+        COALESCE(ARRAY_TO_JSON(ARRAY_AGG(DISTINCT
+            cast(JSON_BUILD_OBJECT('uid', e.id, 'name', e.name, 'project_id', e.project_id, 'url', e.url, 'secrets', e.secrets) as jsonb)
+        ) FILTER (WHERE e.id IS NOT NULL)), '[]'::json) AS endpoints_metadata
     FROM convoy.portal_links p
     LEFT JOIN convoy.portal_links_endpoints pe
         ON p.id = pe.portal_link_id


### PR DESCRIPTION
## Summary
- Portal links with zero endpoints returned `endpoints_metadata: [null]`: the `ARRAY_AGG(DISTINCT CASE WHEN e.id IS NOT NULL THEN ... END)` aggregation keeps the NULL the CASE produces for the unmatched LEFT JOIN row. Strict SDK clients crashed on the null element until the spec was patched to tolerate it.
- Fixed at the assembly point in all five portal link read queries (`internal/portal_links/queries.sql` + regenerated sqlc): aggregate with `FILTER (WHERE e.id IS NOT NULL)` and `COALESCE(..., '[]'::json)`, so the column is `[]` with no endpoints and real objects otherwise. Create/update responses go through the fixed by-id query via their re-fetch.
- The SDK-side null-item tolerance shipped earlier stays: older servers remain in the field, so clients keep accepting both shapes.

Note for release: the server-side repo cache (5 min TTL) can serve pre-fix `[null]` briefly after deploy; it self-heals, no action needed.


## Test plan
- [x] New tests assert `[]` (not `[null]`) across get by id/token/owner, find-many, and paginated list, plus real-object assertions with endpoints; empty-case test fails without the fix
- [x] `go test ./internal/portal_links/...` 63 passed (testcontainers)
- [x] gofmt, go vet, golangci-lint clean

Fixes PDE-930
