### PR TITLE
Reduce GC pressure and memory allocations during webhook ingestion

### DIFF
--- a/api/ingest.go
+++ b/api/ingest.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -31,6 +32,15 @@ import (
 	"github.com/frain-dev/convoy/util"
 	"github.com/frain-dev/convoy/worker/task"
 )
+
+const defaultBufferCapacity = 16 * 1024
+const maxBufferCapacity = 64 * 1024
+
+var ingestBufferPool = sync.Pool{
+	New: func() interface{} {
+		return bytes.NewBuffer(make([]byte, 0, defaultBufferCapacity))
+	},
+}
 
 func (a *ApplicationHandler) IngestEvent(w http.ResponseWriter, r *http.Request) {
 	// s.AppService.CountProjectApplications()
@@ -181,12 +191,21 @@ func (a *ApplicationHandler) IngestEvent(w http.ResponseWriter, r *http.Request)
 	// 3.1 On Failure
 	// Return 400 Bad Request.
 	// Read raw body for signature verification first (e.g., GitHub signs raw bytes)
-	rawPayload, err := io.ReadAll(io.LimitReader(r.Body, int64(maxIngestSize)))
+	buf := ingestBufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer func() {
+		if buf.Cap() <= maxBufferCapacity {
+			ingestBufferPool.Put(buf)
+		}
+	}()
+
+	_, err = io.Copy(buf, io.LimitReader(r.Body, int64(maxIngestSize)))
 	if err != nil {
 		a.A.Logger.Error("Failed to read request body", "error", err)
 		_ = render.Render(w, r, util.NewErrorResponse("Invalid request format", http.StatusBadRequest))
 		return
 	}
+	rawPayload := buf.Bytes()
 
 	// Restore body for subsequent reads
 	r.Body = io.NopCloser(bytes.NewReader(rawPayload))
@@ -197,7 +216,7 @@ func (a *ApplicationHandler) IngestEvent(w http.ResponseWriter, r *http.Request)
 	var payload []byte
 	if rawVerifyErr != nil {
 		// Fallback: extract/convert payload (e.g., form -> JSON) and verify against that for backward compatibility
-		payload, err = extractPayloadFromIngestEventReq(r, maxIngestSize)
+		payload, err = extractPayloadFromIngestEventReq(r, rawPayload, maxIngestSize)
 		if err != nil {
 			a.A.Logger.Error("Failed to extract payload", "error", err)
 			_ = render.Render(w, r, util.NewErrorResponse("Invalid request format", http.StatusBadRequest))
@@ -214,7 +233,7 @@ func (a *ApplicationHandler) IngestEvent(w http.ResponseWriter, r *http.Request)
 		}
 	} else {
 		// Raw verification succeeded; now convert for storage
-		payload, err = extractPayloadFromIngestEventReq(r, maxIngestSize)
+		payload, err = extractPayloadFromIngestEventReq(r, rawPayload, maxIngestSize)
 		if err != nil {
 			a.A.Logger.Error("Failed to extract payload", "error", err)
 			_ = render.Render(w, r, util.NewErrorResponse("Invalid request format", http.StatusBadRequest))
@@ -325,7 +344,7 @@ const (
 	urlEncodedContentType        = "application/x-www-form-urlencoded"
 )
 
-func extractPayloadFromIngestEventReq(r *http.Request, maxIngestSize uint64) ([]byte, error) {
+func extractPayloadFromIngestEventReq(r *http.Request, rawPayload []byte, maxIngestSize uint64) ([]byte, error) {
 	var contentType string
 	rawContentType := strings.ToLower(
 		strings.TrimSpace(
@@ -357,7 +376,7 @@ func extractPayloadFromIngestEventReq(r *http.Request, maxIngestSize uint64) ([]
 	default:
 		// To avoid introducing a breaking change, we are keeping the old behaviour of assuming
 		// the content type is JSON if the content type is not specified/unsupported.
-		return io.ReadAll(io.LimitReader(r.Body, int64(maxIngestSize)))
+		return rawPayload, nil
 	}
 }
 

--- a/api/ingest.go
+++ b/api/ingest.go
@@ -199,12 +199,20 @@ func (a *ApplicationHandler) IngestEvent(w http.ResponseWriter, r *http.Request)
 		}
 	}()
 
-	_, err = io.Copy(buf, io.LimitReader(r.Body, int64(maxIngestSize)))
+	n, err := io.Copy(buf, io.LimitReader(r.Body, int64(maxIngestSize)+1))
 	if err != nil {
 		a.A.Logger.Error("Failed to read request body", "error", err)
 		_ = render.Render(w, r, util.NewErrorResponse("Invalid request format", http.StatusBadRequest))
 		return
 	}
+	if n > int64(maxIngestSize) {
+		_ = render.Render(w, r, util.NewErrorResponse("Payload too large", http.StatusRequestEntityTooLarge))
+		return
+	}
+
+	// rawPayload is backed by the pooled buffer's array. It is only valid until this
+	// function returns and the buffer is recycled. Do not let it escape synchronously!
+	// msgpack.EncodeMsgPack performs a deep copy later, making this safe.
 	rawPayload := buf.Bytes()
 
 	// Restore body for subsequent reads

--- a/api/ingest_bench_test.go
+++ b/api/ingest_bench_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func BenchmarkExtractPayloadFromIngestEventReq(b *testing.B) {
+	jsonBody := []byte(`{"event_type": "user.created", "data": {"id": 123, "name": "John Doe"}}`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(jsonBody))
+		req.Header.Set("Content-Type", applicationJsonContentType)
+		rawPayload, _ := io.ReadAll(req.Body)
+		req.Body = io.NopCloser(bytes.NewReader(rawPayload))
+
+		_, err := extractPayloadFromIngestEventReq(req, rawPayload, 1024*1024)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/api/ingest_compare_bench_test.go
+++ b/api/ingest_compare_bench_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+var benchmarkPool = sync.Pool{
+	New: func() interface{} {
+		return bytes.NewBuffer(make([]byte, 0, 16*1024))
+	},
+}
+
+func BenchmarkIngestion(b *testing.B) {
+	// A typical 5KB webhook payload
+	payload := bytes.Repeat([]byte("a"), 5*1024)
+	maxIngestSize := int64(1024 * 1024) // 1MB limit
+
+	b.Run("Before_io.ReadAll", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			r := httptest.NewRequest("POST", "/", bytes.NewReader(payload))
+			raw, err := io.ReadAll(io.LimitReader(r.Body, maxIngestSize))
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = raw
+		}
+	})
+
+	b.Run("After_sync.Pool", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			r := httptest.NewRequest("POST", "/", bytes.NewReader(payload))
+			buf := benchmarkPool.Get().(*bytes.Buffer)
+			buf.Reset()
+			
+			_, err := io.Copy(buf, io.LimitReader(r.Body, maxIngestSize))
+			if err != nil {
+				b.Fatal(err)
+			}
+			raw := buf.Bytes()
+			
+			// Simulate processing, then return to pool
+			if buf.Cap() <= 64*1024 {
+				benchmarkPool.Put(buf)
+			}
+			_ = raw
+		}
+	})
+}

--- a/api/ingest_test.go
+++ b/api/ingest_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -21,7 +22,10 @@ func Test_extractPayloadFromIngestEventReq(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(jsonBody))
 		req.Header.Set("Content-Type", applicationJsonContentType)
 
-		payload, err := extractPayloadFromIngestEventReq(req, 1024)
+		rawPayload, _ := io.ReadAll(req.Body)
+		req.Body = io.NopCloser(bytes.NewReader(rawPayload))
+
+		payload, err := extractPayloadFromIngestEventReq(req, rawPayload, 1024)
 		require.NoError(t, err)
 		require.Equal(t, jsonBody, payload)
 	})
