### PR TITLE
fix(dashboard): clarify unverified-email copy for dialog and trial modal

### DIFF
--- a/web/ui/dashboard/src/app/private/components/verify-email/verify-email.component.html
+++ b/web/ui/dashboard/src/app/private/components/verify-email/verify-email.component.html
@@ -3,7 +3,7 @@
         <img src="assets/img/svg/lock-open.svg" alt="lock icon" class="h-26px" />
     </div>
     <h3 class="font-bold mt-12px mb-20px">Verify Email</h3>
-    <p class="text-neutral-11">Please verify your email.</p>
+    <p class="text-neutral-11">Verify your email to continue using Convoy.</p>
     <p class="text-neutral-11">If you didn't receive a verification email, please try resending your verification email below.</p>
     <div class="flex mt-38px">
         <button convoy-button [disabled]="isResendingEmail" (click)="resendVerificationEmail()">Resend Verification</button>

--- a/web/ui/dashboard/src/app/private/pages/settings/billing/trial-modal.component.html
+++ b/web/ui/dashboard/src/app/private/pages/settings/billing/trial-modal.component.html
@@ -47,7 +47,7 @@
 
     @if (mode === 'cloud' && !emailVerified) {
       <p class="text-12 text-neutral-11 mb-16px">
-        Verify your email before starting a trial. Check your inbox for the verification link.
+        Verify your email to continue using Convoy.
       </p>
     }
 


### PR DESCRIPTION
## Summary
- Update verify-email dialog copy to: "Verify your email to continue using Convoy."
- Use the same line in the cloud trial modal when email is unverified (button stays disabled).

## Test plan
- [ ] Unverified user sees the new dialog copy from the email reminder chip
- [ ] Cloud trial modal shows the same line and Start free trial stays disabled until verified