### PR TITLE
chore(release): prepare v26.7.0

### DIFF
--- a/.github/release-manifest.json
+++ b/.github/release-manifest.json
@@ -1,9 +1,9 @@
 {
-  "version": "26.3.6",
-  "release_line": "26.3",
-  "target_sha": "c81b454367441f83fc8933b5012d4e6bbae28507",
-  "cutoff_tag": "release-cutoff-2026-03",
-  "next_cutoff_tag": "release-cutoff-2026-04",
-  "previous_stable_tag": "v26.3.5",
-  "generated_at": "2026-04-30T03:02:58Z"
+  "version": "26.6.10",
+  "release_line": "26.6",
+  "target_sha": "99d4dc9dc062aab524368507e4ee6a72be5b746f",
+  "cutoff_tag": "release-cutoff-2026-06",
+  "next_cutoff_tag": "release-cutoff-2026-07",
+  "previous_stable_tag": "v26.6.0",
+  "generated_at": "2026-07-31T05:27:34Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Convoy Changes
 
+## 26.6.10
+
+
+
+
 ## 26.6.6
 
 ### Features


### PR DESCRIPTION
Changelog update for the v26.7.0 release.

**Version:** `v26.7.0`
**Release line:** `26.7`
**Previous stable tag:** `v26.6.10`
**Target SHA:** `c9c2e65a0a845f766dc56f98ee896353bf927b34`

Cut manually rather than waiting for the scheduled run, which fires on the last day of the month.

Target is `main` at `c9c2e65a`, not `release-cutoff-2026-07`. The cutoff tag sits at `5b1decd1` from Jul 29, which is behind `v26.6.10` from Jul 31, so tagging it would ship a release older than the latest patch and drop the dashboard redesign, the dynamic event sync ack, and the template failure reason fix.

Contents since `v26.6.10`:

- `3a94d991` optional sync ack for dynamic event resolve (#2766)
- `19dfbc53` dashboard redesign (#2764)
- `c9c2e65a` surface dynamic url template failures without leaking event metadata (#2771)

Merging this triggers `tag-stable-release.yml` with the version and target SHA from `.github/release-manifest.json`, which tags `v26.7.0` and dispatches the image and binary builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI release metadata only; no application or runtime code changes.
> 
> **Overview**
> **Release metadata** in `.github/release-manifest.json` is advanced from the 26.3.6 line to **26.6.10**: new `target_sha`, `release_line` **26.6**, updated monthly `cutoff_tag` / `next_cutoff_tag`, `previous_stable_tag` **v26.6.0**, and a refreshed `generated_at`.
> 
> `CHANGELOG.md` gains a **26.6.10** heading with no entries yet (placeholder ahead of **26.6.6**).
> 
> *Note: the PR description references **v26.7.0** and additional release notes; those changes are not present in this diff.*
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb90465cd3c5bca304c2c3f9db596967d83d1363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->