@@ -36,7 +40,10 @@ func Test_extractPayloadFromIngestEventReq(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", body)
 		req.Header.Set("Content-Type", fmt.Sprintf("%s; boundary=%s", multipartFormDataContentType, writer.Boundary()))
 
-		payload, err := extractPayloadFromIngestEventReq(req, 1024)
+		rawPayload, _ := io.ReadAll(req.Body)
+		req.Body = io.NopCloser(bytes.NewReader(rawPayload))
+
+		payload, err := extractPayloadFromIngestEventReq(req, rawPayload, 1024)
 		require.NoError(t, err)
 
 		var form map[string]string
@@ -51,7 +58,10 @@ func Test_extractPayloadFromIngestEventReq(t *testing.T) {
 
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(jsonBody))
 
-		payload, err := extractPayloadFromIngestEventReq(req, 1024)
+		rawPayload, _ := io.ReadAll(req.Body)
+		req.Body = io.NopCloser(bytes.NewReader(rawPayload))
+
+		payload, err := extractPayloadFromIngestEventReq(req, rawPayload, 1024)
 		require.NoError(t, err)
 		require.Equal(t, jsonBody, payload)
 	})
@@ -62,7 +72,10 @@ func Test_extractPayloadFromIngestEventReq(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", body)
 		req.Header.Set("Content-Type", urlEncodedContentType)
 
-		payload, err := extractPayloadFromIngestEventReq(req, 1024)
+		rawPayload, _ := io.ReadAll(req.Body)
+		req.Body = io.NopCloser(bytes.NewReader(rawPayload))
+
+		payload, err := extractPayloadFromIngestEventReq(req, rawPayload, 1024)
 		require.NoError(t, err)
 		require.Equal(t, []byte(`{"key1":"value1","key2":"value2"}`), payload)
 	})
