### PR TITLE
fix(controlplane): harden ingest verifier fallback, retry scoping, bulk onboard and billing update

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -728,6 +728,12 @@ func (a *ApplicationHandler) mountControlPlaneRoutes(router chi.Router, handler 
 			BillingClient: a.A.BillingClient,
 		}
 		uiRouter.Route("/billing", func(billingRouter chi.Router) {
+			// Catalog endpoints (config, plans, tax_id_types) are intentionally
+			// readable by any authenticated user: they return only public
+			// catalog data the dashboard needs to render billing UI (plan
+			// names/pricing, tax ID formats, payment provider publishable key,
+			// billing mode). Org-scoped and checkout-state fields stay behind
+			// orgGuard/canManageSelfHostedBilling inside the handlers.
 			billingRouter.Get("/config", billingHandler.GetBillingConfig)
 			billingRouter.Get("/plans", billingHandler.GetPlans)
 			billingRouter.Get("/tax_id_types", billingHandler.GetTaxIDTypes)

--- a/api/handlers/billing_cloud.go
+++ b/api/handlers/billing_cloud.go
@@ -444,16 +444,30 @@ func (h *BillingHandler) GetOrganisation(w http.ResponseWriter, r *http.Request)
 	_ = render.Render(w, r, util.NewServerResponse("Organisation retrieved successfully", resp.Data, http.StatusOK))
 }
 
+// updateBillingOrganisationRequest allowlists the caller-settable billing
+// profile fields. Identity and linkage fields (external_id, license_key, host,
+// id, slug) are owned by the billing bootstrap flow and must never be forwarded
+// from a user request body.
+type updateBillingOrganisationRequest struct {
+	Name         string `json:"name,omitempty"`
+	BillingEmail string `json:"billing_email,omitempty"`
+}
+
 func (h *BillingHandler) UpdateOrganisation(w http.ResponseWriter, r *http.Request) {
 	orgID, ok := h.orgGuard(w, r)
 	if !ok {
 		return
 	}
 
-	var orgData billing.BillingOrganisation
-	if err := json.NewDecoder(r.Body).Decode(&orgData); err != nil {
+	var req updateBillingOrganisationRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		_ = render.Render(w, r, util.NewErrorResponse("Invalid request body", http.StatusBadRequest))
 		return
+	}
+
+	orgData := billing.BillingOrganisation{
+		Name:         req.Name,
+		BillingEmail: req.BillingEmail,
 	}
 
 	resp, err := h.BillingClient.UpdateOrganisation(r.Context(), orgID, orgData)

--- a/api/handlers/organisation.go
+++ b/api/handlers/organisation.go
@@ -1049,9 +1049,11 @@ func (h *Handler) RetryEventDeliveries(w http.ResponseWriter, r *http.Request) {
 	tracker := batch_tracker.NewBatchTracker(h.A.Redis)
 	batchID := tracker.GenerateBatchID()
 
-	// Run retry in background goroutine - don't block the response
+	// Run retry in background goroutine - don't block the response.
+	// Empty projectID is intentional: this endpoint is instance-admin gated and
+	// requeues across the whole instance.
 	go func() {
-		task.RetryEventDeliveriesWithTracker(h.A.Logger, h.A.DB, h.A.Queue, statuses, retryRequest.Time, retryRequest.EventID, batchID, tracker)
+		task.RetryEventDeliveriesWithTracker(h.A.Logger, h.A.DB, h.A.Queue, "", statuses, retryRequest.Time, retryRequest.EventID, batchID, tracker)
 	}()
 
 	_ = render.Render(w, r, util.NewServerResponse("Event deliveries retry initiated successfully", map[string]interface{}{

--- a/api/ingest.go
+++ b/api/ingest.go
@@ -115,8 +115,20 @@ func (a *ApplicationHandler) IngestEvent(w http.ResponseWriter, r *http.Request)
 				verifierConfig.ApiKey.HeaderValue,
 				verifierConfig.ApiKey.HeaderName,
 			)
-		default:
+		case datastore.NoopVerifier:
+			// Explicit opt-out of verification. Sources persisted without a
+			// verifier row are canonicalized to this type by the sources read
+			// layer (buildVerifierConfig), so "no verifier configured" lands
+			// here by design.
 			v = &verifier.NoopVerifier{}
+		default:
+			// Fail closed: an unknown or stale verifier type must not silently
+			// accept unverified events (see frain-dev/convoy#2656).
+			a.A.Logger.Error("no valid verifier configured for source",
+				"source_id", source.UID, "verifier_type", verifierConfig.Type, "mask_id", maskID)
+			_ = render.Render(w, r, util.NewErrorResponse(
+				"source has no valid verifier configured", http.StatusBadRequest))
+			return
 		}
 	}
 

--- a/api/ingest_integration_test.go
+++ b/api/ingest_integration_test.go
@@ -356,6 +356,35 @@ func (i *IngestIntegrationTestSuite) Test_IngestEvent_NoopVerifier_EmptyRequestB
 	require.Equal(i.T(), float64(2), response["data"].(float64))
 }
 
+func (i *IngestIntegrationTestSuite) Test_IngestEvent_UnknownVerifierRejected() {
+	maskID := ulid.Make().String()
+	sourceID := ulid.Make().String()
+	expectedStatusCode := http.StatusBadRequest
+
+	// A source with an unknown verifier type (e.g. a stale config after a
+	// verifier is renamed/removed) must fail closed, never fall back to
+	// accepting unverified events. An empty type never reaches the handler:
+	// the sources read layer canonicalizes it to the explicit noop verifier.
+	v := &datastore.VerifierConfig{
+		Type: datastore.VerifierType("unknown-verifier"),
+	}
+	_, _ = testdb.SeedSource(i.ConvoyApp.A.DB, i.DefaultProject, sourceID, maskID, "", v, "", "")
+
+	body := serialize(`{ "name": "convoy" }`)
+
+	// Arrange Request.
+	url := fmt.Sprintf("/ingest/%s", maskID)
+	req := createRequest(http.MethodPost, url, "", body)
+
+	w := httptest.NewRecorder()
+
+	// Act.
+	i.Router.ServeHTTP(w, req)
+
+	// Assert.
+	require.Equal(i.T(), expectedStatusCode, w.Code)
+}
+
 func (i *IngestIntegrationTestSuite) Test_IngestEvent_WriteToQueueFailed() {
 	i.T().Skip("Depends on mocking")
 }

--- a/cmd/retry/retry.go
+++ b/cmd/retry/retry.go
@@ -16,6 +16,8 @@ func AddRetryCommand(a *cli.App) *cobra.Command {
 	var status string
 	var timeInterval string
 	var eventId string
+	var projectID string
+	var allProjects bool
 
 	cmd := &cobra.Command{
 		Use:   "retry",
@@ -35,13 +37,26 @@ func AddRetryCommand(a *cli.App) *cobra.Command {
 				os.Exit(1)
 			}
 
+			// Instance-wide requeue must be an explicit choice, not the silent
+			// default of an omitted flag.
+			if projectID == "" && !allProjects {
+				fmt.Fprintln(os.Stderr, "Error: provide --project-id to scope the retry, or pass --all-projects to requeue across every project")
+				os.Exit(1)
+			}
+			if projectID != "" && allProjects {
+				fmt.Fprintln(os.Stderr, "Error: --project-id and --all-projects are mutually exclusive")
+				os.Exit(1)
+			}
+
 			statuses := []datastore.EventDeliveryStatus{datastore.EventDeliveryStatus(status)}
-			task.RetryEventDeliveries(a.Logger, a.DB, a.Queue, statuses, timeInterval, eventId)
+			task.RetryEventDeliveries(a.Logger, a.DB, a.Queue, projectID, statuses, timeInterval, eventId)
 		},
 	}
 
 	cmd.Flags().StringVar(&status, "status", "", "Status of event deliveries to requeue")
 	cmd.Flags().StringVar(&timeInterval, "time", "", "Time interval")
 	cmd.Flags().StringVar(&eventId, "eventid", "", "Requeue the informed eventId")
+	cmd.Flags().StringVar(&projectID, "project-id", "", "Limit the retry to a single project")
+	cmd.Flags().BoolVar(&allProjects, "all-projects", false, "Explicitly requeue across all projects")
 	return cmd
 }

--- a/pkg/url/url_template.go
+++ b/pkg/url/url_template.go
@@ -12,7 +12,39 @@ var (
 	ErrURLTemplateInvalidToken    = errors.New("endpoint URL template contains an invalid token")
 	ErrURLTemplateUnsupportedPart = errors.New("endpoint URL templates are only supported in the path or query")
 	ErrURLTemplateInvalidURL      = errors.New("endpoint url must include a valid host")
+
+	ErrEndpointURLRequired   = errors.New("please provide the endpoint url")
+	ErrHTTPSOnly             = errors.New("only https endpoints allowed")
+	ErrInvalidEndpointScheme = errors.New("invalid endpoint scheme")
 )
+
+// ValidateEndpointURL validates an endpoint URL's format and scheme without
+// performing a network ping. enforceSecure rejects plain http URLs. It is the
+// single source of truth for endpoint URL validation shared by the API
+// (services) and the bulk-onboard worker, so the security-sensitive scheme rule
+// cannot drift between the two call sites.
+func ValidateEndpointURL(rawURL string, enforceSecure bool) (*url.URL, error) {
+	if strings.TrimSpace(rawURL) == "" {
+		return nil, ErrEndpointURLRequired
+	}
+
+	u, _, err := ValidateEndpointTemplate(rawURL, false)
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case "http":
+		if enforceSecure {
+			return nil, ErrHTTPSOnly
+		}
+	case "https":
+	default:
+		return nil, ErrInvalidEndpointScheme
+	}
+
+	return u, nil
+}
 
 var templateTokenPattern = regexp.MustCompile(`^\{[A-Za-z_][A-Za-z0-9_]*\}`)
 

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -282,7 +282,12 @@ func (tv *TwitterVerifier) VerifyRequest(r *http.Request, payload []byte) error 
 }
 
 func (tV *TwitterVerifier) getSignature(sig string) string {
-	return strings.Split(sig, "sha256=")[1]
+	values := strings.Split(sig, "sha256=")
+	if len(values) < 2 {
+		return ""
+	}
+
+	return values[1]
 }
 
 type NoopVerifier struct{}

