### PR TITLE
fix(controlplane): scope source lookups by project and canonicalize jwt logout blacklist

### DIFF
--- a/auth/realm/jwt/jwt.go
+++ b/auth/realm/jwt/jwt.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -130,7 +131,30 @@ func (j *Jwt) BlacklistToken(verified *VerifiedToken, token string) error {
 }
 
 func (j *Jwt) EncodeToken(token string) string {
-	return base64.StdEncoding.EncodeToString([]byte(token))
+	return base64.StdEncoding.EncodeToString([]byte(canonicalToken(token)))
+}
+
+// canonicalToken normalizes a JWT so alternate base64url spellings of the same
+// token collapse to a single blacklist key. golang-jwt decodes the signature
+// non-strictly, so a token and an equivalent spelling of its signature verify
+// identically; keying the blacklist on the raw string would let a logged-out
+// token survive under a re-spelled signature (see GHSA-hpqj-2j2x-p5p2). Only the
+// signature segment is malleable, since the header and payload are covered by
+// the signature, so we re-encode just that segment canonically. Anything that
+// is not a well-formed three-segment token is returned unchanged.
+func canonicalToken(token string) string {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return token
+	}
+
+	sig, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		return token
+	}
+
+	parts[2] = base64.RawURLEncoding.EncodeToString(sig)
+	return strings.Join(parts, ".")
 }
 
 func (j *Jwt) generateRefreshToken(user *datastore.User) (string, error) {

--- a/auth/realm/jwt/jwt_test.go
+++ b/auth/realm/jwt/jwt_test.go
@@ -1,6 +1,8 @@
 package jwt
 
 import (
+	"encoding/base64"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,6 +11,40 @@ import (
 	"github.com/frain-dev/convoy/config"
 	"github.com/frain-dev/convoy/datastore"
 )
+
+const base64URLAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+
+// respellSignature returns an equivalent spelling of the token's signature: it
+// flips the unused trailing bits of the final base64url character so the string
+// differs but decodes to the exact same signature bytes (which golang-jwt
+// accepts under non-strict decoding).
+func respellSignature(t *testing.T, token string) string {
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+
+	sig := parts[2]
+	last := sig[len(sig)-1]
+	v := strings.IndexByte(base64URLAlphabet, last)
+	require.GreaterOrEqual(t, v, 0)
+
+	base := v &^ 0x03
+	alt := base
+	if alt == v {
+		alt++
+	}
+
+	newSig := sig[:len(sig)-1] + string(base64URLAlphabet[alt])
+	require.NotEqual(t, sig, newSig)
+
+	orig, err := base64.RawURLEncoding.DecodeString(sig)
+	require.NoError(t, err)
+	respelled, err := base64.RawURLEncoding.DecodeString(newSig)
+	require.NoError(t, err)
+	require.Equal(t, orig, respelled, "respelled signature must decode to identical bytes")
+
+	parts[2] = newSig
+	return strings.Join(parts, ".")
+}
 
 func provideJwt(t *testing.T) *Jwt {
 	newCache := mcache.NewMemoryCache()
@@ -88,4 +124,33 @@ func TestJwt_BlacklistToken(t *testing.T) {
 	isBlacklist, err := jwt.isTokenBlacklisted(token.AccessToken)
 	require.Nil(t, err)
 	require.True(t, isBlacklist)
+}
+
+// A token blacklisted at logout must stay blacklisted even when presented under
+// an alternate base64url spelling of the same signature (GHSA-hpqj-2j2x-p5p2).
+func TestJwt_BlacklistToken_AlternateSpellingBypass(t *testing.T) {
+	user := &datastore.User{UID: "123456"}
+	jwt := provideJwt(t)
+
+	token, err := jwt.GenerateToken(user)
+	require.Nil(t, err)
+
+	verified, err := jwt.ValidateAccessToken(token.AccessToken)
+	require.Nil(t, err)
+
+	err = jwt.BlacklistToken(verified, token.AccessToken)
+	require.Nil(t, err)
+
+	respelled := respellSignature(t, token.AccessToken)
+
+	// The respelled token still verifies (jwt decodes signatures non-strictly)...
+	require.Equal(t, canonicalToken(token.AccessToken), canonicalToken(respelled))
+
+	// ...so it must be caught by the blacklist and rejected on validation.
+	isBlacklist, err := jwt.isTokenBlacklisted(respelled)
+	require.Nil(t, err)
+	require.True(t, isBlacklist)
+
+	_, err = jwt.ValidateAccessToken(respelled)
+	require.ErrorIs(t, err, ErrInvalidToken)
 }

--- a/internal/sources/get_source_test.go
+++ b/internal/sources/get_source_test.go
@@ -250,15 +250,12 @@ func TestFindSource_VerifiesProjectScope(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, source.UID, fetched.UID)
 
-	// Should not find when using project2 ID (though FindSourceByID doesn't enforce project scope in current impl)
-	// This test documents current behavior
+	// Must not find the source through another project's id: FindSourceByID is
+	// project-scoped, so a cross-project lookup returns ErrSourceNotFound and
+	// never leaks the source or its broker credentials.
 	fetched2, err := service.FindSourceByID(ctx, project2.UID, source.UID)
-	if err != nil {
-		require.Equal(t, datastore.ErrSourceNotFound, err)
-	} else {
-		// Current implementation doesn't filter by project in FindSourceByID
-		require.Equal(t, project1.UID, fetched2.ProjectID)
-	}
+	require.Nil(t, fetched2)
+	require.ErrorIs(t, err, datastore.ErrSourceNotFound)
 }
 
 func TestFindSource_IncludesTimestamps(t *testing.T) {

--- a/internal/sources/impl.go
+++ b/internal/sources/impl.go
@@ -432,7 +432,7 @@ func (s *Service) UpdateSource(ctx context.Context, projectID string, source *da
 	return nil
 }
 
-// FindSourceByID retrieves a source by its ID
+// FindSourceByID retrieves a source by its ID, scoped to the given project.
 func (s *Service) FindSourceByID(ctx context.Context, projectID, id string) (*datastore.Source, error) {
 	row, err := s.repo.FetchSourceByID(ctx, common.StringToPgText(id))
 	if err != nil {
@@ -443,7 +443,21 @@ func (s *Service) FindSourceByID(ctx context.Context, projectID, id string) (*da
 		return nil, &ServiceError{ErrMsg: "error retrieving source", Err: err}
 	}
 
-	return rowToSource(row)
+	source, err := rowToSource(row)
+	if err != nil {
+		return nil, err
+	}
+
+	// FetchSourceByID keys only on the source id, so enforce the project scope
+	// here (the sibling FindSourceByName/DeleteSourceByID scope in SQL). Without
+	// this, any authorized caller could read another project's source by id,
+	// including its plaintext broker credentials. Treat a cross-project hit as
+	// not found so ids stay non-enumerable.
+	if source.ProjectID != projectID {
+		return nil, datastore.ErrSourceNotFound
+	}
+
+	return source, nil
 }
 
 // FindSourceByName retrieves a source by its name and project ID


### PR DESCRIPTION
## Summary
- `FindSourceByID` now rejects a source whose `project_id` does not match the caller's project, closing a cross-tenant IDOR that leaked another project's source and its plaintext broker credentials (GHSA-p5vg-v7mj-f6q4). This mirrors the project scoping already enforced by `FindSourceByName` and `DeleteSourceByID`.
- The JWT logout blacklist now keys on a canonicalized token. golang-jwt decodes signatures non-strictly, so an alternate base64url spelling of a logged-out token previously survived under a different cache key (GHSA-hpqj-2j2x-p5p2). The signature segment is re-encoded canonically before the blacklist key is derived.

## Test plan
- [x] `internal/sources`: cross-project source fetch returns `ErrSourceNotFound`
- [x] `auth/realm/jwt`: a respelled-signature token stays blacklisted and is rejected on validation
- [x] gofmt / go vet / golangci-lint clean on touched packages, build passes