### PR TITLE
fix(dataplane): block cloud metadata and link-local targets on default webhook egress

### DIFF
--- a/net/dispatcher.go
+++ b/net/dispatcher.go
@@ -283,7 +283,9 @@ func NewDispatcher(l license.Licenser, ff *fflag.FFlag, options ...DispatcherOpt
 	if ff.CanAccessFeature(fflag.IpRules) && l.IpRules() {
 		d.client.Transport = NewNetJailTransport(netJailTransport, d.detailedTrace.Enabled)
 	} else {
-		d.client.Transport = NewVanillaTransport(d.transport, d.detailedTrace.Enabled)
+		// Default (unlicensed) egress: block cloud metadata / link-local targets
+		// at dial time while still allowing delivery to general private networks.
+		d.client.Transport = NewVanillaTransport(withMetadataGuard(d.transport), d.detailedTrace.Enabled)
 	}
 
 	// Notifications dial user-controlled URLs (e.g. slack_webhook_url), so the
@@ -384,6 +386,99 @@ func blockPrivateNetworks(_, address string, _ syscall.RawConn) error {
 	}
 
 	return nil
+}
+
+// awsIMDSv6 is the fixed IPv6 address of the AWS instance metadata service.
+var awsIMDSv6 = netip.MustParseAddr("fd00:ec2::254")
+
+// nat64WellKnown is the RFC 6052 well-known NAT64 prefix used to embed an IPv4
+// address inside an IPv6 address.
+var nat64WellKnown = netip.MustParsePrefix("64:ff9b::/96")
+
+// blockMetadataEndpoints is the default (unlicensed) webhook egress guard.
+// Unlike blockPrivateNetworks it deliberately does NOT block general private
+// networks: self-hosted deployments legitimately deliver webhooks to RFC1918
+// internal services. It blocks only the cloud instance-metadata / link-local
+// targets that no legitimate webhook needs and that are the SSRF
+// credential-theft vector:
+//   - IPv4 link-local 169.254.0.0/16 (covers 169.254.169.254 and, post-DNS,
+//     metadata.google.internal),
+//   - IPv6 link-local (fe80::/10) and link-local multicast,
+//   - the AWS IMDS IPv6 address fd00:ec2::254,
+//
+// including IPv4-mapped, NAT64 (64:ff9b::/96) and 6to4 (2002::/16) encodings of
+// a link-local IPv4 target. It runs post-DNS with the concrete dial IP, closing
+// the DNS-rebinding window a write-time URL check cannot. Fail-closed: an
+// address that cannot be parsed is rejected. Licensed deployments layer the
+// netjail allow/block rules on top of delivery instead of this baseline.
+func blockMetadataEndpoints(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("ssrf guard: cannot parse dial address %q: %w", address, err)
+	}
+
+	ip, err := netip.ParseAddr(host)
+	if err != nil {
+		return fmt.Errorf("ssrf guard: cannot parse dial ip %q: %w", host, err)
+	}
+
+	if isMetadataOrLinkLocal(ip) {
+		return fmt.Errorf("ssrf guard: blocked connection to metadata/link-local address %s", ip)
+	}
+
+	return nil
+}
+
+// isMetadataOrLinkLocal reports whether ip is a cloud-metadata / link-local
+// target, resolving IPv4-mapped, NAT64 and 6to4 encodings to the embedded IPv4
+// so a wrapped 169.254.x.x target cannot slip past.
+func isMetadataOrLinkLocal(ip netip.Addr) bool {
+	ip = ip.Unmap()
+
+	if ip.Is6() {
+		if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip == awsIMDSv6 {
+			return true
+		}
+		if v4, ok := embeddedV4(ip); ok {
+			ip = v4
+		}
+	}
+
+	return ip.Is4() && (ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast())
+}
+
+// embeddedV4 extracts the IPv4 address embedded in a NAT64 (64:ff9b::/96) or
+// 6to4 (2002::/16) IPv6 address.
+func embeddedV4(ip netip.Addr) (netip.Addr, bool) {
+	b := ip.As16()
+
+	if nat64WellKnown.Contains(ip) {
+		return netip.AddrFrom4([4]byte{b[12], b[13], b[14], b[15]}), true
+	}
+
+	if b[0] == 0x20 && b[1] == 0x02 { // 6to4 2002::/16
+		return netip.AddrFrom4([4]byte{b[2], b[3], b[4], b[5]}), true
+	}
+
+	return netip.Addr{}, false
+}
+
+// withMetadataGuard returns a clone of base whose dialer applies the default
+// webhook egress guard (blockMetadataEndpoints), blocking cloud metadata /
+// link-local targets at connect time while leaving general private-network
+// delivery intact. ForceAttemptHTTP2 is set because installing a custom
+// DialContext otherwise disables HTTP/2 negotiation for TLS targets.
+func withMetadataGuard(base *http.Transport) *http.Transport {
+	t := base.Clone()
+	t.ForceAttemptHTTP2 = true
+	t.DialContext = (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+		ControlContext: func(_ context.Context, network, address string, c syscall.RawConn) error {
+			return blockMetadataEndpoints(network, address, c)
+		},
+	}).DialContext
+	return t
 }
 
 // NewOAuth2Dispatcher builds a dispatcher for OAuth2 token exchange. It mirrors
@@ -582,7 +677,7 @@ func (d *Dispatcher) createClientWithMTLS(mtlsCert *tls.Certificate) *http.Clien
 		return &http.Client{Transport: NewNetJailTransport(netJailTransport, d.detailedTrace.Enabled)}
 	}
 