@@ -73,7 +86,10 @@ func Test_extractPayloadFromIngestEventReq(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(jsonBody))
 		req.Header.Set("Content-Type", "text/html")
 
-		payload, err := extractPayloadFromIngestEventReq(req, 1024)
+		rawPayload, _ := io.ReadAll(req.Body)
+		req.Body = io.NopCloser(bytes.NewReader(rawPayload))
+
+		payload, err := extractPayloadFromIngestEventReq(req, rawPayload, 1024)
 		require.NoError(t, err)
 		require.Equal(t, jsonBody, payload)
 	})


### PR DESCRIPTION
What does this PR do?

This PR optimizes the webhook ingestion pipeline (POST /ingest) by reducing memory allocations during request body processing using sync.Pool. It also fixes an issue where oversized payloads could be silently truncated before validation.

Background

Previously, webhook payloads were read using io.ReadAll(), which allocated a new []byte for every request. Under high throughput, these short-lived allocations increased garbage collection pressure, resulting in unnecessary CPU usage and latency spikes.

Additionally, the use of io.LimitReader could silently truncate payloads that exceeded the configured size limit. These truncated payloads would later fail signature verification instead of returning the appropriate HTTP error.

Changes
Introduced a sync.Pool of reusable bytes.Buffer instances (16 KB default capacity) for reading webhook payloads.
Replaced io.ReadAll() with io.Copy() into pooled buffers to significantly reduce per-request allocations.
Added protection against oversized pooled buffers by only returning buffers with a capacity of 64 KB or less to the pool.
Fixed oversized payload handling by reading maxIngestSize + 1 bytes, allowing the handler to explicitly detect requests that exceed the configured limit and return HTTP 413 (Payload Too Large) instead of silently truncating the request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot ingest path (verification, payload extraction, and enqueue) with pooled-buffer lifetime constraints; behavior change for oversized bodies (413 vs truncated verify failure) is intentional but client-visible.
> 
> **Overview**
> **Webhook ingest** (`IngestEvent`) now reads request bodies through a **`sync.Pool`** of reusable `bytes.Buffer` instances (16 KB default cap, only buffers ≤64 KB returned to the pool), using **`io.Copy`** instead of per-request **`io.ReadAll`** allocations to cut GC pressure under load.
> 
> **Oversized bodies** are detected by reading up to **`maxIngestSize + 1`** bytes; when the limit is exceeded the handler responds with **HTTP 413** instead of silently truncating and failing signature verification later.
> 
> **`extractPayloadFromIngestEventReq`** takes the already-read **`rawPayload`** and, for JSON/unknown content types, returns that slice instead of reading **`r.Body`** again. Tests were updated for the new signature; benchmarks compare the old read path vs pooled **`io.Copy`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 896d07412b28e09780eca722ac9d0b90929f2d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->