### PR TITLE
fix(release): open homebrew tap PR instead of direct commit

### DIFF
--- a/.publisher.yml
+++ b/.publisher.yml
@@ -74,6 +74,11 @@ brews:
       owner: frain-dev
       name: homebrew-tools
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+      branch: "convoy-{{ .Version }}"
+      pull_request:
+        enabled: true
+        base:
+          branch: main
     url_template: https://github.com/frain-dev/convoy/releases/download/{{ .Tag }}/{{ .ArtifactName }}
 
 checksum:


### PR DESCRIPTION
## Summary
- The release pipeline published `v26.6.7` binaries successfully, but the final Homebrew step failed: goreleaser commits `convoy.rb` directly to `frain-dev/homebrew-tools`, whose `main` branch is protected and requires pull requests (`409 Could not update file: Changes must be made through a pull request`).
- This enables `pull_request` mode on the `brews` block so goreleaser pushes the formula to a per-version branch (`convoy-<version>`) and opens a PR against the tap's `main`, satisfying branch protection.

## Test plan
- [ ] Next tagged release opens a formula PR on `frain-dev/homebrew-tools` instead of failing on a direct push.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only Goreleaser config; no runtime app code, with low blast radius beyond how the Homebrew formula lands on the tap.
> 
> **Overview**
> Fixes failed tagged releases where Goreleaser could not push `convoy.rb` to `frain-dev/homebrew-tools` because **`main` is branch-protected** (409: changes must go through a PR).
> 
> The **`brews`** block in `.publisher.yml` now pushes each formula update to **`convoy-{{ .Version }}`** and **opens a PR into `main`** instead of committing directly. Tagged release workflow behavior is unchanged aside from this Homebrew publish path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0480412e1aa3289efb72a327842593f99a69fdf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->