### PR TITLE
feat(dataplane): custom user-agent replaces convoy branding header

### DIFF
--- a/internal/pkg/license/features.go
+++ b/internal/pkg/license/features.go
@@ -32,6 +32,7 @@ var featureKeys = []struct {
 	{"oauth2_endpoint_auth", "OAuth2EndpointAuth"},
 	{"basic_auth_endpoint_auth", "BasicAuthEndpointAuth"},
 	{"endpoint_url_templates", "EndpointURLTemplates"},
+	{"custom_user_agent", "CustomUserAgent"},
 	{"use_forward_proxy", "UseForwardProxy"},
 	{"asynq_monitoring", "AsynqMonitoring"},
 	{"agent_execution_mode", "AgentExecutionMode"},

--- a/internal/pkg/license/license.go
+++ b/internal/pkg/license/license.go
@@ -42,6 +42,7 @@ type Licenser interface {
 	OAuth2EndpointAuth() bool
 	BasicAuthEndpointAuth() bool
 	EndpointURLTemplates() bool
+	CustomUserAgent() bool
 	FeatureListJSON(ctx context.Context) (json.RawMessage, error)
 
 	RemoveEnabledProject(projectID string)

--- a/internal/pkg/license/noop/noop.go
+++ b/internal/pkg/license/noop/noop.go
@@ -82,6 +82,10 @@ func (Licenser) EndpointURLTemplates() bool {
 	return true
 }
 
+func (Licenser) CustomUserAgent() bool {
+	return true
+}
+
 func (Licenser) RemoveEnabledProject(_ string) {}
 
 func (Licenser) ProjectEnabled(_ string) bool {

--- a/internal/pkg/license/service/entitlements.go
+++ b/internal/pkg/license/service/entitlements.go
@@ -111,6 +111,7 @@ var EntitlementKeyMapping = map[string]string{
 	"oauth2_endpoint_auth":         "OAuth2EndpointAuth",
 	"basic_auth_endpoint_auth":     "BasicAuthEndpointAuth",
 	"endpoint_url_templates":       "EndpointURLTemplates",
+	"custom_user_agent":            "CustomUserAgent",
 	"use_forward_proxy":            "UseForwardProxy",
 	"asynq_monitoring":             "AsynqMonitoring",
 	"agent_execution_mode":         "AgentExecutionMode",

--- a/internal/pkg/license/service/licenser.go
+++ b/internal/pkg/license/service/licenser.go
@@ -620,6 +620,10 @@ func (l *Licenser) EndpointURLTemplates() bool {
 	return l.hasFeature("endpoint_url_templates")
 }
 
+func (l *Licenser) CustomUserAgent() bool {
+	return l.hasFeature("custom_user_agent")
+}
+
 func (l *Licenser) FeatureListJSON(ctx context.Context) (json.RawMessage, error) {
 	if err := l.ensureValidCache(ctx); err != nil {
 		return nil, err
@@ -721,6 +725,7 @@ func (l *Licenser) FeatureListJSON(ctx context.Context) (json.RawMessage, error)
 	featureList["OAuth2EndpointAuth"] = l.OAuth2EndpointAuth()
 	featureList["BasicAuthEndpointAuth"] = l.BasicAuthEndpointAuth()
 	featureList["EndpointURLTemplates"] = l.EndpointURLTemplates()
+	featureList["CustomUserAgent"] = l.CustomUserAgent()
 	featureList["UseForwardProxy"] = l.UseForwardProxy()
 	featureList["AsynqMonitoring"] = l.AsynqMonitoring()
 	featureList["AgentExecutionMode"] = l.AgentExecutionMode()

--- a/mocks/license.go
+++ b/mocks/license.go
@@ -280,6 +280,20 @@ func (mr *MockLicenserMockRecorder) EndpointURLTemplates() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EndpointURLTemplates", reflect.TypeOf((*MockLicenser)(nil).EndpointURLTemplates))
 }
 
+// CustomUserAgent mocks base method.
+func (m *MockLicenser) CustomUserAgent() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CustomUserAgent")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// CustomUserAgent indicates an expected call of CustomUserAgent.
+func (mr *MockLicenserMockRecorder) CustomUserAgent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CustomUserAgent", reflect.TypeOf((*MockLicenser)(nil).CustomUserAgent))
+}
+
 // EnterpriseSSO mocks base method.
 func (m *MockLicenser) EnterpriseSSO() bool {
 	m.ctrl.T.Helper()

--- a/net/dispatcher.go
+++ b/net/dispatcher.go
@@ -770,19 +770,31 @@ func deleteHeaderCaseInsensitive(header httpheader.HTTPHeader, key string) {
 }
 
 // ensureUserAgent sets Convoy/<version> only when no non-empty User-Agent is present.
-// A configured User-Agent fully replaces the default branding header.
+// A configured User-Agent fully replaces the default branding header and is always
+// stored under the canonical "User-Agent" key. custom_headers may preserve caller
+// casing (e.g. "user-agent"); Go's request writer only treats the canonical key as
+// the special User-Agent path, so leaving a non-canonical key can emit both Go's
+// default agent and the custom value.
 // Empty values ("" / whitespace) do not count as a custom agent.
 func ensureUserAgent(header httpheader.HTTPHeader) {
+	var custom string
 	for k, vals := range header {
 		if !strings.EqualFold(k, "User-Agent") {
 			continue
 		}
-		for _, v := range vals {
-			if strings.TrimSpace(v) != "" {
-				return
+		if custom == "" {
+			for _, v := range vals {
+				if strings.TrimSpace(v) != "" {
+					custom = v
+					break
+				}
 			}
 		}
 		delete(header, k)
+	}
+	if custom != "" {
+		header["User-Agent"] = []string{custom}
+		return
 	}
 	header["User-Agent"] = []string{defaultUserAgent()}
 }

--- a/net/dispatcher.go
+++ b/net/dispatcher.go
@@ -732,10 +732,10 @@ func (d *Dispatcher) sendWebhookInternal(ctx context.Context, endpoint string, j
 	req.Header.Set(signatureHeader, hmac)
 	req.Header.Add("Content-Type", converter.ContentType())
 	req.Header.Set("Accept-Encoding", "gzip")
-	req.Header.Add("User-Agent", defaultUserAgent())
 
 	header := httpheader.HTTPHeader(req.Header)
 	header.MergeHeaders(headers)
+	ensureUserAgent(header)
 	if isCustomRequestIDHeader(requestIDHeader) && len(idempotencyKey) == 0 {
 		err := ErrMissingIdempotencyKeyForCustomRequestIDHeader
 		d.logger.Error("Dispatcher invalid arguments", "error", err)
@@ -767,6 +767,24 @@ func deleteHeaderCaseInsensitive(header httpheader.HTTPHeader, key string) {
 			delete(header, k)
 		}
 	}
+}
+
+// ensureUserAgent sets Convoy/<version> only when no non-empty User-Agent is present.
+// A configured User-Agent fully replaces the default branding header.
+// Empty values ("" / whitespace) do not count as a custom agent.
+func ensureUserAgent(header httpheader.HTTPHeader) {
+	for k, vals := range header {
+		if !strings.EqualFold(k, "User-Agent") {
+			continue
+		}
+		for _, v := range vals {
+			if strings.TrimSpace(v) != "" {
+				return
+			}
+		}
+		delete(header, k)
+	}
+	header["User-Agent"] = []string{defaultUserAgent()}
 }
 
 func isCustomRequestIDHeader(requestIDHeader string) bool {

--- a/net/dispatcher_test.go
+++ b/net/dispatcher_test.go
@@ -588,6 +588,54 @@ func TestDispatcher_SendRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "should_canonicalize_lowercase_user_agent_key",
+			args: args{
+				endpoint: "https://google.com",
+				method:   http.MethodPost,
+				jsonData: bytes.NewBufferString("testing").Bytes(),
+				headers: map[string][]string{
+					"user-agent": {"PartnerBot/1"},
+				},
+				project: &datastore.Project{
+					UID: "12345",
+					Config: &datastore.ProjectConfig{
+						Signature: &datastore.SignatureConfiguration{
+							Header: configSignature,
+						},
+						ReplayAttacks: false,
+					},
+				},
+				hmac: "12345",
+			},
+			want: &Response{
+				Status:     "200",
+				StatusCode: http.StatusOK,
+				Method:     http.MethodPost,
+				URL:        nil,
+				RequestHeader: http.Header{
+					"Accept-Encoding":                      []string{"gzip"},
+					"Content-Type":                         []string{constants.ContentTypeJSON},
+					"User-Agent":                           []string{"PartnerBot/1"},
+					config.DefaultSignatureHeader.String(): []string{"12345"},
+				},
+				ResponseHeader: nil,
+				Body:           successBody,
+				IP:             "",
+				Error:          "",
+			},
+			nFn: func() func() {
+				httpmock.Activate()
+
+				httpmock.RegisterResponder(http.MethodPost, "https://google.com",
+					httpmock.NewStringResponder(http.StatusOK, string(successBody)))
+
+				return func() {
+					httpmock.DeactivateAndReset()
+				}
+			},
+			wantErr: false,
+		},
+		{
 			name: "should_use_default_user_agent_when_custom_is_empty",
 			args: args{
 				endpoint: "https://google.com",

--- a/net/dispatcher_test.go
+++ b/net/dispatcher_test.go
@@ -540,6 +540,102 @@ func TestDispatcher_SendRequest(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "should_replace_default_user_agent_when_custom_is_set",
+			args: args{
+				endpoint: "https://google.com",
+				method:   http.MethodPost,
+				jsonData: bytes.NewBufferString("testing").Bytes(),
+				headers: map[string][]string{
+					"User-Agent": {"PartnerBot/1"},
+				},
+				project: &datastore.Project{
+					UID: "12345",
+					Config: &datastore.ProjectConfig{
+						Signature: &datastore.SignatureConfiguration{
+							Header: configSignature,
+						},
+						ReplayAttacks: false,
+					},
+				},
+				hmac: "12345",
+			},
+			want: &Response{
+				Status:     "200",
+				StatusCode: http.StatusOK,
+				Method:     http.MethodPost,
+				URL:        nil,
+				RequestHeader: http.Header{
+					"Accept-Encoding":                      []string{"gzip"},
+					"Content-Type":                         []string{constants.ContentTypeJSON},
+					"User-Agent":                           []string{"PartnerBot/1"},
+					config.DefaultSignatureHeader.String(): []string{"12345"},
+				},
+				ResponseHeader: nil,
+				Body:           successBody,
+				IP:             "",
+				Error:          "",
+			},
+			nFn: func() func() {
+				httpmock.Activate()
+
+				httpmock.RegisterResponder(http.MethodPost, "https://google.com",
+					httpmock.NewStringResponder(http.StatusOK, string(successBody)))
+
+				return func() {
+					httpmock.DeactivateAndReset()
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "should_use_default_user_agent_when_custom_is_empty",
+			args: args{
+				endpoint: "https://google.com",
+				method:   http.MethodPost,
+				jsonData: bytes.NewBufferString("testing").Bytes(),
+				headers: map[string][]string{
+					"User-Agent": {"  "},
+				},
+				project: &datastore.Project{
+					UID: "12345",
+					Config: &datastore.ProjectConfig{
+						Signature: &datastore.SignatureConfiguration{
+							Header: configSignature,
+						},
+						ReplayAttacks: false,
+					},
+				},
+				hmac: "12345",
+			},
+			want: &Response{
+				Status:     "200",
+				StatusCode: http.StatusOK,
+				Method:     http.MethodPost,
+				URL:        nil,
+				RequestHeader: http.Header{
+					"Accept-Encoding":                      []string{"gzip"},
+					"Content-Type":                         []string{constants.ContentTypeJSON},
+					"User-Agent":                           []string{defaultUserAgent()},
+					config.DefaultSignatureHeader.String(): []string{"12345"},
+				},
+				ResponseHeader: nil,
+				Body:           successBody,
+				IP:             "",
+				Error:          "",
+			},
+			nFn: func() func() {
+				httpmock.Activate()
+
+				httpmock.RegisterResponder(http.MethodPost, "https://google.com",
+					httpmock.NewStringResponder(http.StatusOK, string(successBody)))
+
+				return func() {
+					httpmock.DeactivateAndReset()
+				}
+			},
+			wantErr: false,
+		},
+		{
 			name: "should_cut_down_oversized_response_body",
 			args: args{
 				endpoint: "https://google.com",

--- a/worker/task/outbound_headers.go
+++ b/worker/task/outbound_headers.go
@@ -1,0 +1,30 @@
+package task
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/frain-dev/convoy/pkg/httpheader"
+)
+
+// prepareOutboundHeaders returns headers for webhook dispatch.
+// Failure policy: fail closed to Convoy branding when custom_user_agent is off —
+// strip any User-Agent so the dispatcher fills Convoy/<version>. Does not mutate
+// the stored delivery headers.
+//
+// customUserAgentAllowed comes from the instance Licenser (same pattern as
+// MutualTLS / EndpointURLTemplates). Cloud UI may also surface org license_data
+// flags; wire enforcement stays on the instance entitlement.
+func prepareOutboundHeaders(headers httpheader.HTTPHeader, customUserAgentAllowed bool) httpheader.HTTPHeader {
+	if customUserAgentAllowed || headers == nil {
+		return headers
+	}
+
+	out := httpheader.HTTPHeader(http.Header(headers).Clone())
+	for k := range out {
+		if strings.EqualFold(k, "User-Agent") {
+			delete(out, k)
+		}
+	}
+	return out
+}

--- a/worker/task/outbound_headers_test.go
+++ b/worker/task/outbound_headers_test.go
@@ -1,0 +1,40 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/frain-dev/convoy/pkg/httpheader"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareOutboundHeaders_AllowsCustomWhenEntitled(t *testing.T) {
+	headers := httpheader.HTTPHeader{
+		"User-Agent": []string{"PartnerBot/1"},
+		"X-Custom":   []string{"keep"},
+	}
+
+	out := prepareOutboundHeaders(headers, true)
+	require.Equal(t, []string{"PartnerBot/1"}, out["User-Agent"])
+	require.Equal(t, []string{"keep"}, out["X-Custom"])
+}
+
+func TestPrepareOutboundHeaders_StripsCustomWhenNotEntitled(t *testing.T) {
+	headers := httpheader.HTTPHeader{
+		"User-Agent": []string{"PartnerBot/1"},
+		"user-agent": []string{"also-custom"},
+		"X-Custom":   []string{"keep"},
+	}
+
+	out := prepareOutboundHeaders(headers, false)
+	_, hasUA := out["User-Agent"]
+	_, hasLower := out["user-agent"]
+	require.False(t, hasUA)
+	require.False(t, hasLower)
+	require.Equal(t, []string{"keep"}, out["X-Custom"])
+	// Original map must stay intact for stored delivery headers.
+	require.Equal(t, []string{"PartnerBot/1"}, headers["User-Agent"])
+}
+
+func TestPrepareOutboundHeaders_NilPassthrough(t *testing.T) {
+	require.Nil(t, prepareOutboundHeaders(nil, false))
+}

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -381,6 +381,7 @@ func ProcessEventDelivery(deps EventDeliveryProcessorDeps) func(context.Context,
 		// idempotency_key at publish time (any stable value); that value is sent on the
 		// outbound header below.
 		requestSentAt := time.Now()
+		outboundHeaders := prepareOutboundHeaders(eventDelivery.Headers, deps.Licenser.CustomUserAgent())
 		resp, err := deps.Dispatcher.SendWebhookWithMTLS(
 			ctx,
 			targetURL,
@@ -388,7 +389,7 @@ func ProcessEventDelivery(deps EventDeliveryProcessorDeps) func(context.Context,
 			project.Config.Signature.Header.String(),
 			header,
 			int64(cfg.MaxResponseSize),
-			eventDelivery.Headers,
+			outboundHeaders,
 			project.Config.GetRequestIDHeader().String(),
 			eventDelivery.IdempotencyKey,
 			httpDuration,

--- a/worker/task/process_event_delivery_test.go
+++ b/worker/task/process_event_delivery_test.go
@@ -366,6 +366,7 @@ func TestProcessEventDelivery(t *testing.T) {
 				l.EXPECT().UseForwardProxy().Times(1).Return(true)
 				l.EXPECT().IpRules().Times(3).Return(true)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 			},
 			nFn: func() func() {
@@ -457,6 +458,7 @@ func TestProcessEventDelivery(t *testing.T) {
 				l.EXPECT().UseForwardProxy().Times(1).Return(true)
 				l.EXPECT().IpRules().Times(3).Return(true)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 			},
 			nFn: func() func() {
@@ -548,6 +550,7 @@ func TestProcessEventDelivery(t *testing.T) {
 				l.EXPECT().IpRules().Times(3).Return(true)
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 			},
 			nFn: func() func() {
 				httpmock.Activate()
@@ -642,6 +645,7 @@ func TestProcessEventDelivery(t *testing.T) {
 				l.EXPECT().IpRules().Times(3).Return(true)
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 			},
 			nFn: func() func() {
 				httpmock.Activate()
@@ -733,6 +737,7 @@ func TestProcessEventDelivery(t *testing.T) {
 				l.EXPECT().IpRules().Times(3).Return(true)
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 			},
 			nFn: func() func() {
 				httpmock.Activate()
@@ -824,6 +829,7 @@ func TestProcessEventDelivery(t *testing.T) {
 				l.EXPECT().IpRules().Times(3).Return(true)
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(false)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 			},
 			nFn: func() func() {
 				httpmock.Activate()
@@ -920,6 +926,7 @@ func TestProcessEventDelivery(t *testing.T) {
 				l.EXPECT().IpRules().Times(3).Return(true)
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 			},
 			nFn: func() func() {
 				httpmock.Activate()
@@ -1017,6 +1024,7 @@ func TestProcessEventDelivery(t *testing.T) {
 				l.EXPECT().IpRules().Times(3).Return(true)
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 			},
 			nFn: func() func() {
 				httpmock.Activate()
@@ -1271,6 +1279,7 @@ func TestProcessEventDelivery_SyncsAsynqMaxRetryToRetryLimit(t *testing.T) {
 			licenser.EXPECT().UseForwardProxy().Return(true).AnyTimes()
 			licenser.EXPECT().IpRules().Return(true).AnyTimes()
 			licenser.EXPECT().AdvancedEndpointMgmt().Return(false).AnyTimes()
+			licenser.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 			licenser.EXPECT().CircuitBreaking().Return(false).AnyTimes()
 
 			require.NoError(t, config.LoadConfig("./testdata/Config/basic-convoy.json"))
@@ -1461,6 +1470,7 @@ func TestProcessEventDelivery_AttemptTimingReflectsWireDelay(t *testing.T) {
 	licenser.EXPECT().UseForwardProxy().Return(true).AnyTimes()
 	licenser.EXPECT().IpRules().Return(true).AnyTimes()
 	licenser.EXPECT().AdvancedEndpointMgmt().Return(false).AnyTimes()
+	licenser.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 	licenser.EXPECT().CircuitBreaking().Return(false).AnyTimes()
 
 	require.NoError(t, config.LoadConfig("./testdata/Config/basic-convoy.json"))

--- a/worker/task/process_event_delivery_test.go
+++ b/worker/task/process_event_delivery_test.go
@@ -1136,6 +1136,7 @@ func TestProcessEventDelivery(t *testing.T) {
 			attemptsRepo := mocks.NewMockDeliveryAttemptsRepository(ctrl)
 			licenser := mocks.NewMockLicenser(ctrl)
 			licenser.EXPECT().ProjectEnabled(gomock.Any()).Return(true).AnyTimes()
+			licenser.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 			mt := mocks.NewMockBackend(ctrl)
 
 			err := config.LoadConfig(tc.cfgPath)

--- a/worker/task/process_retry_event_delivery.go
+++ b/worker/task/process_retry_event_delivery.go
@@ -301,6 +301,7 @@ func ProcessRetryEventDelivery(deps EventDeliveryProcessorDeps) func(context.Con
 		}
 
 		requestSentAt := time.Now()
+		outboundHeaders := prepareOutboundHeaders(eventDelivery.Headers, deps.Licenser.CustomUserAgent())
 		resp, err := deps.Dispatcher.SendWebhookWithMTLS(
 			ctx,
 			targetURL,
@@ -308,7 +309,7 @@ func ProcessRetryEventDelivery(deps EventDeliveryProcessorDeps) func(context.Con
 			project.Config.Signature.Header.String(),
 			header,
 			int64(cfg.MaxResponseSize),
-			eventDelivery.Headers,
+			outboundHeaders,
 			project.Config.GetRequestIDHeader().String(),
 			eventDelivery.IdempotencyKey,
 			httpDuration,

--- a/worker/task/process_retry_event_delivery_test.go
+++ b/worker/task/process_retry_event_delivery_test.go
@@ -1138,6 +1138,7 @@ func TestProcessRetryEventDelivery(t *testing.T) {
 			attemptsRepo := mocks.NewMockDeliveryAttemptsRepository(ctrl)
 			l := mocks.NewMockLicenser(ctrl)
 			l.EXPECT().ProjectEnabled(gomock.Any()).Return(true).AnyTimes()
+			l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 			mt := mocks.NewMockBackend(ctrl)
 
 			err := config.LoadConfig(tc.cfgPath)

--- a/worker/task/process_retry_event_delivery_test.go
+++ b/worker/task/process_retry_event_delivery_test.go
@@ -276,6 +276,7 @@ func TestProcessRetryEventDelivery(t *testing.T) {
 
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 				l.EXPECT().UseForwardProxy().Times(1).Return(true)
 				l.EXPECT().IpRules().Times(3).Return(true)
 			},
@@ -367,6 +368,7 @@ func TestProcessRetryEventDelivery(t *testing.T) {
 
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 				l.EXPECT().UseForwardProxy().Times(1).Return(true)
 				l.EXPECT().IpRules().Times(3).Return(true)
 			},
@@ -458,6 +460,7 @@ func TestProcessRetryEventDelivery(t *testing.T) {
 
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 				l.EXPECT().UseForwardProxy().Times(1).Return(true)
 				l.EXPECT().IpRules().Times(3).Return(true)
 			},
@@ -550,6 +553,7 @@ func TestProcessRetryEventDelivery(t *testing.T) {
 
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 				l.EXPECT().UseForwardProxy().Times(1).Return(true)
 				l.EXPECT().IpRules().Times(3).Return(true)
 			},
@@ -642,6 +646,7 @@ func TestProcessRetryEventDelivery(t *testing.T) {
 
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 				l.EXPECT().UseForwardProxy().Times(1).Return(true)
 				l.EXPECT().IpRules().Times(3).Return(true)
 			},
@@ -735,6 +740,7 @@ func TestProcessRetryEventDelivery(t *testing.T) {
 
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 				l.EXPECT().UseForwardProxy().Times(1).Return(false)
 				l.EXPECT().IpRules().Times(3).Return(true)
 			},
@@ -825,6 +831,7 @@ func TestProcessRetryEventDelivery(t *testing.T) {
 
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 				l.EXPECT().UseForwardProxy().Times(1).Return(true)
 				l.EXPECT().IpRules().Times(3).Return(true)
 			},
@@ -920,6 +927,7 @@ func TestProcessRetryEventDelivery(t *testing.T) {
 
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 				l.EXPECT().UseForwardProxy().Times(1).Return(true)
 				l.EXPECT().IpRules().Times(3).Return(true)
 			},
@@ -1016,6 +1024,7 @@ func TestProcessRetryEventDelivery(t *testing.T) {
 
 				l.EXPECT().CircuitBreaking().Times(1).Return(false)
 				l.EXPECT().AdvancedEndpointMgmt().Times(1).Return(true)
+				l.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 				l.EXPECT().UseForwardProxy().Times(1).Return(true)
 				l.EXPECT().IpRules().Times(3).Return(true)
 			},
@@ -1330,6 +1339,7 @@ func TestProcessRetryEventDelivery_AttemptTimingReflectsWireDelay(t *testing.T) 
 	licenser.EXPECT().UseForwardProxy().Return(true).AnyTimes()
 	licenser.EXPECT().IpRules().Return(true).AnyTimes()
 	licenser.EXPECT().AdvancedEndpointMgmt().Return(false).AnyTimes()
+	licenser.EXPECT().CustomUserAgent().Return(false).AnyTimes()
 	licenser.EXPECT().CircuitBreaking().Return(false).AnyTimes()
 
 	require.NoError(t, config.LoadConfig("./testdata/Config/basic-convoy.json"))


### PR DESCRIPTION
## Summary
- Adds entitlement `custom_user_agent` so a configured outbound `User-Agent` fully replaces `Convoy/<version>` (single header on the wire).
- Unentitled / community paths strip any custom `User-Agent` before dispatch; dispatcher fills the default branding header.
- Empty / whitespace `User-Agent` values do not count as a custom agent.

## Test plan
- [x] `go test ./net/ ./internal/pkg/license/...`
- [ ] CI `worker/task` (needs Docker; local daemon unavailable)
- [ ] Confirm paid plans grant `custom_user_agent`
- [ ] With entitlement on and a custom UA set, partner sees one User-Agent header

Linear: https://linear.app/convoy-engineering/issue/PDE-967

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes every outbound webhook’s User-Agent handling and license gating on the delivery hot path; behavior is well-tested but partners may see different headers on community vs paid tiers.
> 
> **Overview**
> Introduces the **`custom_user_agent`** license entitlement and wires it through the licenser, feature lists, and mocks like other endpoint features.
> 
> **Outbound webhook behavior:** Event delivery and retry paths call **`prepareOutboundHeaders`**, which strips any `User-Agent` from a cloned header map when the instance is not entitled (stored delivery headers stay unchanged). The dispatcher no longer sets `Convoy/<version>` before merging custom headers; **`ensureUserAgent`** runs after merge so a single canonical `User-Agent` is sent—custom value when entitled and non-empty, otherwise default branding. Whitespace-only values are ignored, and lowercase `user-agent` keys are normalized so Go does not emit duplicate agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fd637b7aaac91e1f4021dfe9d148e11a5f0ff8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->