### PR TITLE
fix(dataplane): correct partition naming, retention adoption and event-id enforcement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/jarcoal/httpmock v1.4.0
 	github.com/jaswdr/faker v1.19.1
-	github.com/jirevwe/gopartman v0.1.0
+	github.com/jirevwe/gopartman v0.2.0
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -1236,8 +1236,8 @@ github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJk
 github.com/jinzhu/copier v0.3.4/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jirevwe/goja_nodejs v0.0.0-20240322142733-81d2fcfb82c1 h1:SpbhN3p8Sh8R5a+OFA9iUKc368c81g5Rx/yTwg1tzfE=
 github.com/jirevwe/goja_nodejs v0.0.0-20240322142733-81d2fcfb82c1/go.mod h1:bhGPmCgCCTSRfiMYWjpS46IDo9EUZXlsuUaPXSWGbv0=
-github.com/jirevwe/gopartman v0.1.0 h1:QUFRtmqvFxqn+UCONJNcosg8a1eMvy+GRSB4O+9gLXI=
-github.com/jirevwe/gopartman v0.1.0/go.mod h1:kJ2hJ3JJ1DVg1u9AVVbI3kn//cnzXfRU8QvlCoyusps=
+github.com/jirevwe/gopartman v0.2.0 h1:XCgUs1zy8x0VY/tjhUd8lyWaeEfp9ZHCmuMjnHht3mo=
+github.com/jirevwe/gopartman v0.2.0/go.mod h1:kJ2hJ3JJ1DVg1u9AVVbI3kn//cnzXfRU8QvlCoyusps=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/internal/dataplane/worker.go
+++ b/internal/dataplane/worker.go
@@ -291,7 +291,7 @@ func NewWorker(ctx context.Context, opts RuntimeOpts, cfg config.Configuration) 
 	// Retention is paid-only and partition-based; the license is the single
 	// gate (the delete-query retention system and its feature flag were
 	// removed). LicensedRetentionPolicy re-reads partition state at job time
