### PR TITLE
chore(release): prepare v26.7.1

### DIFF
--- a/.github/release-manifest.json
+++ b/.github/release-manifest.json
@@ -1,9 +1,9 @@
 {
-  "version": "26.3.6",
-  "release_line": "26.3",
-  "target_sha": "c81b454367441f83fc8933b5012d4e6bbae28507",
-  "cutoff_tag": "release-cutoff-2026-03",
-  "next_cutoff_tag": "release-cutoff-2026-04",
-  "previous_stable_tag": "v26.3.5",
-  "generated_at": "2026-04-30T03:02:58Z"
+  "version": "26.7.1",
+  "release_line": "26.7",
+  "target_sha": "a88cd70acbf32abdc01a687b5e6ed4bbb30b2e8d",
+  "cutoff_tag": "",
+  "next_cutoff_tag": "",
+  "previous_stable_tag": "v26.7.0",
+  "generated_at": "2026-08-07T14:22:25Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,73 @@
 # Convoy Changes
 
+## 26.7.1
+
+### Breaking Changes
+
+- The project config field `sync_dynamic_event_ack`, released in 26.7.0, is renamed to `verify_dynamic_events`. `POST /projects` and `PUT /projects/{id}` reject the old key with a 400 naming the new field rather than ignoring it (#2773)
+- `CONVOY_SYNC_DYNAMIC_EVENT_ACK_TIMEOUT` is renamed to `CONVOY_VERIFY_DYNAMIC_EVENTS_TIMEOUT`. The old variable is no longer read and warns at boot; the same key in a config file falls back to the 30s default silently (#2773)
+
+### Features
+
+- feat(dataplane): allow dynamic urls that match no endpoint template (#2773)
+
+### Bug Fixes
+
+- fix(dashboard): correct subscription event type selection and redesign alert toasts (#2775)
+
+## 26.7.0
+
+### Features
+
+- feat(dataplane): optional sync ack for dynamic event resolve (#2766)
+- feat(dashboard): Redesign Convoy dashboard (#2764)
+
+### Bug Fixes
+
+- fix(dataplane): surface dynamic url template failures without leaking event metadata (#2771)
+
+## 26.6.10
+
+### Features
+
+- feat(dataplane): custom user-agent replaces convoy branding header (#2765)
+
+## 26.6.9
+
+### Improvements
+
+- refactor(dataplane): remove delete-query retention and its feature flag (#2753)
+
+### Bug Fixes
+
+- fix(controlplane): swap transactional email header logo (#2761)
+- fix(build): refactor docker install script (#2711)
+- fix(controlplane): harden ingest verifier fallback, retry scoping, bulk onboard and billing update (#2754)
+
+## 26.6.8
+
+### Improvements
+
+- chore(deps): bump golang.org/x/crypto to v0.52.0 and golang.org/x/net to v0.55.0 (#2757)
+
+### Bug Fixes
+
+- fix(controlplane): scope source lookups by project and canonicalize jwt blacklist keys (#2755)
+- fix(dataplane): block cloud metadata and link-local targets on default webhook egress (#2756)
+- fix(controlplane): scope portal-link and org authorization to close cross-tenant access (#2760)
+
+## 26.6.7
+
+### Bug Fixes
+
+- fix: agent ingest honors instance ingest rate limit (#2744)
+- fix: return empty endpoints_metadata for portal links with no endpoints (#2745)
+- fix: close idempotency dedup race on concurrent event creation (#2747)
+- fix(dataplane): reject events without a delivery target and honor app_id fanout (#2746)
+- fix(controlplane): close jul 20-21 vulnerability audit findings (#2749)
+- fix(dashboard): clarify unverified-email copy for dialog and trial modal (#2751)
+- fix: render current year in email template footers (#2750)
+
 ## 26.6.6
 
 ### Features


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Merging this PR cuts the release

`monthly-release-pr.yml` has a `pull_request: closed` job that fires only for a merged PR whose head branch is exactly `chore/monthly-release`. It reads `.version` and `.target_sha` from `.github/release-manifest.json` and dispatches `tag-stable-release.yml`, which creates and pushes `v26.7.1` and then dispatches `build-image.yml` and `release.yml` on the tag ref.

That branch name is why this PR uses it: merging is the only action needed to publish, with no `workflow_dispatch` from a browser.

The tag will point at `a88cd70a` (main's HEAD before this PR), not the merge commit. This matches the monthly flow, and it means the released code is exactly the commit CI already ran green — the changelog commit itself ships in the next release.

## Contents

**`CHANGELOG.md`** — the file stopped at `26.6.6`, so `26.6.7` through `26.7.0` were never recorded. Entries are generated with `git-cliff` against `.git-cliff.toml` and then curated the way earlier entries were: internal CI, SDK bootstrap and release-plumbing commits dropped, user-facing changes kept, ticket refs trimmed. The `26.7.1` section leads with a Breaking Changes block, because `git-cliff` classifies #2773 as a plain `feat` from its subject and nothing in the generated notes would tell a caller to act.

**`.github/release-manifest.json`** — set to `26.7.1` / `a88cd70a`. `cutoff_tag` and `next_cutoff_tag` are empty because no cutoff tag exists for the `26.7` line (the newest in the repo is `release-cutoff-2026-06`); this patch is not gated by one.

## What ships in v26.7.1

Two commits since `v26.7.0`:

- #2773 `feat(dataplane): allow dynamic urls that match no endpoint template`
- #2775 `fix(dashboard): UI bug`

#2773 is not a routine patch. It renames a project config field and an env var that shipped in `v26.7.0` three days earlier:

- `sync_dynamic_event_ack` → `verify_dynamic_events`, with the old JSON key **rejected with a 400** on `POST /projects` and `PUT /projects/{id}` rather than ignored
- `CONVOY_SYNC_DYNAMIC_EVENT_ACK_TIMEOUT` → `CONVOY_VERIFY_DYNAMIC_EVENTS_TIMEOUT`, old variable no longer read (warns at boot; the same key in a config file falls back to the 30s default silently)

It also adds two migrations to `convoy.project_configurations` (`sql/1786060800.sql`, `sql/1786060900.sql`): both additive with `IF NOT EXISTS`, `lock_timeout = '2s'`, `statement_timeout = '30s'`, and reversible. The rename is expand/contract — the old column stays so `v26.7.0` pods keep reading a column that exists mid-roll, and writes go to both columns (`projectConfigToCreateParams` / `projectConfigToUpdateParams` set `SyncDynamicEventAck` from `config.VerifyDynamicEvents`). The project cache key is versioned to `projects:v2:` so pre-rename entries are not decoded with the field missing. A follow-up release drops the old column and must re-copy first; the statement is written into `sql/1786060900.sql`.

## Confirm before merging

- [ ] A breaking rename of a `26.7.0` surface is acceptable in a `26.7` patch rather than a bigger version bump
- [ ] The website docs PR (`frain-dev/convoy-website#480`) is ready to merge together — per #2773 the published pages currently document the rejected field name. I could not check its status; that repo is not readable from this environment
- [ ] Whoever deploys knows two migrations run, and that the backfill `UPDATE` sits under a 30s `statement_timeout`

## Verify after merging

1. `monthly-release-pr.yml` → `trigger-tag-stable-release` succeeds, then `Tag Stable Release` runs
2. `v26.7.1` points at `a88cd70a`
3. The dispatched `build-image.yml` and `release.yml` runs both pass
4. The GitHub release lists both PRs; note its body comes from `git-cliff --latest`, not from `CHANGELOG.md`, so the Breaking Changes block has to be pasted in by hand — the text is below
5. The `v26.7.1` image reports `v26.7.1` from `convoy version` (injected via ldflags, not the `VERSION` file)

If a dispatched run fails **after** the tag exists, do not re-run `Tag Stable Release`: `tag-release.sh` exits with `created=false` and skips the dispatch step. Dispatch `build-image.yml` / `release.yml` directly on the `v26.7.1` ref.

## Release notes to paste into the v26.7.1 GitHub release

`release.yml` generates the release body from `git-cliff --latest`, which will produce two bare commit subjects. Replacing it with the following puts the rename first:

```markdown
## Breaking Changes

**`sync_dynamic_event_ack` is now `verify_dynamic_events`.** The project config field released in v26.7.0 has been renamed. `POST /projects` and `PUT /projects/{id}` reject the old key with a 400 naming the new field, so callers that adopted it in v26.7.0 must update before upgrading.

**`CONVOY_SYNC_DYNAMIC_EVENT_ACK_TIMEOUT` is now `CONVOY_VERIFY_DYNAMIC_EVENTS_TIMEOUT`.** The old variable is no longer read. Convoy warns at boot if it is still set; the equivalent key in a config file falls back to the 30s default silently.

## Upgrade Notes

Two additive migrations run against `convoy.project_configurations`: `allow_unmatched_dynamic_urls`, and `verify_dynamic_events` backfilled from `sync_dynamic_event_ack`. Both use `IF NOT EXISTS` with a 2s lock timeout and a 30s statement timeout.

Rolling deploys are safe in both directions. The old column is left in place so v26.7.0 pods keep reading a column that exists, and v26.7.1 writes both columns while reading only the new one. A later release drops `sync_dynamic_event_ack`.

Existing projects are unaffected until the new setting is switched on: `allow_unmatched_dynamic_urls` defaults to false, which preserves today's strict template matching.

## Features

- Dynamic event URLs matching none of a project's endpoint URL templates can now auto-create an endpoint, via the new per-project `allow_unmatched_dynamic_urls` setting (default off). URLs matching several templates stay strict, so a template misconfiguration is not hidden. (#2773)

## Bug Fixes

- Fixed subscription event type selection in the dashboard — wildcard versus specific types, row clicks, and filter enable/disable — and redesigned alert toasts. (#2775)
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61dd3a76-296b-4647-b0de-77302d89de28?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61dd3a76-296b-4647-b0de-77302d89de28&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

