### PR TITLE
feat(api): implement HyperLogLog blast radius tracking for failing webhooks

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -708,6 +708,7 @@ func (a *ApplicationHandler) mountControlPlaneRoutes(router chi.Router, handler 
 
 						projectSubRouter.Route("/dashboard", func(dashboardRouter chi.Router) {
 							dashboardRouter.Get("/summary", handler.GetDashboardSummary)
+							dashboardRouter.Get("/blast-radius", handler.GetProjectBlastRadius)
 						})
 					})
 				})

--- a/api/handlers/dashboard.go
+++ b/api/handlers/dashboard.go
@@ -229,3 +229,34 @@ func (h *Handler) computeDashboardMessages(ctx context.Context, projectID string
 
 	return messagesSent, messages, nil
 }
+
+func (h *Handler) GetProjectBlastRadius(w http.ResponseWriter, r *http.Request) {
+	project, err := h.retrieveProject(r)
+	if err != nil {
+		_ = render.Render(w, r, util.NewServiceErrResponse(err))
+		return
+	}
+
+	if h.A.Redis == nil {
+		_ = render.Render(w, r, util.NewErrorResponse("Redis is not configured", http.StatusServiceUnavailable))
+		return
+	}
+
+	hllKey := datastore.BlastRadiusKey(project.UID, time.Now())
+	count, err := h.A.Redis.PFCount(r.Context(), hllKey).Result()
+	if err != nil {
+		h.A.Logger.ErrorContext(r.Context(), "failed to fetch blast radius", "error", err)
+		_ = render.Render(w, r, util.NewServiceErrResponse(err))
+		return
+	}
+
+	response := map[string]interface{}{
+		"status":  true,
+		"message": "Blast radius fetched successfully",
+		"data": map[string]interface{}{
+			"blast_radius": count,
+		},
+	}
+
+	render.JSON(w, r, response)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -406,7 +406,8 @@ type CircuitBreakerConfiguration struct {
 }
 
 type AnalyticsConfiguration struct {
-	IsEnabled bool `json:"enabled" envconfig:"CONVOY_ANALYTICS_ENABLED"`
+	IsEnabled                 bool   `json:"enabled" envconfig:"CONVOY_ANALYTICS_ENABLED"`
+	BlastRadiusRetentionHours uint64 `json:"blast_radius_retention_hours" envconfig:"CONVOY_ANALYTICS_BLAST_RADIUS_RETENTION_HOURS"`
 }
 
 type StoragePolicyConfiguration struct {

--- a/datastore/models.go
+++ b/datastore/models.go
@@ -2328,3 +2328,7 @@ type UpdateOrganisationCircuitBreakerConfig struct {
 	MinimumRequestCount         uint64 `json:"minimum_request_count" valid:"required,min(0)"`
 	ConsecutiveFailureThreshold uint64 `json:"consecutive_failure_threshold" valid:"required,min(0)"`
 }
+
+func BlastRadiusKey(projectUID string, t time.Time) string {
+	return fmt.Sprintf("project:%s:blast_radius:%s", projectUID, t.UTC().Format("2006-01-02"))
+}

--- a/internal/dataplane/worker.go
+++ b/internal/dataplane/worker.go
@@ -335,6 +335,11 @@ func NewWorker(ctx context.Context, opts RuntimeOpts, cfg config.Configuration) 
 		services.WithOAuth2Context(oauth2Dispatcher.ContextWithRules),
 	)
 
+	retentionHours := cfg.Analytics.BlastRadiusRetentionHours
+	if retentionHours == 0 {
+		retentionHours = 24
+	}
+
 	eventDeliveryProcessorDeps := task.EventDeliveryProcessorDeps{
 		EndpointRepo:               endpointRepo,
 		EventDeliveryRepo:          eventDeliveryRepo,
@@ -351,6 +356,7 @@ func NewWorker(ctx context.Context, opts RuntimeOpts, cfg config.Configuration) 
 		EarlyAdopterFeatureFetcher: postgres.NewEarlyAdopterFeatureFetcher(opts.DB),
 		OAuth2TokenService:         oauth2TokenService,
 		Redis:                      opts.Redis.Client(),
+		BlastRadiusRetention:       time.Duration(retentionHours) * time.Hour,
 		Logger:                     lo,
 	}
 

--- a/internal/dataplane/worker.go
+++ b/internal/dataplane/worker.go
@@ -350,6 +350,7 @@ func NewWorker(ctx context.Context, opts RuntimeOpts, cfg config.Configuration) 
 		FeatureFlagFetcher:         featureFlagFetcher,
 		EarlyAdopterFeatureFetcher: postgres.NewEarlyAdopterFeatureFetcher(opts.DB),
 		OAuth2TokenService:         oauth2TokenService,
+		Redis:                      opts.Redis.Client(),
 		Logger:                     lo,
 	}
 

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hibiken/asynq"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/frain-dev/convoy"
 	"github.com/frain-dev/convoy/config"
