### PR TITLE
chore(deps): make release pipeline create binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,17 +67,6 @@ jobs:
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         name: Set up QEMU
 
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-        name: Setup Python
-        with:
-          python-version: "3.9"
-
-      - name: Install Cloudsmith CLI
-        run: |
-          echo $(pip --version)
-          pip install --upgrade cloudsmith-cli
-          echo $(cloudsmith --version)
-
       - name: Clean git state
         run: |
           git checkout -- api/ui/build/
@@ -100,9 +89,9 @@ jobs:
           version: latest
           args: -f .publisher.yml release --clean --release-notes /tmp/release-notes.md
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           REPO_NAME: ${{ github.repository }}
-          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
 
       - name: Release (Main Snapshot)
         if: ${{ needs.set-release-kind.outputs.release_kind == 'main' }}
@@ -111,6 +100,5 @@ jobs:
           version: latest
           args: -f .publisher.yml release --clean --snapshot --skip=homebrew --skip=nfpm
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           REPO_NAME: ${{ github.repository }}
-          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}

--- a/.publisher.yml
+++ b/.publisher.yml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: convoy
 
 before:
@@ -56,35 +58,11 @@ nfpms:
     formats:
       - rpm
 
-# https://goreleaser.com/customization/publishers/
-publishers:
-  - name: cloudsmith-raw
-    ids:
-      - cobin-archive
-    dir: "{{ dir .ArtifactPath }}"
-    cmd: cloudsmith push raw --version={{ .Version }} convoy/convoy {{ .ArtifactName }}
-    env:
-      - CLOUDSMITH_API_KEY={{ .Env.CLOUDSMITH_API_KEY }}
-
-  - name: cloudsmith-deb
-    ids:
-      - deb
-    dir: "{{ dir .ArtifactPath }}"
-    cmd: cloudsmith push deb convoy/convoy/any-distro/any-version {{ .ArtifactName }}
-    env:
-      - CLOUDSMITH_API_KEY={{ .Env.CLOUDSMITH_API_KEY }}
-
-  - name: cloudsmith-rpm
-    ids:
-      - rpm
-    dir: "{{ dir .ArtifactPath }}"
-    cmd: cloudsmith push rpm convoy/convoy/any-distro/any-version {{ .ArtifactName }}
-    env:
-      - CLOUDSMITH_API_KEY={{ .Env.CLOUDSMITH_API_KEY }}
-
 # https://goreleaser.com/customization/homebrew/
 brews:
   - name: convoy
+    ids:
+      - cobin-archive
     homepage: https://getconvoy.io/
     description: A fast & secure open source webhooks service
     license: MPL-2.0
@@ -95,14 +73,13 @@ brews:
     repository:
       owner: frain-dev
       name: homebrew-tools
-    url_template: https://dl.cloudsmith.io/public/convoy/convoy/raw/versions/{{.Version}}/{{ .ArtifactName }}
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    url_template: https://github.com/frain-dev/convoy/releases/download/{{ .Tag }}/{{ .ArtifactName }}
 
 checksum:
   name_template: "{{ .ProjectName}}_checksums.txt"
 
 release:
-  ids:
-    - lib
   github:
     owner: frain-dev
     name: Convoy

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -85,9 +85,14 @@ Then release with `git tag-release`.
 
 Once a tag is created, the release process through Github actions will take care of the rest.
 
-TODO: A missing step here which should be later automated. A release needs to be created before the assets can be uploaded to match the tag. :)
+Wait for the tag workflows to finish. GoReleaser creates and publishes the
+GitHub Release, uploads binary archives, Linux packages, and checksums, publishes
+the Homebrew formula to `frain-dev/homebrew-tools`, and the container release
+workflow publishes the tagged images separately.
 
-Finally, wait for the build step for the tag to finish. The point here is to wait for tarballs to be uploaded to the Github release and the container images to be pushed to the Docker Hub and Quay.io. Once that has happened, click _Publish release_, which will make the release publicly visible and create a GitHub notification.
+The repository must define `HOMEBREW_TAP_TOKEN` with contents write access to
+`frain-dev/homebrew-tools`. The GitHub Release itself uses the workflow's
+repository-scoped `GITHUB_TOKEN`.
 
 ## Release Manager
 The release manager is the individual responsible for the release. The following are the responsibilities of the release manager: 

--- a/docs/monthly-release-workflow.md
+++ b/docs/monthly-release-workflow.md
@@ -47,7 +47,13 @@ release PR merged
 
 tag pushed
              |
-             +-----> existing release workflow builds binaries for v26.3.0
+             +-----> release workflow builds binaries for v26.3.0
+                     |
+                     +-----> publish archives, packages, and checksums
+                     |       to the GitHub Release
+                     |
+                     +-----> update frain-dev/homebrew-tools
+                             with GitHub Release archive URLs
 ```
 
 ## Patch Promotion Decision Tree


### PR DESCRIPTION
```
change updates the release pipeline to build and publish binaries.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production binaries and Homebrew formulas are published; misconfigured `HOMEBREW_TAP_TOKEN` or token permissions could break releases or leave install paths stale.
> 
> **Overview**
> Shifts binary distribution from **Cloudsmith** to **GitHub Releases** and updates how releases are automated end-to-end.
> 
> The **release workflow** drops Python/Cloudsmith CLI setup and `CLOUDSMITH_API_KEY`, switches `GITHUB_TOKEN` from `secrets.RELEASE_TOKEN` to the workflow `github.token`, and passes **`HOMEBREW_TAP_TOKEN`** into GoReleaser for tap updates.
> 
> **`.publisher.yml`** is bumped to **GoReleaser v2**, removes all Cloudsmith `publishers`, wires Homebrew to **`cobin-archive`** with download URLs from `github.com/frain-dev/convoy/releases`, and simplifies the `release` block (no `lib` release id).
> 
> **`RELEASE.md`** and **`docs/monthly-release-workflow.md`** describe the new flow: GoReleaser creates/publishes the GitHub Release (archives, deb/rpm, checksums), updates `frain-dev/homebrew-tools`, and documents the required `HOMEBREW_TAP_TOKEN` secret—replacing the old manual “publish release” / Cloudsmith steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b63b4ac5bbc8458a7b89f24e2607f9aea1a84c39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->