### PR TITLE
fix(release): dispatch tag-triggered workflows after bot tag pushes

### DIFF
--- a/.github/workflows/promote-patch-release.yml
+++ b/.github/workflows/promote-patch-release.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   promote-patch-release:
@@ -47,5 +48,21 @@ jobs:
           echo "Next cutoff gate: ${{ steps.plan.outputs.next_cutoff_tag }} (${{ steps.validate.outputs.next_cutoff_sha }})"
 
       - name: Create and push patch tag
+        id: tag
         run: |
           ./scripts/tag-release.sh "${{ steps.plan.outputs.version }}" "${{ inputs.commit_sha }}"
+
+      # Tag pushes made with GITHUB_TOKEN do not fire `on: push: tags`
+      # workflows, so dispatch the tag-triggered workflows explicitly.
+      # Keep this list in sync with workflows that declare `tags: [v*]`.
+      # Gated on the tag actually being created so re-runs cannot re-publish
+      # an existing tag; to heal a tag with missing artifacts, dispatch
+      # build-image.yml / release.yml directly on the tag ref.
+      - name: Trigger release workflows for the tag
+        if: ${{ steps.tag.outputs.created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="v${{ steps.plan.outputs.version }}"
+          gh workflow run build-image.yml --repo "${GITHUB_REPOSITORY}" --ref "${TAG}" -f name="publish ${TAG} docker images"
+          gh workflow run release.yml --repo "${GITHUB_REPOSITORY}" --ref "${TAG}" -f name="publish ${TAG} binaries"

--- a/.github/workflows/tag-stable-release.yml
+++ b/.github/workflows/tag-stable-release.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag-release:
@@ -33,5 +34,21 @@ jobs:
           echo "Target SHA: ${{ inputs.target_sha }}"
 
       - name: Create and push tag
+        id: tag
         run: |
           ./scripts/tag-release.sh "${{ inputs.version }}" "${{ inputs.target_sha }}"
+
+      # Tag pushes made with GITHUB_TOKEN do not fire `on: push: tags`
+      # workflows, so dispatch the tag-triggered workflows explicitly.
+      # Keep this list in sync with workflows that declare `tags: [v*]`.
+      # Gated on the tag actually being created so re-runs cannot re-publish
+      # an existing tag; to heal a tag with missing artifacts, dispatch
+      # build-image.yml / release.yml directly on the tag ref.
+      - name: Trigger release workflows for the tag
+        if: ${{ steps.tag.outputs.created == 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="v${{ inputs.version }}"
+          gh workflow run build-image.yml --repo "${GITHUB_REPOSITORY}" --ref "${TAG}" -f name="publish ${TAG} docker images"
+          gh workflow run release.yml --repo "${GITHUB_REPOSITORY}" --ref "${TAG}" -f name="publish ${TAG} binaries"

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -25,6 +25,9 @@ fi
 
 if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
   echo "Tag ${TAG} already exists; exiting."
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "created=false" >>"${GITHUB_OUTPUT}"
+  fi
   exit 0
 fi
 
@@ -36,3 +39,7 @@ export GIT_COMMITTER_EMAIL="${GIT_COMMITTER_EMAIL:-${GIT_AUTHOR_EMAIL}}"
 
 git tag -a "${TAG}" "${TARGET_SHA}" -m "Release ${TAG}"
 git push origin "${TAG}"
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "created=true" >>"${GITHUB_OUTPUT}"
+fi


### PR DESCRIPTION
## Summary

- Tags pushed with `GITHUB_TOKEN` do not fire `on: push: tags` workflows (GitHub anti-recursion), so `promote-patch-release` and `tag-stable-release` produced GitHub releases with no Docker images or Go binaries. v26.6.7 and v26.6.8 shipped without Docker Hub images until they were dispatched manually.
- Both tagging workflows now dispatch `build-image.yml` and `release.yml` explicitly on the new tag ref after pushing it (`actions: write` added for `gh workflow run`).
- `scripts/tag-release.sh` reports `created=true/false` via `GITHUB_OUTPUT`, and the dispatch step gates on it, so re-running a tagging workflow for an existing tag cannot re-publish. Healing a tag with missing artifacts stays a direct dispatch of the affected workflow on the tag ref.

## Test plan

- [x] `actionlint` and `shellcheck` clean on the touched files
- [x] Manual dispatch of `build-image.yml` on `v26.6.8` / `v26.6.7` refs (same mechanism the workflows now use) publishes the versioned images
- [ ] Verify on the next patch promotion that images and binaries appear without manual dispatch