@@ -78,6 +79,7 @@ type EventDeliveryProcessorDeps struct {
 	FeatureFlagFetcher         fflag.FeatureFlagFetcher
 	EarlyAdopterFeatureFetcher fflag.EarlyAdopterFeatureFetcher
 	OAuth2TokenService         OAuth2TokenService
+	Redis                      redis.UniversalClient
 	Logger                     log.Logger
 }
 
@@ -436,6 +438,18 @@ func ProcessEventDelivery(deps EventDeliveryProcessorDeps) func(context.Context,
 		} else {
 			deps.Logger.ErrorContext(ctx, "event delivery http error", append(logAttrs, "event_delivery_uid", eventDelivery.UID)...)
 			done = false
+
+			if deps.Redis != nil {
+				hllKey := datastore.BlastRadiusKey(project.UID, time.Now())
+				_, pfErr := deps.Redis.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+					pipe.PFAdd(ctx, hllKey, endpoint.UID)
+					pipe.Expire(ctx, hllKey, 24*time.Hour)
+					return nil
+				})
+				if pfErr != nil {
+					deps.Logger.ErrorContext(ctx, "failed to update blast radius hyperloglog", "error", pfErr)
+				}
+			}
 
 			// For at-most-once delivery, only retry on network failures
 			if eventDelivery.DeliveryMode == datastore.AtMostOnceDeliveryMode {

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -80,6 +80,7 @@ type EventDeliveryProcessorDeps struct {
 	EarlyAdopterFeatureFetcher fflag.EarlyAdopterFeatureFetcher
 	OAuth2TokenService         OAuth2TokenService
 	Redis                      redis.UniversalClient
+	BlastRadiusRetention       time.Duration
 	Logger                     log.Logger
 }
 
@@ -443,7 +444,7 @@ func ProcessEventDelivery(deps EventDeliveryProcessorDeps) func(context.Context,
 				hllKey := datastore.BlastRadiusKey(project.UID, time.Now())
 				_, pfErr := deps.Redis.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 					pipe.PFAdd(ctx, hllKey, endpoint.UID)
-					pipe.Expire(ctx, hllKey, 24*time.Hour)
+					pipe.Expire(ctx, hllKey, deps.BlastRadiusRetention)
 					return nil
 				})
 				if pfErr != nil {

--- a/worker/task/process_event_delivery.go
+++ b/worker/task/process_event_delivery.go
@@ -442,9 +442,15 @@ func ProcessEventDelivery(deps EventDeliveryProcessorDeps) func(context.Context,
 
 			if deps.Redis != nil {
 				hllKey := datastore.BlastRadiusKey(project.UID, time.Now())
+				
+				ttl := deps.BlastRadiusRetention
+				if ttl < 24*time.Hour {
+					ttl = 24 * time.Hour
+				}
+
 				_, pfErr := deps.Redis.Pipelined(ctx, func(pipe redis.Pipeliner) error {
 					pipe.PFAdd(ctx, hllKey, endpoint.UID)
-					pipe.Expire(ctx, hllKey, deps.BlastRadiusRetention)
+					pipe.Expire(ctx, hllKey, ttl)
 					return nil
 				})
 				if pfErr != nil {

--- a/worker/task/process_retry_event_delivery.go
+++ b/worker/task/process_retry_event_delivery.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hibiken/asynq"
 	"github.com/oklog/ulid/v2"
+	"github.com/redis/go-redis/v9"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/frain-dev/convoy"
@@ -351,6 +352,22 @@ func ProcessRetryEventDelivery(deps EventDeliveryProcessorDeps) func(context.Con
 		} else {
 			deps.Logger.ErrorContext(ctx, eventDelivery.UID, logAttrs...)
 			done = false
+
+			if deps.Redis != nil {
+				hllKey := datastore.BlastRadiusKey(project.UID, time.Now())
+				ttl := deps.BlastRadiusRetention
+				if ttl < 24*time.Hour {
+					ttl = 24 * time.Hour
+				}
+				_, pfErr := deps.Redis.Pipelined(ctx, func(pipe redis.Pipeliner) error {
+					pipe.PFAdd(ctx, hllKey, endpoint.UID)
+					pipe.Expire(ctx, hllKey, ttl)
+					return nil
+				})
+				if pfErr != nil {
+					deps.Logger.ErrorContext(ctx, "failed to update blast radius hyperloglog", "error", pfErr)
+				}
+			}
 
 			// For at-most-once delivery, only retry on network failures
 			if eventDelivery.DeliveryMode == datastore.AtMostOnceDeliveryMode {


### PR DESCRIPTION
What does this PR do?
This PR introduces a highly efficient "Blast Radius" metric to track the number of unique customer endpoints currently experiencing webhook delivery failures. It uses Redis's HyperLogLog (PFADD / PFCOUNT) data structure to calculate set cardinality in O(1) time using a maximum of 12KB of memory.

**Use Cases & How it Helps**

1. Incident Triage: During a massive outage, support teams can instantly see if 1,000 deliveries failing is affecting 1 customer (a single misconfigured endpoint) or 1,000 customers (a systemic Convoy issue).

2. System Health Dashboarding: The new API endpoint makes it trivial to plot "Unique Failing Endpoints" on a Grafana or UI dashboard to visually monitor the blast radius of network issues in real-time.

3. Alerting: Teams can set up alerts to trigger only when the blast radius exceeds a certain threshold, eliminating noise from a single customer taking down their own server and causing hundreds of delivery failures.

The Implementation

- Zero-Overhead Write Path: Injected the Redis client into the ProcessEventDelivery worker dependencies. When an HTTP delivery returns a non-2xx status code or encounters a network failure, we immediately execute a PFADD to record the failing EndpointID.

- Pipelining for Performance: The PFADD and Expire commands are combined in a single Redis Pipeline to prevent paying for two network round-trips per delivery failure.

- Centralized Key Generation: Created a new shared helper datastore.BlastRadiusKey() which pins the time buckets to UTC to prevent drift across server environments.

- New Analytics API: Added GET /api/v1/projects/{projectID}/dashboard/blast-radius which executes a PFCOUNT on the daily bucket and returns the unique count in JSON.

- Customizable Retention: Added BlastRadiusRetentionHours to the Analytics configuration. Users can now override the default 24-hour retention period using the CONVOY_ANALYTICS_BLAST_RADIUS_RETENTION_HOURS environment variable.

**TODO**

- UI once feature is approvesd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds Redis writes on the delivery failure hot path (pipelined, errors logged only) and makes the metric depend on Redis being configured for reads.
> 
> **Overview**
> Adds a **blast radius** metric: how many distinct endpoints had at least one failed webhook delivery in the current UTC day bucket.
> 
> On **non-2xx delivery outcomes**, the event-delivery and retry-delivery workers **PFADD** the endpoint ID into a per-project daily Redis HyperLogLog (pipelined with **EXPIRE**). TTL comes from **`CONVOY_ANALYTICS_BLAST_RADIUS_RETENTION_HOURS`** (default 24h, minimum 24h on keys). **`datastore.BlastRadiusKey`** centralizes UTC day bucketing.
> 
> The control-plane UI exposes **`GET …/dashboard/blast-radius`**, which **PFCOUNT**s today’s bucket and returns `blast_radius` (503 if Redis is unavailable). Redis and retention are wired through **`internal/dataplane/worker`** into shared **`EventDeliveryProcessorDeps`** used by both delivery processors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed4ab8f007a95a022a06851cdd70f116c14583c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->