### PR TITLE
docs(release): add the 26.7.2 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Convoy Changes
 
+## 26.7.2
+
+### Breaking Changes
+
+- Partition retention now manages the partitions `convoy utils partition` creates, which it previously ignored because their names were folded to lower case. On a licensed instance, history kept only because those partitions were unmanaged is dropped at `CONVOY_RETENTION_POLICY` on the next maintenance run. Confirm that duration before upgrading (#2781)
+
+### Bug Fixes
+
+- fix(dataplane): correct partition naming, retention adoption and event-id enforcement (#2781)
+
 ## 26.7.1
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - fix(dataplane): correct partition naming, retention adoption and event-id enforcement (#2781)
+- fix(controlplane): fit transactional emails to mobile and move the footer inside the card (#2783)
 
 ## 26.7.1
 


### PR DESCRIPTION
## Summary

`tag-stable-release.yml`, which is how the recent tags were actually cut, does not run `git-cliff`. Only `monthly-release-pr.yml` does. So a tag cut that way lands with no changelog entry, and `CHANGELOG.md` currently stops at `26.7.1`. This writes the `26.7.2` section by hand ahead of the tag.

The retention change from #2781 is filed under Breaking Changes rather than folded into the bug-fix line. The partitions retention starts managing are ones an upgrading instance already has, so history that survived only because those partitions were unmanaged is dropped on the next maintenance run. An operator who never set `CONVOY_RETENTION_POLICY` gets the 720h default applied to data they believed was retained indefinitely. The changelog is where they would look for that, so it needs to be the first thing in the entry rather than an implication of the fix.

## Test plan

Documentation only, no code paths touched. `26.7.2` matches what `scripts/calver.sh 26 7` reports as the next patch for the line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `CHANGELOG.md` is modified; no runtime or deployment behavior changes in this PR.
> 
> **Overview**
> **Documentation-only:** extends `CHANGELOG.md` with a new **26.7.2** block (the file previously stopped at **26.7.1**) because releases tagged via `tag-stable-release.yml` do not run `git-cliff`.
> 
> The entry documents shipped work from #2781 and #2783:
> 
> - **Breaking change:** partition retention now applies to partitions created by `convoy utils partition`, which were previously skipped when names were lower-cased. On licensed instances, data that only persisted because those partitions were unmanaged can be purged on the next maintenance run according to `CONVOY_RETENTION_POLICY` (default 720h if unset).
> - **Bug fixes:** dataplane partition naming, retention adoption, and event-id enforcement (#2781); controlplane transactional email mobile layout and footer placement (#2783).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8543251bc2c5d6848735add02d6a71e539b1727. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->