### PR TITLE
fix(controlplane): render current year in email template footers

### DIFF
--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -5,7 +5,9 @@ import (
 	"embed"
 	"fmt"
 	"html/template"
+	"path"
 	"strings"
+	"time"
 
 	"github.com/frain-dev/convoy/internal/pkg/smtp"
 )
@@ -58,9 +60,20 @@ func NewEmail(c smtp.SmtpClient) *Email {
 	return &Email{client: c}
 }
 
+// templateFuncs are available to every email template.
+var templateFuncs = template.FuncMap{
+	"currentYear": func() int {
+		return time.Now().Year()
+	},
+}
+
 // TODO(subomi): glob pattern must not match more than one template
 func (e *Email) Build(glob string, params interface{}) error {
-	templ, err := e.templ.ParseFS(templateDir, e.buildGlob(glob))
+	pattern := e.buildGlob(glob)
+
+	// The root template must share the parsed file's base name so that
+	// Execute runs the parsed template.
+	templ, err := template.New(path.Base(pattern)).Funcs(templateFuncs).ParseFS(templateDir, pattern)
 	if err != nil {
 		return fmt.Errorf("failed to parse template fs: %v", err)
 	}

--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -1,7 +1,9 @@
 package email
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -56,6 +58,44 @@ func Test_Build(t *testing.T) {
 			if tc.wantErr {
 				require.Error(t, err)
 			}
+		})
+	}
+}
+
+func Test_Build_FooterRendersCurrentYear(t *testing.T) {
+	templates := []string{
+		"user.verify.email.html",
+		"reset.password.html",
+		"organisation.invite.html",
+		"endpoint.update.html",
+	}
+
+	params := map[string]string{
+		"recipient_name":         "Jon",
+		"email":                  "jon@example.com",
+		"email_verification_url": "https://example.com/verify",
+		"inviter_name":           "Jane",
+		"invite_url":             "https://example.com/invite",
+		"password_reset_url":     "https://example.com/reset",
+		"expires_at":             "2026-01-01",
+		"endpoint_status":        "inactive",
+		"name":                   "test-endpoint",
+		"target_url":             "https://example.com/endpoint",
+		"response_body":          "",
+		"failure_msg":            "connection refused",
+	}
+
+	for _, glob := range templates {
+		t.Run(glob, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			e := NewEmail(buildClient(ctrl))
+			require.NoError(t, e.Build(glob, params))
+
+			body := e.body.String()
+			require.Contains(t, body, fmt.Sprintf("© %d Frain Technologies", time.Now().Year()))
+			require.NotContains(t, body, "© 2024")
 		})
 	}
 }

--- a/internal/email/templates/endpoint.update.html
+++ b/internal/email/templates/endpoint.update.html
@@ -145,7 +145,7 @@
         <div class="footer">
             <p>
                 2261 Market Street, San Francisco, CA 94114<br>
-                © 2024 Frain Technologies
+                © {{ currentYear }} Frain Technologies
             </p>
 <!--            <p>-->
 <!--                <a href="#" style="color: #3b82f6; text-decoration: none;">Unsubscribe</a> |-->

--- a/internal/email/templates/organisation.invite.html
+++ b/internal/email/templates/organisation.invite.html
@@ -143,7 +143,7 @@
                     2261 Market Street, San Francisco, CA 94114
                 </p>
                 <p class="footer-text" style="color: #718096; font-size: 14px; line-height: 24px; margin: 0;">
-                    © 2024 Frain Technologies
+                    © {{ currentYear }} Frain Technologies
                 </p>
             </td>
         </tr>

--- a/internal/email/templates/reset.password.html
+++ b/internal/email/templates/reset.password.html
@@ -143,7 +143,7 @@
                     2261 Market Street, San Francisco, CA 94114
                 </p>
                 <p class="footer-text" style="color: #718096; font-size: 14px; line-height: 24px; margin: 0;">
-                    © 2024 Frain Technologies
+                    © {{ currentYear }} Frain Technologies
                 </p>
             </td>
         </tr>

--- a/internal/email/templates/user.verify.email.html
+++ b/internal/email/templates/user.verify.email.html
@@ -107,7 +107,7 @@
                     2261 Market Street, San Francisco, CA 94114
                 </p>
                 <p class="footer-text" style="color: #718096; font-size: 14px; line-height: 24px; margin: 0;">
-                    © 2024 Frain Technologies
+                    © {{ currentYear }} Frain Technologies
                 </p>
             </td>
         </tr>


### PR DESCRIPTION
## Summary
- Inject the current calendar year into system email templates instead of hardcoding 2024.
- Covers verify-email, organisation invite, reset-password, and endpoint-update footers.

## Test plan
- [ ] `go test ./internal/email/...`
- [ ] Trigger a verify-email (or invite) send and confirm the footer shows the current year