--- a/pkg/verifier/verifier_test.go
+++ b/pkg/verifier/verifier_test.go
@@ -439,6 +439,28 @@ func Test_TwitterVerifier_VerifyRequest(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		"malformed_signature_without_prefix": {
+			secret:  "Convoy",
+			payload: []byte(`Test Payload Body`),
+			requestFn: func(t *testing.T) *http.Request {
+				req, err := http.NewRequest("POST", "URL", strings.NewReader(``))
+				require.NoError(t, err)
+
+				req.Header.Add("X-Twitter-Webhooks-Signature", "16FUVH58NeMcTIIOICN2UJOcPTTa4TbjCndXymGrtM8=")
+				return req
+			},
+			expectedError: ErrSignatureCannotBeEmpty,
+		},
+		"missing_signature_header": {
+			secret:  "Convoy",
+			payload: []byte(`Test Payload Body`),
+			requestFn: func(t *testing.T) *http.Request {
+				req, err := http.NewRequest("POST", "URL", strings.NewReader(``))
+				require.NoError(t, err)
+				return req
+			},
+			expectedError: ErrSignatureCannotBeEmpty,
+		},
 	}
 
 	for name, tc := range tests {

--- a/services/create_endpoint.go
+++ b/services/create_endpoint.go
@@ -378,24 +378,9 @@ func (a *CreateEndpointService) ValidateEndpoint(ctx context.Context, project *d
 // ValidateEndpointURL validates the URL format without performing an HTTPS ping.
 // This is used by bulk operations where pinging each endpoint would be too slow.
 func ValidateEndpointURL(rawURL string, enforceSecure bool) (string, error) {
-	if util.IsStringEmpty(rawURL) {
-		return "", ErrEndpointURLRequired
-	}
-
-	u, _, err := endpointurl.ValidateEndpointTemplate(rawURL, false)
+	u, err := endpointurl.ValidateEndpointURL(rawURL, enforceSecure)
 	if err != nil {
 		return "", err
-	}
-
-	switch u.Scheme {
-	case "http":
-		if enforceSecure {
-			return "", ErrHTTPSOnly
-		}
-	case "https":
-		// URL format is valid, skip ping
-	default:
-		return "", ErrInvalidEndpointScheme
 	}
 
 	return u.String(), nil

--- a/services/errors.go
+++ b/services/errors.go
@@ -1,6 +1,10 @@
 package services
 
-import "errors"
+import (
+	"errors"
+
+	endpointurl "github.com/frain-dev/convoy/pkg/url"
+)
 
 const (
 	ErrCodeAuthInvalid    = "auth.invalid"
@@ -18,9 +22,12 @@ const (
 )
 
 var (
-	ErrEndpointURLRequired   = errors.New("please provide the endpoint url")
-	ErrHTTPSOnly             = errors.New("only https endpoints allowed")
-	ErrInvalidEndpointScheme = errors.New("invalid endpoint scheme")
+	// Endpoint URL validation errors are owned by pkg/url (the single source of
+	// truth shared by the API and the bulk-onboard worker); aliased here so
+	// existing services callers and errors.Is checks keep working.
+	ErrEndpointURLRequired   = endpointurl.ErrEndpointURLRequired
+	ErrHTTPSOnly             = endpointurl.ErrHTTPSOnly
+	ErrInvalidEndpointScheme = endpointurl.ErrInvalidEndpointScheme
 	ErrAPIKeyFieldRequired   = errors.New("api key field is required")
 )
 

--- a/worker/task/process_bulk_onboard.go
+++ b/worker/task/process_bulk_onboard.go
@@ -16,6 +16,7 @@ import (
 	"github.com/frain-dev/convoy/internal/pkg/license"
 	log "github.com/frain-dev/convoy/pkg/logger"
 	"github.com/frain-dev/convoy/pkg/msgpack"
+	endpointurl "github.com/frain-dev/convoy/pkg/url"
 	"github.com/frain-dev/convoy/util"
 )
 
@@ -66,6 +67,15 @@ func ProcessBulkOnboard(deps BulkOnboardDeps) func(context.Context, *asynq.Task)
 
 		var successCount, skipCount, failCount int
 		for _, item := range batch.Items {
+			// Re-validate the URL here: the queue payload is a trust boundary, so
+			// the API layer's validation (services.ValidateEndpointURL) must be
+			// re-applied before creating anything from it.
+			if urlErr := validateOnboardItemURL(item.URL, project); urlErr != nil {
+				deps.Logger.ErrorContext(ctx, fmt.Sprintf("bulk onboard: invalid endpoint URL %q: %v", item.URL, urlErr))
+				failCount++
+				continue
+			}
+
 			// Check for existing endpoint with the same URL
 			existingEndpoint, findErr := deps.EndpointRepo.FindEndpointByTargetURL(ctx, project.UID, item.URL)
 			var endpointID string
@@ -140,6 +150,32 @@ func ProcessBulkOnboard(deps BulkOnboardDeps) func(context.Context, *asynq.Task)
 
 		return nil
 	}
+}
+
+// validateOnboardItemURL mirrors services.ValidateEndpointURL (which worker/task
+// cannot import without a cycle): valid endpoint template, http/https only, and
+// https enforced when the project requires secure endpoints.
+func validateOnboardItemURL(rawURL string, project *datastore.Project) error {
+	if util.IsStringEmpty(rawURL) {
+		return errors.New("endpoint url is required")
+	}
+
+	u, _, err := endpointurl.ValidateEndpointTemplate(rawURL, false)
+	if err != nil {
+		return err
+	}
+
+	switch u.Scheme {
+	case "http":
+		if project.Config != nil && project.Config.SSL != nil && project.Config.SSL.EnforceSecureEndpoints {
+			return errors.New("only https endpoints allowed")
+		}
+	case "https":
+	default:
+		return errors.New("invalid endpoint scheme")
+	}
+
+	return nil
 }
 
 func buildEndpoint(ctx context.Context, deps BulkOnboardDeps, project *datastore.Project, item BulkOnboardItem) (*datastore.Endpoint, error) {

--- a/worker/task/process_bulk_onboard.go
+++ b/worker/task/process_bulk_onboard.go
@@ -155,27 +155,14 @@ func ProcessBulkOnboard(deps BulkOnboardDeps) func(context.Context, *asynq.Task)
 // validateOnboardItemURL mirrors services.ValidateEndpointURL (which worker/task
 // cannot import without a cycle): valid endpoint template, http/https only, and
 // https enforced when the project requires secure endpoints.
+// validateOnboardItemURL re-applies the shared endpoint URL rule
+// (pkg/url.ValidateEndpointURL) to a queue payload item. The queue is a trust
+// boundary, so the API layer's validation must be re-run here before creating
+// anything from the item.
 func validateOnboardItemURL(rawURL string, project *datastore.Project) error {
-	if util.IsStringEmpty(rawURL) {
-		return errors.New("endpoint url is required")
-	}
-
-	u, _, err := endpointurl.ValidateEndpointTemplate(rawURL, false)
-	if err != nil {
-		return err
-	}
-
-	switch u.Scheme {
-	case "http":
-		if project.Config != nil && project.Config.SSL != nil && project.Config.SSL.EnforceSecureEndpoints {
-			return errors.New("only https endpoints allowed")
-		}
-	case "https":
-	default:
-		return errors.New("invalid endpoint scheme")
-	}
-
-	return nil
+	enforceSecure := project.Config != nil && project.Config.SSL != nil && project.Config.SSL.EnforceSecureEndpoints
+	_, err := endpointurl.ValidateEndpointURL(rawURL, enforceSecure)
+	return err
 }
 
 func buildEndpoint(ctx context.Context, deps BulkOnboardDeps, project *datastore.Project, item BulkOnboardItem) (*datastore.Endpoint, error) {

--- a/worker/task/process_bulk_onboard_test.go
+++ b/worker/task/process_bulk_onboard_test.go
@@ -1,0 +1,67 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/frain-dev/convoy/datastore"
+)
+
+func TestValidateOnboardItemURL(t *testing.T) {
+	projectWith := func(enforceSecure bool) *datastore.Project {
+		return &datastore.Project{
+			Config: &datastore.ProjectConfig{
+				SSL: &datastore.SSLConfiguration{EnforceSecureEndpoints: enforceSecure},
+			},
+		}
+	}
+
+	tests := map[string]struct {
+		rawURL  string
+		project *datastore.Project
+		wantErr bool
+	}{
+		"https_url_is_valid": {
+			rawURL:  "https://example.com/webhook",
+			project: projectWith(true),
+			wantErr: false,
+		},
+		"http_url_allowed_when_not_enforced": {
+			rawURL:  "http://example.com/webhook",
+			project: projectWith(false),
+			wantErr: false,
+		},
+		"http_url_rejected_when_secure_enforced": {
+			rawURL:  "http://example.com/webhook",
+			project: projectWith(true),
+			wantErr: true,
+		},
+		"empty_url_rejected": {
+			rawURL:  "",
+			project: projectWith(false),
+			wantErr: true,
+		},
+		"invalid_scheme_rejected": {
+			rawURL:  "ftp://example.com/webhook",
+			project: projectWith(false),
+			wantErr: true,
+		},
+		"garbage_url_rejected": {
+			rawURL:  "://not-a-url",
+			project: projectWith(false),
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := validateOnboardItemURL(tc.rawURL, tc.project)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/worker/task/retry_event_deliveries.go
+++ b/worker/task/retry_event_deliveries.go
@@ -19,11 +19,14 @@ import (
 	"github.com/frain-dev/convoy/util"
 )
 
-func RetryEventDeliveries(logger log.Logger, db database.Database, eventQueue queue.Queuer, statuses []datastore.EventDeliveryStatus, lookBackDuration, eventId string) {
-	RetryEventDeliveriesWithTracker(logger, db, eventQueue, statuses, lookBackDuration, eventId, "", nil)
+// RetryEventDeliveries requeues deliveries for one project, or for the whole
+// instance when projectID is empty. Instance-wide requeue is reserved for the
+// admin surfaces (instance-admin API, explicitly confirmed CLI).
+func RetryEventDeliveries(logger log.Logger, db database.Database, eventQueue queue.Queuer, projectID string, statuses []datastore.EventDeliveryStatus, lookBackDuration, eventId string) {
+	RetryEventDeliveriesWithTracker(logger, db, eventQueue, projectID, statuses, lookBackDuration, eventId, "", nil)
 }
 
-func RetryEventDeliveriesWithTracker(logger log.Logger, db database.Database, eventQueue queue.Queuer, statuses []datastore.EventDeliveryStatus, lookBackDuration, eventId, batchID string, tracker *batch_tracker.BatchTracker) {
+func RetryEventDeliveriesWithTracker(logger log.Logger, db database.Database, eventQueue queue.Queuer, projectID string, statuses []datastore.EventDeliveryStatus, lookBackDuration, eventId, batchID string, tracker *batch_tracker.BatchTracker) {
 	if len(statuses) == 1 && util.IsStringEmpty(string(statuses[0])) {
 		statuses = []datastore.EventDeliveryStatus{"Retry", "Scheduled", "Processing"}
 	}
@@ -97,16 +100,16 @@ func RetryEventDeliveriesWithTracker(logger log.Logger, db database.Database, ev
 
 			wg.Add(1)
 
-			go processEventDeliveryBatch(ctx, s, eventDeliveryRepo, deliveryChan, q, &wg, batchID, tracker, logger)
+			go processEventDeliveryBatch(ctx, projectID, s, eventDeliveryRepo, deliveryChan, q, &wg, batchID, tracker, logger)
 
-			counter, err := eventDeliveryRepo.CountDeliveriesByStatus(ctx, "", s, searchParams)
+			counter, err := eventDeliveryRepo.CountDeliveriesByStatus(ctx, projectID, s, searchParams)
 			if err != nil {
 				logger.Error("Failed to count event deliveries")
 			}
 			logger.Info(fmt.Sprintf("Total number of event deliveries to requeue is %d", counter))
 
 			for {
-				deliveries, pagination, err := eventDeliveryRepo.LoadEventDeliveriesPaged(ctx, "", []string{}, eventId, "", []datastore.EventDeliveryStatus{s}, searchParams, pageable, "", "", "")
+				deliveries, pagination, err := eventDeliveryRepo.LoadEventDeliveriesPaged(ctx, projectID, []string{}, eventId, "", []datastore.EventDeliveryStatus{s}, searchParams, pageable, "", "", "")
 				if err != nil {
 					logger.Error(fmt.Sprintf("successfully fetched %d event deliveries but with error: %v", count, err))
 					close(deliveryChan)
@@ -146,7 +149,7 @@ func RetryEventDeliveriesWithTracker(logger log.Logger, db database.Database, ev
 	}
 }
 
-func processEventDeliveryBatch(ctx context.Context, s datastore.EventDeliveryStatus, edRepo datastore.EventDeliveryRepository, deliveryChan <-chan []datastore.EventDelivery, q *redisqueue.RedisQueue, wg *sync.WaitGroup, batchID string, t *batch_tracker.BatchTracker, l log.Logger) {
+func processEventDeliveryBatch(ctx context.Context, projectID string, s datastore.EventDeliveryStatus, edRepo datastore.EventDeliveryRepository, deliveryChan <-chan []datastore.EventDelivery, q *redisqueue.RedisQueue, wg *sync.WaitGroup, batchID string, t *batch_tracker.BatchTracker, l log.Logger) {
 	defer wg.Done()
 
 	batchCount := 1
@@ -166,7 +169,7 @@ func processEventDeliveryBatch(ctx context.Context, s datastore.EventDeliverySta
 		}
 
 		if s == datastore.ProcessingEventStatus {
-			err := edRepo.UpdateStatusOfEventDeliveries(ctx, "", batchIDs, datastore.ScheduledEventStatus)
+			err := edRepo.UpdateStatusOfEventDeliveries(ctx, projectID, batchIDs, datastore.ScheduledEventStatus)
 			if err != nil {
 				l.Error(fmt.Sprintf("batch %d: failed to update event deliveries status: %v", batchCount, err))
 			}


### PR DESCRIPTION
## Summary

Hardens several paths flagged in a recent security review:

- **Ingest fail-closed on unknown verifier types** (fixes #2656): a source with an unknown/stale verifier type now gets a 400 instead of silently falling back to the noop verifier. Explicit `noop` remains supported, and sources persisted without a verifier row are canonicalized to `noop` by the sources read layer, so existing no-verifier sources keep working.
- **Twitter verifier panic guard**: `getSignature` no longer indexes past the end of a malformed `X-Twitter-Webhooks-Signature` header (was a panic per request); malformed headers now reject via `ErrSignatureCannotBeEmpty`, mirroring the GitHub verifier.
- **`convoy retry` project scoping**: the CLI now requires `--project-id` or an explicit `--all-projects` flag before requeuing, and the project scope is plumbed through the retry task's count/load/update queries. The instance-admin HTTP endpoint keeps its intentional instance-wide behavior.
- **Bulk onboard worker re-validates endpoint URLs**: the queue payload is a trust boundary, so the worker re-applies the API layer's URL rules (valid endpoint template, http/https only, https when the project enforces secure endpoints) before creating endpoints.
- **Billing org update allowlist**: `PUT /ui/billing/organisations/{orgID}` now decodes only `name` and `billing_email` instead of the full billing organisation model, so identity/linkage fields (`external_id`, `license_key`, `host`, `slug`) can no longer be forwarded from a request body. The catalog endpoints' (config/plans/tax_id_types) any-authenticated-user exposure is documented as by-design at route registration.

## Test plan

- [x] New ingest integration case: unknown verifier type returns 400; existing noop cases still pass (13/13 in `TestIngestIntegrationTestSuite`)
- [x] New Twitter verifier cases: malformed header without `sha256=` prefix and missing header both reject without panicking
- [x] New `validateOnboardItemURL` table test (https/http/enforced/empty/bad scheme/garbage)
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` on touched packages, `gofmt` clean
- [x] `./api/handlers` and `./pkg/verifier` suites pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches webhook authentication (ingest fail-closed), operational retry blast radius, and billing org updates; changes are intentional security fixes with targeted tests.
> 
> **Overview**
> Security hardening across ingest, retries, bulk onboard, and billing.
> 
> **Ingest** no longer treats unknown verifier types as unverified acceptance: unknown/stale types return **400** instead of falling through to `NoopVerifier`; explicit `noop` and sources canonicalized to noop stay unchanged. **Twitter** signature parsing avoids panics on malformed `sha256=` headers and rejects like other verifiers.
> 
> **`convoy retry`** must pass **`--project-id`** or **`--all-projects`**; `projectID` is threaded through retry count/load/update paths. The instance-admin HTTP retry endpoint still uses empty `projectID` for instance-wide requeue (documented).
> 
> **Bulk onboard** re-validates endpoint URLs from queue payloads via shared **`pkg/url.ValidateEndpointURL`** (API delegates to the same helper; services errors are aliased). **Billing org PUT** decodes only **`name`** and **`billing_email`**, not full org identity fields. Route comments document public billing catalog endpoints.
> 
> Tests cover unknown verifier ingest, Twitter malformed headers, and onboard URL validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd5bc72ee347918d61b53719463dadf901e4d5a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->