### PR TITLE
fix(controlplane): swap transactional email header logo

### DIFF
--- a/internal/email/templates/endpoint.update.html
+++ b/internal/email/templates/endpoint.update.html
@@ -100,7 +100,7 @@
 <div class="wrapper">
     <div class="container">
         <div class="header">
-            <img src="https://res.cloudinary.com/frain/image/upload/v1639505046/logos/Convoy/Logo-Name-Inline-Transparent_cep9uj.png"
+            <img src="https://res.cloudinary.com/elo9deig/image/upload/f_png,q_auto/blue_kjg9j7"
                  alt="Convoy Logo" style="height: 36px; display: inline-block;">
         </div>
 

--- a/internal/email/templates/organisation.invite.html
+++ b/internal/email/templates/organisation.invite.html
@@ -109,7 +109,7 @@
     <table class="email-header" width="100%" cellpadding="0" cellspacing="0" role="presentation">
         <tr>
             <td class="email-header" style="padding: 24px 40px; background-color: #ffffff;">
-                <img src="https://res.cloudinary.com/frain/image/upload/v1639505046/logos/Convoy/Logo-Name-Inline-Transparent_cep9uj.png"
+                <img src="https://res.cloudinary.com/elo9deig/image/upload/f_png,q_auto/blue_kjg9j7"
                      alt="Convoy logo" style="height: 36px; display: block;">
             </td>
         </tr>

--- a/internal/email/templates/reset.password.html
+++ b/internal/email/templates/reset.password.html
@@ -102,7 +102,7 @@
     <table class="container" width="100%" cellpadding="0" cellspacing="0" role="presentation">
         <tr>
             <td class="email-header" style="padding: 30px 40px 60px 40px; background-color: #ffffff;">
-                <img src="https://res.cloudinary.com/frain/image/upload/v1639505046/logos/Convoy/Logo-Name-Inline-Transparent_cep9uj.png"
+                <img src="https://res.cloudinary.com/elo9deig/image/upload/f_png,q_auto/blue_kjg9j7"
                      alt="Convoy logo" style="height: 36px; display: block;">
             </td>
         </tr>

--- a/internal/email/templates/user.verify.email.html
+++ b/internal/email/templates/user.verify.email.html
@@ -58,7 +58,7 @@
     <table role="presentation" style="width: 100%; border: none; border-spacing: 0; background-color: #ffffff;">
         <tr>
             <td class="email-header" style="padding: 24px 40px; background-color: #ffffff;">
-                <img src="https://res.cloudinary.com/frain/image/upload/v1639505046/logos/Convoy/Logo-Name-Inline-Transparent_cep9uj.png"
+                <img src="https://res.cloudinary.com/elo9deig/image/upload/f_png,q_auto/blue_kjg9j7"
                      alt="Convoy logo" style="height: 36px; display: block;">
             </td>
         </tr>


### PR DESCRIPTION
## Summary
- Swap the transactional email header logo to the new hosted blue wordmark PNG.
- Uses `f_png` so email clients get a stable PNG without Accept negotiation.

## Test plan
- [ ] Open verify / invite / reset password email HTML and confirm the new logo loads
- [ ] Confirm the Cloudinary URL returns PNG 200