-	// so `convoy partition` activates retention without a worker restart.
+	// so `convoy utils partition` activates retention without a worker restart.
 	// Until tables are partitioned it deletes nothing and logs the action.
 	var ret retention.Retentioner
 	if opts.Licenser.RetentionPolicy() {

--- a/internal/delivery_attempts/create_delivery_attempt_test.go
+++ b/internal/delivery_attempts/create_delivery_attempt_test.go
@@ -164,6 +164,35 @@ func TestCreateDeliveryAttempt_NoResponseLeavesRespondedAtNull(t *testing.T) {
 	require.False(t, fetched.RespondedAt.Valid)
 }
 
+// Partitions must be named so retention can adopt them. See
+// testenv.RequirePartitionsAddressableByRetention for why that is not automatic.
+func TestPartitionDeliveryAttemptsTableNamesForRetention(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	defer db.Close()
+
+	project := seedTestData(t, db, ctx)
+	endpoint := seedEndpoint(t, db, ctx, project)
+	eventDelivery := seedEventDelivery(t, db, ctx, project, endpoint)
+
+	service := New(log.New("convoy", log.LevelError), db)
+
+	require.NoError(t, service.CreateDeliveryAttempt(ctx, &datastore.DeliveryAttempt{
+		UID:              ulid.Make().String(),
+		URL:              "https://example.com/webhook",
+		Method:           "POST",
+		APIVersion:       "2023.12.25",
+		EndpointID:       endpoint.UID,
+		EventDeliveryId:  eventDelivery.UID,
+		ProjectId:        project.UID,
+		HttpResponseCode: "200",
+		Status:           true,
+		RequestedAt:      null.TimeFrom(time.Now().UTC()),
+	}))
+
+	require.NoError(t, service.PartitionDeliveryAttemptsTable(ctx))
+	testenv.RequirePartitionsAddressableByRetention(t, db, "delivery_attempts", project.UID)
+}
+
 func TestPartitionRoundTrip_PreservesRequestedAndRespondedAt(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	defer db.Close()

--- a/internal/delivery_attempts/impl.go
+++ b/internal/delivery_attempts/impl.go
@@ -323,8 +323,10 @@ BEGIN
                'delivery_attempts_' || pg_catalog.UPPER(pg_catalog.REPLACE(project_id::TEXT, '-', '')) || '_' || pg_catalog.REPLACE(created_at::TEXT, '-', '') AS partition_table_name
         FROM dates
     LOOP
-        -- %I, not %s: an unquoted identifier folds to lower case, and retention
-        -- only adopts partitions whose name carries an upper-case tenant segment.
+        -- %I, not %s: an unquoted identifier folds to lower case. Retention names
+        -- the partitions it creates for later days with an upper-case tenant
+        -- segment, so folding here spells one table two ways. Adoption itself
+        -- tolerates either since gopartman v0.2.0.
         EXECUTE FORMAT(
             'CREATE TABLE IF NOT EXISTS convoy.%I PARTITION OF convoy.delivery_attempts_new FOR VALUES FROM (%L, %L) TO (%L, %L)',
             r.partition_table_name, r.project_id, r.start_date, r.project_id, r.stop_date

--- a/internal/delivery_attempts/impl.go
+++ b/internal/delivery_attempts/impl.go
@@ -320,11 +320,13 @@ BEGIN
         SELECT project_id,
                created_at::TEXT AS start_date,
                (created_at + 1)::TEXT AS stop_date,
-               'delivery_attempts_' || pg_catalog.REPLACE(project_id::TEXT, '-', '') || '_' || pg_catalog.REPLACE(created_at::TEXT, '-', '') AS partition_table_name
+               'delivery_attempts_' || pg_catalog.UPPER(pg_catalog.REPLACE(project_id::TEXT, '-', '')) || '_' || pg_catalog.REPLACE(created_at::TEXT, '-', '') AS partition_table_name
         FROM dates
     LOOP
+        -- %I, not %s: an unquoted identifier folds to lower case, and retention
+        -- only adopts partitions whose name carries an upper-case tenant segment.
         EXECUTE FORMAT(
-            'CREATE TABLE IF NOT EXISTS convoy.%s PARTITION OF convoy.delivery_attempts_new FOR VALUES FROM (%L, %L) TO (%L, %L)',
+            'CREATE TABLE IF NOT EXISTS convoy.%I PARTITION OF convoy.delivery_attempts_new FOR VALUES FROM (%L, %L) TO (%L, %L)',
             r.partition_table_name, r.project_id, r.start_date, r.project_id, r.stop_date
         );
     END LOOP;

--- a/internal/event_deliveries/impl.go
+++ b/internal/event_deliveries/impl.go
@@ -805,6 +805,34 @@ BEGIN
     BEFORE INSERT ON convoy.delivery_attempts
     FOR EACH ROW EXECUTE FUNCTION enforce_event_delivery_fk();
 
+    -- event_deliveries_new declares event_id with no references clause, so
+    -- dropping the old table above took event_id enforcement with it: either the
+    -- original constraint, or the event_fk_check trigger partition_events_table()
+    -- leaves behind. Restore whichever form is correct for the current state of
+    -- convoy.events, because both orders of the two partition commands are
+    -- reachable from convoy utils partition <table>.
+    --
+    -- A foreign key cannot reference a partitioned table, so a partitioned events
+    -- admits only the trigger. convoy.enforce_event_fk() is guaranteed to exist in
+    -- that branch: the only thing that partitions events also defines it.
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'convoy' AND c.relname = 'events' AND c.relkind = 'p'
+    ) THEN
+        CREATE OR REPLACE TRIGGER event_fk_check
+        BEFORE INSERT ON convoy.event_deliveries
+        FOR EACH ROW EXECUTE FUNCTION convoy.enforce_event_fk();
+    ELSE
+        -- Validated rather than NOT VALID: every row here was just copied from a
+        -- table the same constraint already held on, and the scan is small beside
+        -- the copy it follows.
+        ALTER TABLE convoy.event_deliveries
+            ADD CONSTRAINT event_deliveries_event_id_fkey
+                FOREIGN KEY (event_id) REFERENCES convoy.events (id);
+    END IF;
+
     RAISE NOTICE 'Migration complete!';
 END;
 $$ LANGUAGE plpgsql;

--- a/internal/event_deliveries/impl.go
+++ b/internal/event_deliveries/impl.go
@@ -761,8 +761,10 @@ BEGIN
                'event_deliveries_' || pg_catalog.UPPER(pg_catalog.REPLACE(project_id::TEXT, '-', '')) || '_' || pg_catalog.REPLACE(created_at::TEXT, '-', '') AS partition_table_name
         FROM dates
     LOOP
-        -- %I, not %s: an unquoted identifier folds to lower case, and retention
-        -- only adopts partitions whose name carries an upper-case tenant segment.
+        -- %I, not %s: an unquoted identifier folds to lower case. Retention names
+        -- the partitions it creates for later days with an upper-case tenant
+        -- segment, so folding here spells one table two ways. Adoption itself
+        -- tolerates either since gopartman v0.2.0.
         EXECUTE FORMAT(
             'CREATE TABLE IF NOT EXISTS convoy.%I PARTITION OF convoy.event_deliveries_new FOR VALUES FROM (%L, %L) TO (%L, %L)',
             r.partition_table_name, r.project_id, r.start_date, r.project_id, r.stop_date

--- a/internal/event_deliveries/impl.go
+++ b/internal/event_deliveries/impl.go
@@ -758,11 +758,13 @@ BEGIN
         SELECT project_id,
                created_at::TEXT AS start_date,
                (created_at + 1)::TEXT AS stop_date,
-               'event_deliveries_' || pg_catalog.REPLACE(project_id::TEXT, '-', '') || '_' || pg_catalog.REPLACE(created_at::TEXT, '-', '') AS partition_table_name
+               'event_deliveries_' || pg_catalog.UPPER(pg_catalog.REPLACE(project_id::TEXT, '-', '')) || '_' || pg_catalog.REPLACE(created_at::TEXT, '-', '') AS partition_table_name
         FROM dates
     LOOP
+        -- %I, not %s: an unquoted identifier folds to lower case, and retention
+        -- only adopts partitions whose name carries an upper-case tenant segment.
         EXECUTE FORMAT(
-            'CREATE TABLE IF NOT EXISTS convoy.%s PARTITION OF convoy.event_deliveries_new FOR VALUES FROM (%L, %L) TO (%L, %L)',
+            'CREATE TABLE IF NOT EXISTS convoy.%I PARTITION OF convoy.event_deliveries_new FOR VALUES FROM (%L, %L) TO (%L, %L)',
             r.partition_table_name, r.project_id, r.start_date, r.project_id, r.stop_date
         );
     END LOOP;

--- a/internal/event_deliveries/impl.go
+++ b/internal/event_deliveries/impl.go
@@ -910,6 +910,26 @@ begin
     create index idx_event_deliveries_status on convoy.event_deliveries (status);
     create index idx_event_deliveries_status_key on convoy.event_deliveries (status);
 
+    -- Same reason as partition_event_deliveries_table: this function also
+    -- rebuilds convoy.event_deliveries, so it also has to put event-id
+    -- enforcement back. Unpartitioning event deliveries says nothing about
+    -- convoy.events, which may still be partitioned and can therefore still only
+    -- be enforced by the trigger.
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'convoy' AND c.relname = 'events' AND c.relkind = 'p'
+    ) THEN
+        CREATE OR REPLACE TRIGGER event_fk_check
+        BEFORE INSERT ON convoy.event_deliveries
+        FOR EACH ROW EXECUTE FUNCTION convoy.enforce_event_fk();
+    ELSE
+        ALTER TABLE convoy.event_deliveries
+            ADD CONSTRAINT event_deliveries_event_id_fkey
+                FOREIGN KEY (event_id) REFERENCES convoy.events (id);
+    END IF;
+
 	RAISE NOTICE 'Successfully un-partitioned events table...';
 end $$ language plpgsql;
 select convoy.un_partition_event_deliveries_table()

--- a/internal/event_deliveries/impl_test.go
+++ b/internal/event_deliveries/impl_test.go
@@ -1227,3 +1227,22 @@ func TestPartitionFunctions(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+// Partitions must be named so retention can adopt them. See
+// testenv.RequirePartitionsAddressableByRetention for why that is not automatic.
+func TestPartitionEventDeliveriesTableNamesForRetention(t *testing.T) {
+	service, db := setupTestDB(t)
+	ctx := context.Background()
+
+	project := seedTestProject(t, db)
+	endpoint := seedTestEndpoint(t, db, project.UID)
+	source := seedTestSource(t, db, project.UID)
+	subscription := seedSubscription(t, db, project.UID, endpoint.UID, source.UID)
+	event := seedEvent(t, db, project.UID, endpoint.UID, source.UID)
+
+	delivery := createTestEventDelivery(t, project.UID, event.UID, endpoint.UID, subscription.UID)
+	require.NoError(t, service.CreateEventDelivery(ctx, delivery))
+
+	require.NoError(t, service.PartitionEventDeliveriesTable(ctx))
+	testenv.RequirePartitionsAddressableByRetention(t, db, "event_deliveries", project.UID)
+}

--- a/internal/event_deliveries/impl_test.go
+++ b/internal/event_deliveries/impl_test.go
@@ -1278,6 +1278,35 @@ func TestPartitionEventDeliveriesTableKeepsEventIDEnforcement(t *testing.T) {
 	}
 }
 
+// UnPartition rebuilds convoy.event_deliveries too, so it owes the same
+// event-id enforcement the partition path owes. Unpartitioning deliveries says
+// nothing about convoy.events, which may still be partitioned.
+func TestUnPartitionEventDeliveriesTableKeepsEventIDEnforcement(t *testing.T) {
+	service, db := setupTestDB(t)
+	ctx := context.Background()
+
+	project := seedTestProject(t, db)
+	endpoint := seedTestEndpoint(t, db, project.UID)
+	source := seedTestSource(t, db, project.UID)
+	subscription := seedSubscription(t, db, project.UID, endpoint.UID, source.UID)
+	event := seedEvent(t, db, project.UID, endpoint.UID, source.UID)
+
+	require.NoError(t, service.CreateEventDelivery(ctx,
+		createTestEventDelivery(t, project.UID, event.UID, endpoint.UID, subscription.UID)))
+
+	// events stays partitioned, so the trigger is the only form available.
+	require.NoError(t, events.New(log.New("convoy", log.LevelInfo), db).PartitionEventsTable(ctx))
+	require.NoError(t, service.PartitionEventDeliveriesTable(ctx))
+	require.NoError(t, service.UnPartitionEventDeliveriesTable(ctx))
+
+	orphan := createTestEventDelivery(t, project.UID, ulid.Make().String(), endpoint.UID, subscription.UID)
+	require.Error(t, service.CreateEventDelivery(ctx, orphan),
+		"delivery referencing a nonexistent event was accepted after unpartitioning")
+
+	require.NoError(t, service.CreateEventDelivery(ctx,
+		createTestEventDelivery(t, project.UID, event.UID, endpoint.UID, subscription.UID)))
+}
+
 // Partitions must be named so retention can adopt them. See
 // testenv.RequirePartitionsAddressableByRetention for why that is not automatic.
 func TestPartitionEventDeliveriesTableNamesForRetention(t *testing.T) {

--- a/internal/event_deliveries/impl_test.go
+++ b/internal/event_deliveries/impl_test.go
@@ -1228,6 +1228,56 @@ func TestPartitionFunctions(t *testing.T) {
 	})
 }
 
+// event_deliveries_new declares event_id with no references clause, so
+// partitioning rebuilds the table without event-id enforcement unless the
+// function restores it. Both orders of the two partition commands are reachable
+// from `convoy utils partition <table>`, and the enforcement that is correct
+// differs between them: a foreign key cannot reference a partitioned events, so
+// that case admits only the trigger.
+//
+// Asserting the behaviour rather than the catalog: what matters is that a
+// delivery naming an event that does not exist is rejected, not which mechanism
+// rejects it.
+func TestPartitionEventDeliveriesTableKeepsEventIDEnforcement(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		wantMechanism   string
+		partitionEvents bool
+	}{
+		{name: "events partitioned first", wantMechanism: "event_fk_check trigger", partitionEvents: true},
+		{name: "events left unpartitioned", wantMechanism: "event_deliveries_event_id_fkey", partitionEvents: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			service, db := setupTestDB(t)
+			ctx := context.Background()
+
+			project := seedTestProject(t, db)
+			endpoint := seedTestEndpoint(t, db, project.UID)
+			source := seedTestSource(t, db, project.UID)
+			subscription := seedSubscription(t, db, project.UID, endpoint.UID, source.UID)
+			event := seedEvent(t, db, project.UID, endpoint.UID, source.UID)
+
+			// The partition helpers only build children for days that hold rows.
+			require.NoError(t, service.CreateEventDelivery(ctx,
+				createTestEventDelivery(t, project.UID, event.UID, endpoint.UID, subscription.UID)))
+
+			if tc.partitionEvents {
+				require.NoError(t, events.New(log.New("convoy", log.LevelInfo), db).PartitionEventsTable(ctx))
+			}
+			require.NoError(t, service.PartitionEventDeliveriesTable(ctx))
+
+			orphan := createTestEventDelivery(t, project.UID, ulid.Make().String(), endpoint.UID, subscription.UID)
+			require.Error(t, service.CreateEventDelivery(ctx, orphan),
+				"delivery referencing a nonexistent event was accepted: %s is missing", tc.wantMechanism)
+
+			// A valid delivery must still be accepted, so the test cannot pass on a
+			// mechanism that rejects everything.
+			require.NoError(t, service.CreateEventDelivery(ctx,
+				createTestEventDelivery(t, project.UID, event.UID, endpoint.UID, subscription.UID)))
+		})
+	}
+}
+
 // Partitions must be named so retention can adopt them. See
 // testenv.RequirePartitionsAddressableByRetention for why that is not automatic.
 func TestPartitionEventDeliveriesTableNamesForRetention(t *testing.T) {

--- a/internal/events/impl.go
+++ b/internal/events/impl.go
@@ -716,11 +716,13 @@ BEGIN
         SELECT project_id,
                created_at::TEXT AS start_date,
                (created_at + 1)::TEXT AS stop_date,
-               'events_' || pg_catalog.REPLACE(project_id::TEXT, '-', '') || '_' || pg_catalog.REPLACE(created_at::TEXT, '-', '') AS partition_table_name
+               'events_' || pg_catalog.UPPER(pg_catalog.REPLACE(project_id::TEXT, '-', '')) || '_' || pg_catalog.REPLACE(created_at::TEXT, '-', '') AS partition_table_name
         FROM dates
     LOOP
+        -- %I, not %s: an unquoted identifier folds to lower case, and retention
+        -- only adopts partitions whose name carries an upper-case tenant segment.
         EXECUTE FORMAT(
-            'CREATE TABLE IF NOT EXISTS convoy.%s PARTITION OF convoy.events_new FOR VALUES FROM (%L, %L) TO (%L, %L)',
+            'CREATE TABLE IF NOT EXISTS convoy.%I PARTITION OF convoy.events_new FOR VALUES FROM (%L, %L) TO (%L, %L)',
             r.partition_table_name, r.project_id, r.start_date, r.project_id, r.stop_date
         );
     END LOOP;
@@ -888,11 +890,13 @@ BEGIN
         SELECT project_id,
                created_at::TEXT AS start_date,
                (created_at + 1)::TEXT AS stop_date,
-               'events_search_' || pg_catalog.REPLACE(project_id::TEXT, '-', '') || '_' || pg_catalog.REPLACE(created_at::TEXT, '-', '') AS partition_table_name
+               'events_search_' || pg_catalog.UPPER(pg_catalog.REPLACE(project_id::TEXT, '-', '')) || '_' || pg_catalog.REPLACE(created_at::TEXT, '-', '') AS partition_table_name
         FROM dates
         LOOP
+            -- %I, not %s: an unquoted identifier folds to lower case, and retention
+            -- only adopts partitions whose name carries an upper-case tenant segment.
             EXECUTE FORMAT(
-                    'CREATE TABLE IF NOT EXISTS convoy.%s PARTITION OF convoy.events_search_new FOR VALUES FROM (%L, %L) TO (%L, %L)',
+                    'CREATE TABLE IF NOT EXISTS convoy.%I PARTITION OF convoy.events_search_new FOR VALUES FROM (%L, %L) TO (%L, %L)',
                     r.partition_table_name, r.project_id, r.start_date, r.project_id, r.stop_date
                     );
         END LOOP;

--- a/internal/events/impl.go
+++ b/internal/events/impl.go
@@ -825,6 +825,12 @@ BEGIN
         ADD CONSTRAINT event_deliveries_event_id_fkey
             FOREIGN KEY (event_id) REFERENCES convoy.events_new (id);
 
+    -- The constraint above is the enforcement the trigger stood in for while
+    -- events was partitioned. Leaving the trigger installed would make every
+    -- delivery insert pay a second existence query, and would report a violation
+    -- through whichever of the two fires first.
+    DROP TRIGGER IF EXISTS event_fk_check ON convoy.event_deliveries;
+
     ALTER TABLE convoy.events RENAME TO events_old;
     ALTER TABLE convoy.events_new RENAME TO events;
     DROP TABLE IF EXISTS convoy.events_old;

--- a/internal/events/impl.go
+++ b/internal/events/impl.go
@@ -719,8 +719,10 @@ BEGIN
                'events_' || pg_catalog.UPPER(pg_catalog.REPLACE(project_id::TEXT, '-', '')) || '_' || pg_catalog.REPLACE(created_at::TEXT, '-', '') AS partition_table_name
         FROM dates
     LOOP
-        -- %I, not %s: an unquoted identifier folds to lower case, and retention
-        -- only adopts partitions whose name carries an upper-case tenant segment.
+        -- %I, not %s: an unquoted identifier folds to lower case. Retention names
+        -- the partitions it creates for later days with an upper-case tenant
+        -- segment, so folding here spells one table two ways. Adoption itself
+        -- tolerates either since gopartman v0.2.0.
         EXECUTE FORMAT(
             'CREATE TABLE IF NOT EXISTS convoy.%I PARTITION OF convoy.events_new FOR VALUES FROM (%L, %L) TO (%L, %L)',
             r.partition_table_name, r.project_id, r.start_date, r.project_id, r.stop_date
@@ -899,8 +901,10 @@ BEGIN
                'events_search_' || pg_catalog.UPPER(pg_catalog.REPLACE(project_id::TEXT, '-', '')) || '_' || pg_catalog.REPLACE(created_at::TEXT, '-', '') AS partition_table_name
         FROM dates
         LOOP
-            -- %I, not %s: an unquoted identifier folds to lower case, and retention
-            -- only adopts partitions whose name carries an upper-case tenant segment.
+            -- %I, not %s: an unquoted identifier folds to lower case. Retention
+            -- names the partitions it creates for later days with an upper-case
+            -- tenant segment, so folding here spells one table two ways. Adoption
+            -- itself tolerates either since gopartman v0.2.0.
             EXECUTE FORMAT(
                     'CREATE TABLE IF NOT EXISTS convoy.%I PARTITION OF convoy.events_search_new FOR VALUES FROM (%L, %L) TO (%L, %L)',
                     r.partition_table_name, r.project_id, r.start_date, r.project_id, r.stop_date

--- a/internal/events/impl_test.go
+++ b/internal/events/impl_test.go
@@ -1236,3 +1236,30 @@ func TestPartitionFunctions(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+// Both events tables must name their partitions so retention can adopt them.
+// See testenv.RequirePartitionsAddressableByRetention for why that is not
+// automatic.
+func TestPartitionEventsTablesNameForRetention(t *testing.T) {
+	service, db := setupTestDB(t)
+	ctx := context.Background()
+
+	project := seedTestProject(t, db)
+	endpoint := seedTestEndpoint(t, db, project.UID)
+	source := seedTestSource(t, db, project.UID)
+	require.NoError(t, service.CreateEvent(ctx, createTestEvent(t, project.UID, []string{endpoint.UID}, source.UID)))
+
+	require.NoError(t, service.PartitionEventsTable(ctx))
+	testenv.RequirePartitionsAddressableByRetention(t, db, "events", project.UID)
+
+	// The partition helpers only create children for days that already hold rows,
+	// and no application write path in this package populates events_search, so
+	// seed it directly rather than leaving the second naming site uncovered.
+	_, err := db.GetDB().ExecContext(ctx, `
+        INSERT INTO convoy.events_search (id, event_type, project_id, raw, data, url_path)
+        VALUES ($1, 'test.event', $2, '{}', '{}'::bytea, '/')`, ulid.Make().String(), project.UID)
+	require.NoError(t, err)
+
+	require.NoError(t, service.PartitionEventsSearchTable(ctx))
+	testenv.RequirePartitionsAddressableByRetention(t, db, "events_search", project.UID)
+}

--- a/internal/events/impl_test.go
+++ b/internal/events/impl_test.go
@@ -1240,6 +1240,41 @@ func TestPartitionFunctions(t *testing.T) {
 // Both events tables must name their partitions so retention can adopt them.
 // See testenv.RequirePartitionsAddressableByRetention for why that is not
 // automatic.
+// Unpartitioning events restores event_deliveries_event_id_fkey, which is the
+// enforcement event_fk_check stood in for while events was partitioned. The
+// trigger must go, or every delivery insert pays a second existence query and a
+// violation is reported by whichever of the two fires first.
+func TestUnPartitionEventsTableRemovesTheStandInTrigger(t *testing.T) {
+	service, db := setupTestDB(t)
+	ctx := context.Background()
+
+	project := seedTestProject(t, db)
+	endpoint := seedTestEndpoint(t, db, project.UID)
+	source := seedTestSource(t, db, project.UID)
+	require.NoError(t, service.CreateEvent(ctx, createTestEvent(t, project.UID, []string{endpoint.UID}, source.UID)))
+
+	require.NoError(t, service.PartitionEventsTable(ctx))
+	require.NoError(t, service.UnPartitionEventsTable(ctx))
+
+	var triggers int
+	require.NoError(t, db.GetDB().QueryRowContext(ctx, `
+        SELECT count(*)
+        FROM pg_catalog.pg_trigger t
+        JOIN pg_catalog.pg_class c ON c.oid = t.tgrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'convoy'
+          AND c.relname = 'event_deliveries'
+          AND t.tgname = 'event_fk_check'`).Scan(&triggers))
+	require.Zero(t, triggers, "event_fk_check outlived the constraint it stood in for")
+
+	var constraints int
+	require.NoError(t, db.GetDB().QueryRowContext(ctx, `
+        SELECT count(*)
+        FROM pg_catalog.pg_constraint
+        WHERE conname = 'event_deliveries_event_id_fkey'`).Scan(&constraints))
+	require.NotZero(t, constraints, "dropping the trigger left no event-id enforcement at all")
+}
+
 func TestPartitionEventsTablesNameForRetention(t *testing.T) {
 	service, db := setupTestDB(t)
 	ctx := context.Background()

--- a/internal/pkg/retention/retention.go
+++ b/internal/pkg/retention/retention.go
@@ -16,7 +16,7 @@ import (
 )
 
 // RetentionTables are the tables the partition retention policy manages.
-// They must be converted to partitioned parents (`convoy partition`) before
+// They must be converted to partitioned parents (`convoy utils partition`) before
 // retention can run.
 var RetentionTables = []string{"events", "events_search", "event_deliveries", "delivery_attempts"}
 
@@ -71,7 +71,7 @@ type Retentioner interface {
 
 // LicensedRetentionPolicy is installed when the license includes retention.
 // It re-reads partition state on Start, on a reconcile ticker, and on every
-// Perform so `convoy partition` can activate retention without a worker
+// Perform so `convoy utils partition` can activate retention without a worker
 // restart. Until all RetentionTables are partitioned parents it never
 // deletes; each skip logs the actionable error so the asynq job stays healthy.
 type LicensedRetentionPolicy struct {
@@ -143,7 +143,7 @@ func (l *LicensedRetentionPolicy) Perform(ctx context.Context) error {
 	l.mu.Unlock()
 
 	if inner == nil {
-		l.logger.Error(fmt.Sprintf("retention is licensed but skipped: tables are not partitioned: %v. Run `convoy partition`", missing))
+		l.logger.Error(fmt.Sprintf("retention is licensed but skipped: tables are not partitioned: %v. Run `convoy utils partition`", missing))
 		return nil
 	}
 	return inner.Perform(ctx)

--- a/internal/pkg/retention/retention.go
+++ b/internal/pkg/retention/retention.go
@@ -269,9 +269,46 @@ func (r *PartitionRetentionPolicy) registerParents(ctx context.Context) {
 		}
 
 		ref := partman.ParentRef{SchemaName: retentionSchema, TableName: table}
-		if _, err := r.manager.ImportExisting(ctx, ref); err != nil {
+		report, err := r.manager.ImportExisting(ctx, ref)
+		if err != nil {
 			r.logger.Errorf("failed to import existing partitions for convoy.%s: %v", table, err)
+			continue
 		}
+		r.logImportReport(table, report)
+	}
+}
+
+// logImportReport surfaces the outcome of ImportExisting. gopartman reports
+// drifted and skipped children without returning an error, and only adopted
+// partitions reach partman.partitions, so an unread report means retention can
+// silently manage nothing while the table keeps growing. Logged at error level
+// because every unadopted partition is one the nightly job will never drop.
+// Names are capped: a mismatch is usually systematic and affects every child.
+func (r *PartitionRetentionPolicy) logImportReport(table string, report partman.ReconcileReport) {
+	const maxNamed = 3
+
+	if len(report.Drifted) == 0 && len(report.Skipped) == 0 {
+		r.logger.Info(fmt.Sprintf("imported %d existing partitions for convoy.%s", len(report.Imported), table))
+		return
+	}
+
+	r.logger.Error(fmt.Sprintf(
+		"convoy.%s has partitions retention cannot drop: %d adopted, %d drifted, %d skipped",
+		table, len(report.Imported), len(report.Drifted), len(report.Skipped)))
+
+	for i, d := range report.Drifted {
+		if i == maxNamed {
+			r.logger.Errorf("... and %d more drifted partitions on convoy.%s", len(report.Drifted)-maxNamed, table)
+			break
+		}
+		r.logger.Errorf("drifted partition %s: %s", d.Name, d.Reason)
+	}
+	for i, s := range report.Skipped {
+		if i == maxNamed {
+			r.logger.Errorf("... and %d more skipped partitions on convoy.%s", len(report.Skipped)-maxNamed, table)
+			break
+		}
+		r.logger.Errorf("skipped partition %s: %s", s.Name, s.Reason)
 	}
 }
 

--- a/internal/pkg/retention/retention_test.go
+++ b/internal/pkg/retention/retention_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/frain-dev/convoy/config"
@@ -73,4 +75,77 @@ func TestUnpartitionedTables(t *testing.T) {
 	missing, err = UnpartitionedTables(ctx, db)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"event_deliveries", "delivery_attempts"}, missing)
+}
+
+// Partitioning a table is only half of enabling retention: gopartman still has
+// to adopt the existing children into partman.partitions, and it only adopts
+// the ones whose name it can parse. Adoption failures are reported rather than
+// returned as errors, so nothing fails loudly when this breaks. The observable
+// symptom is that retention runs forever and drops nothing, which is why this
+// asserts on partman's own bookkeeping rather than on the partition names.
+func TestRegisterParentsAdoptsExistingPartitions(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	projectID := seedProjectWithEvent(t, db)
+
+	eventsRepo := events.New(log.New("convoy", log.LevelInfo), db)
+	require.NoError(t, eventsRepo.PartitionEventsTable(ctx))
+
+	policy, err := NewPartitionRetentionPolicy(db, log.New("convoy", log.LevelInfo), 24*time.Hour)
+	require.NoError(t, err)
+
+	policy.registerParents(ctx)
+
+	var adopted int
+	require.NoError(t, db.GetDB().QueryRowContext(ctx, `
+        SELECT count(*)
+        FROM partman.partitions p
+        JOIN partman.parent_tables t ON t.id = p.parent_table_id
+        WHERE t.table_name = 'events' AND p.tenant_id = $1`, projectID).Scan(&adopted))
+
+	require.NotZero(t, adopted,
+		"retention adopted no partitions for convoy.events tenant %s, so it will never drop anything",
+		projectID)
+}
+
+// seedProjectWithEvent inserts the minimum chain convoy.events requires
+// (user, organisation, project configuration, project) plus one event, because
+// the partition helpers only create children for days that already hold rows.
+func seedProjectWithEvent(t *testing.T, db database.Database) string {
+	t.Helper()
+
+	ctx := context.Background()
+	userID := ulid.Make().String()
+	orgID := ulid.Make().String()
+	configID := ulid.Make().String()
+	projectID := ulid.Make().String()
+
+	_, err := db.GetDB().ExecContext(ctx, `
+        INSERT INTO convoy.users (id, first_name, last_name, email, password, email_verified)
+        VALUES ($1, 'retention', 'test', $2, 'x', true)`, userID, userID+"@example.com")
+	require.NoError(t, err)
+
+	_, err = db.GetDB().ExecContext(ctx, `
+        INSERT INTO convoy.organisations (id, name, owner_id) VALUES ($1, 'retention-test', $2)`, orgID, userID)
+	require.NoError(t, err)
+
+	_, err = db.GetDB().ExecContext(ctx, `
+        INSERT INTO convoy.project_configurations (
+            id, max_payload_read_size, replay_attacks_prevention_enabled,
+            ratelimit_count, ratelimit_duration, strategy_type, strategy_duration,
+            strategy_retry_count, signature_header, signature_versions)
+        VALUES ($1, 51200, false, 1000, 60, 'linear', 100, 10, 'X-Convoy-Signature', '[]'::jsonb)`, configID)
+	require.NoError(t, err)
+
+	_, err = db.GetDB().ExecContext(ctx, `
+        INSERT INTO convoy.projects (id, name, type, organisation_id, project_configuration_id)
+        VALUES ($1, 'retention-test', 'outgoing', $2, $3)`, projectID, orgID, configID)
+	require.NoError(t, err)
+
+	_, err = db.GetDB().ExecContext(ctx, `
+        INSERT INTO convoy.events (id, event_type, project_id, raw, data, url_path)
+        VALUES ($1, 'test.event', $2, '{}', '{}'::bytea, '/')`, ulid.Make().String(), projectID)
+	require.NoError(t, err)
+
+	return projectID
 }

--- a/internal/pkg/retention/retention_test.go
+++ b/internal/pkg/retention/retention_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,6 +107,62 @@ func TestRegisterParentsAdoptsExistingPartitions(t *testing.T) {
 	require.NotZero(t, adopted,
 		"retention adopted no partitions for convoy.events tenant %s, so it will never drop anything",
 		projectID)
+}
+
+// Instances partitioned before the naming fix carry children whose tenant
+// segment PostgreSQL folded to lower case. gopartman v0.2.0 parses a child name
+// against its parent instead of guessing where the tenant starts, so those names
+// are adopted as they are. This is what lets an existing instance heal on upgrade
+// rather than needing every partition renamed by hand, so it is asserted here and
+// not left as a property of the dependency.
+func TestRegisterParentsAdoptsFoldedPartitionNames(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	seedProjectWithEvent(t, db)
+
+	eventsRepo := events.New(log.New("convoy", log.LevelInfo), db)
+	require.NoError(t, eventsRepo.PartitionEventsTable(ctx))
+
+	// Reproduce the pre-fix state by folding a child's name back down.
+	var current string
+	require.NoError(t, db.GetDB().QueryRowContext(ctx, `
+        SELECT c.relname
+        FROM pg_catalog.pg_inherits i
+        JOIN pg_catalog.pg_class c ON c.oid = i.inhrelid
+        JOIN pg_catalog.pg_class p ON p.oid = i.inhparent
+        JOIN pg_catalog.pg_namespace n ON n.oid = p.relnamespace
+        WHERE n.nspname = 'convoy' AND p.relname = 'events'
+        ORDER BY c.relname
+        LIMIT 1`).Scan(&current))
+
+	folded := strings.ToLower(current)
+	require.NotEqual(t, current, folded, "partition name held no upper case, so this test proves nothing")
+
+	_, err := db.GetDB().ExecContext(ctx,
+		fmt.Sprintf(`ALTER TABLE convoy.%q RENAME TO %q`, current, folded))
+	require.NoError(t, err)
+
+	policy, err := NewPartitionRetentionPolicy(db, log.New("convoy", log.LevelInfo), 24*time.Hour)
+	require.NoError(t, err)
+
+	policy.registerParents(ctx)
+
+	// Metadata stores the schema-qualified name exactly as PostgreSQL holds it,
+	// so the recorded name must still resolve to a real relation: retention drops
+	// by this value, and a canonicalised copy would name a table that is not there.
+	var tenant string
+	require.NoError(t, db.GetDB().QueryRowContext(ctx, `
+        SELECT p.tenant_id
+        FROM partman.partitions p
+        JOIN partman.parent_tables t ON t.id = p.parent_table_id
+        WHERE t.table_name = 'events' AND p.name = $1`, "convoy."+folded).Scan(&tenant),
+		"convoy.%s was not adopted, so retention will never drop it and instances partitioned before the naming fix still need manual renames",
+		folded)
+
+	// Tenant identity comes from the partition bound, not the folded name, so one
+	// tenant keeps one form in metadata however its children happen to be spelled.
+	require.Equal(t, strings.ToUpper(tenant), tenant,
+		"tenant recorded as %q from a folded child name, so the same tenant now has two identities in metadata", tenant)
 }
 
 // seedProjectWithEvent inserts the minimum chain convoy.events requires

--- a/testenv/partitions.go
+++ b/testenv/partitions.go
@@ -1,0 +1,56 @@
+package testenv
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/frain-dev/convoy/database"
+)
+
+// RequirePartitionsAddressableByRetention asserts every child of convoy.<parent>
+// is named <parent>_<TENANT>_<YYYYMMDD>, with TENANT byte-identical to
+// tenantID.
+//
+// Retention adopts a partition only if it can parse the name back into a tenant
+// and a single day, and it requires the tenant segment to be upper-case
+// alphanumeric. Postgres folds unquoted identifiers to lower case, so partition
+// DDL has to both upper-case the tenant id and quote the resulting identifier.
+// Get either half wrong and the partitions are created outside retention's
+// view, so no history is ever dropped and the table grows without bound.
+//
+// This reads pg_class rather than the generated SQL because the folding happens
+// inside Postgres: the statement can look correct while the stored name is not.
+// It lives here so every partitioned table asserts the same contract.
+func RequirePartitionsAddressableByRetention(t *testing.T, db database.Database, parent, tenantID string) {
+	t.Helper()
+
+	rows, err := db.GetDB().QueryContext(context.Background(), `
+        SELECT c.relname
+        FROM pg_class c
+        JOIN pg_inherits i ON i.inhrelid = c.oid
+        JOIN pg_class p ON p.oid = i.inhparent
+        JOIN pg_namespace n ON n.oid = p.relnamespace
+        WHERE n.nspname = 'convoy' AND p.relname = $1`, parent)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	wantPrefix := fmt.Sprintf("%s_%s_", parent, strings.ToUpper(strings.ReplaceAll(tenantID, "-", "")))
+
+	var found int
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		found++
+		require.True(t, strings.HasPrefix(name, wantPrefix),
+			"partition %q is not addressable by retention, want prefix %q", name, wantPrefix)
+	}
+	require.NoError(t, rows.Err())
+
+	// A partition helper only creates children for days that already hold rows,
+	// so an empty parent would vacuously pass every assertion above.
+	require.NotZero(t, found, "convoy.%s has no partitions", parent)
+}

--- a/testenv/partitions.go
+++ b/testenv/partitions.go
@@ -16,11 +16,15 @@ import (
 // tenantID.
 //
 // Retention adopts a partition only if it can parse the name back into a tenant
-// and a single day, and it requires the tenant segment to be upper-case
-// alphanumeric. Postgres folds unquoted identifiers to lower case, so partition
-// DDL has to both upper-case the tenant id and quote the resulting identifier.
-// Get either half wrong and the partitions are created outside retention's
-// view, so no history is ever dropped and the table grows without bound.
+// and a single day, and it builds the partitions it creates for later days with
+// an upper-case tenant segment. Postgres folds unquoted identifiers to lower
+// case, so partition DDL has to both upper-case the tenant id and quote the
+// resulting identifier, or one table ends up spelled two ways.
+//
+// gopartman v0.2.0 adopts a folded name too, which is what lets an instance
+// partitioned before that fix heal on upgrade rather than needing every child
+// renamed. This asserts the name we mean to write, not the widest name adoption
+// happens to accept.
 //
 // This reads pg_class rather than the generated SQL because the folding happens
 // inside Postgres: the statement can look correct while the stored name is not.


### PR DESCRIPTION
## Summary

Two silent defects in the partition path, plus the dependency bump that lets an already-partitioned instance heal instead of needing manual repair.

### Retention managed none of the partitions the copy path created

The DDL interpolated child names with `%s`, so Postgres folded the identifier to lower case. Retention parses a partition name back into a tenant and a single day and required the tenant segment to be upper-case alphanumeric, so it read an empty tenant, reported every child as drifted, and wrote no metadata row. `Maintain` only drops what that metadata lists, so retention ran on schedule and dropped nothing while the tables kept growing. The fix upper-cases the tenant segment and switches to `%I` across all four partitioned tables.

Convoy also discarded the `ImportExisting` report, which returns drift as a value rather than an error. A table whose partitions retention could not manage was indistinguishable from a healthy one, and the only visible symptom was disk that never came back. The counts are now logged, at error level whenever anything went unadopted.

The skip log told operators to run `convoy partition`, which exits with an unknown-command error because the command is registered under the `utils` parent. It now names `convoy utils partition`.

### Partitioning event deliveries left the table with no event-id enforcement

`event_deliveries_new` declares `event_id` with no references clause, because a foreign key cannot reference a partitioned `events`. Enforcement therefore lives in the `event_fk_check` trigger that `partition_events_table()` installs, and rebuilding `event_deliveries` takes that trigger with it. The rebuilt table ended up with no event-id enforcement at all.

Both partition commands are individually reachable and the correct form differs by order, so the fix restores whichever form fits the current state of `convoy.events`: the trigger when it is partitioned, the original constraint when it is not. Recreating the trigger unconditionally is not an option, since `convoy.enforce_event_fk()` is defined only inside the events partition path and would be missing on an instance whose events table is untouched.

The unpartition path had the mirror of this in both directions. Unpartitioning deliveries restored neither form, reopening the same hole. Unpartitioning events restored the constraint but never dropped the trigger that stood in for it, so an unpartitioned instance carried both and every delivery insert paid a redundant existence query.

### gopartman v0.2.0

v0.1.0 guessed where a child name's tenant segment started by looking for an upper-case run, so it read no tenant from a folded name and adopted nothing. v0.2.0 parses the name against its parent, so the tenant is found whatever its case. This is what lets an instance partitioned before the naming fix heal on upgrade; without it the remediation is renaming every existing partition by hand, under a lock, on live tables.

`UPPER` and `%I` stay in the DDL for the reason that is still true: gopartman names the partitions it creates for later days in upper case, so folding here would spell one table two ways.

## Operator-visible behaviour change

On a licensed instance whose partitions were previously unadopted, retention starts dropping history it had been keeping by accident. `CONVOY_RETENTION_POLICY` is worth confirming before upgrading.

## Test plan

```
go test ./internal/pkg/retention/ ./internal/event_deliveries/ ./internal/events/
```

Ten tests, each of which fails when its own fix is reverted.

- Naming tests read `pg_class` rather than the generated SQL, because the folding happens inside Postgres: the statement can look correct while the stored name is not.
- Enforcement tests assert behaviour rather than catalog contents. A delivery naming a nonexistent event must be rejected and a valid one must still be accepted, so a mechanism that rejects everything cannot pass them. Both partition orders are covered, and the unpartitioned-events case is what showed the gap is wider than the events-first order.
- The adoption test reproduces a pre-fix instance by folding a child's name back down after partitioning, then requires adoption. It fails on v0.1.0 and passes on v0.2.0, so it guards the dependency contract rather than restating it. It also pins that metadata keeps Postgres's actual spelling, since retention drops by that value, and that `tenant_id` still comes from the partition bound so one tenant keeps one identity however its children are spelled.