-	return &http.Client{Transport: NewVanillaTransport(customTransport, d.detailedTrace.Enabled)}
+	return &http.Client{Transport: NewVanillaTransport(withMetadataGuard(customTransport), d.detailedTrace.Enabled)}
 }
 
 // SendWebhookWithMTLS sends a webhook request with optional mTLS client certificate configuration

--- a/net/dispatcher_test.go
+++ b/net/dispatcher_test.go
@@ -1539,6 +1539,81 @@ func TestBlockPrivateNetworks(t *testing.T) {
 	}
 }
 
+func TestBlockMetadataEndpoints(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		blocked bool
+	}{
+		// Metadata / link-local targets: blocked regardless of encoding.
+		{name: "aws/gcp metadata v4", address: "169.254.169.254:80", blocked: true},
+		{name: "link-local v4", address: "169.254.0.1:80", blocked: true},
+		{name: "link-local v6", address: "[fe80::1]:80", blocked: true},
+		{name: "link-local multicast v6", address: "[ff02::1]:80", blocked: true},
+		{name: "aws imds v6", address: "[fd00:ec2::254]:80", blocked: true},
+		{name: "ipv4-mapped metadata", address: "[::ffff:169.254.169.254]:80", blocked: true},
+		{name: "nat64-wrapped metadata", address: "[64:ff9b::a9fe:a9fe]:80", blocked: true},
+		{name: "6to4-wrapped metadata", address: "[2002:a9fe:a9fe::1]:80", blocked: true},
+		{name: "unparseable", address: "not-an-ip:80", blocked: true},
+
+		// General private + public targets: allowed (delivery must keep working).
+		{name: "private 10/8", address: "10.0.0.5:80", blocked: false},
+		{name: "private 192.168", address: "192.168.1.10:8080", blocked: false},
+		{name: "private 172.16", address: "172.16.0.1:80", blocked: false},
+		{name: "ipv6 ula non-metadata", address: "[fd12:3456::1]:80", blocked: false},
+		{name: "public ipv4", address: "1.1.1.1:443", blocked: false},
+		{name: "public ipv6", address: "[2606:4700:4700::1111]:443", blocked: false},
+		{name: "nat64-wrapped public", address: "[64:ff9b::808:808]:80", blocked: false},
+		{name: "6to4-wrapped public", address: "[2002:0808:0808::1]:80", blocked: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := blockMetadataEndpoints("tcp", tc.address, nil)
+			if tc.blocked {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestDeliveryTransport_BlocksMetadataButAllowsPrivate(t *testing.T) {
+	// Unlicensed default delivery client dials the metadata IP: refused.
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	licenser := mocks.NewMockLicenser(ctrl)
+	licenser.EXPECT().IpRules().Return(false).AnyTimes()
+
+	d, err := NewDispatcher(
+		licenser,
+		fflag.NewFFlag([]string{}),
+		LoggerOption(log.New("convoy", log.LevelInfo)),
+	)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodGet, "http://169.254.169.254:80", nil)
+	require.NoError(t, err)
+	_, err = d.client.Do(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ssrf guard")
+
+	// A private RFC1918 target is still allowed to dial (it fails to connect, but
+	// not with an ssrf-guard rejection), so self-hosted internal delivery keeps
+	// working. Bound the dial with a short context so an unreachable host does
+	// not ride the full dialer timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, "http://10.255.255.1:9", nil)
+	require.NoError(t, err)
+	_, err = d.client.Do(req)
+	if err != nil {
+		require.NotContains(t, err.Error(), "ssrf guard")
+	}
+}
+
 func TestNotificationTransport_SSRFGuardBlocksPrivate(t *testing.T) {
 	// No proxy configured, so egress is direct: a user-controlled notification
 	// URL resolving to a private/loopback host is refused at dial time.


### PR DESCRIPTION
## Summary
- Unlicensed webhook delivery (and the endpoint create/update ping, which shares the same client) previously used a vanilla transport with no connect-time IP filtering, so an endpoint URL resolving to `169.254.169.254`, `metadata.google.internal`, or the AWS IMDS IPv6 address could reach cloud instance metadata and exfiltrate credentials (GHSA-w5pj-fmvx-pfr8, GHSA-hhw2-xh4x-4p7m, GHSA-fpc9-26gm-q9mq, GHSA-rgm6-4mrj-c94m).
- `withMetadataGuard` installs a post-DNS dial-time `Control` hook (`blockMetadataEndpoints`) on the default delivery and mTLS clients in `net/dispatcher.go`. It blocks the cloud metadata / link-local range only, resolving IPv4-mapped, NAT64 (`64:ff9b::/96`), and 6to4 (`2002::/16`) encodings so a wrapped `169.254.x` target cannot slip past, and fails closed on unparseable addresses. Running post-DNS also closes the DNS-rebinding window a write-time URL check cannot.

## Scope (deliberate)
- This is the default (unlicensed) egress floor. General RFC1918 private delivery stays working so self-hosted deployments can still deliver to internal services, and licensed deployments continue to layer netjail allow/block rules on top. Notification egress keeps its stricter full-private-block guard unchanged.
- Out of scope by decision (pre-existing classes, not regressions): loopback delivery, non-link-local provider metadata IPs (e.g. Alibaba `100.100.100.200`), and proxy-mediated fetches.

## Test plan
- [x] Metadata / link-local blocked across all encodings (IPv4-mapped, NAT64, 6to4)
- [x] RFC1918 and public addresses allowed
- [x] Delivery client rejects a metadata dial while permitting a private one
- [x] gofmt / go vet / golangci-lint clean, full `net/` suite passes