### PR TITLE
fix(controlplane): fit transactional emails to mobile and move the footer inside the card

### DIFF
--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -66,6 +66,16 @@ var templateFuncs = template.FuncMap{
 	"currentYear": func() int {
 		return time.Now().Year()
 	},
+
+	// Outlook ignores max-width, so the fluid shell needs a fixed-width ghost
+	// table to keep its 656px column. html/template strips comments out of
+	// template source, so the conditionals have to be emitted at render time.
+	"outlookShellOpen": func() template.HTML {
+		return `<!--[if mso]><table role="presentation" width="656" cellpadding="0" cellspacing="0" border="0" align="center"><tr><td width="656"><![endif]-->`
+	},
+	"outlookShellClose": func() template.HTML {
+		return `<!--[if mso]></td></tr></table><![endif]-->`
+	},
 }
 
 // TODO(subomi): glob pattern must not match more than one template

--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -62,16 +63,16 @@ func Test_Build(t *testing.T) {
 	}
 }
 
-func Test_Build_FooterRendersCurrentYear(t *testing.T) {
-	templates := []string{
-		"user.verify.email.html",
-		"reset.password.html",
-		"organisation.invite.html",
-		"endpoint.update.html",
-		"twitter.source.html",
-	}
+var emailTemplates = []string{
+	"user.verify.email.html",
+	"reset.password.html",
+	"organisation.invite.html",
+	"endpoint.update.html",
+	"twitter.source.html",
+}
 
-	params := map[string]string{
+func emailParams() map[string]string {
+	return map[string]string{
 		"recipient_name":         "Jon",
 		"email":                  "jon@example.com",
 		"email_verification_url": "https://example.com/verify",
@@ -87,14 +88,16 @@ func Test_Build_FooterRendersCurrentYear(t *testing.T) {
 		"source_name":            "twitter-source",
 		"crc_verified_at":        "2026-01-01",
 	}
+}
 
-	for _, glob := range templates {
+func Test_Build_FooterRendersCurrentYear(t *testing.T) {
+	for _, glob := range emailTemplates {
 		t.Run(glob, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
 			e := NewEmail(buildClient(ctrl))
-			require.NoError(t, e.Build(glob, params))
+			require.NoError(t, e.Build(glob, emailParams()))
 
 			body := e.body.String()
 			require.Contains(t, body, fmt.Sprintf("© %d Frain Technologies", time.Now().Year()))
@@ -104,6 +107,39 @@ func Test_Build_FooterRendersCurrentYear(t *testing.T) {
 			require.Contains(t, body, "https://www.getconvoy.io/images/email/email-logo-white.png")
 			require.Contains(t, body, "https://www.getconvoy.io/images/email/email-dots-left.png")
 			require.Contains(t, body, "https://www.getconvoy.io/images/email/email-dots-right.png")
+		})
+	}
+}
+
+var msoConditional = regexp.MustCompile(`(?s)<!--\[if [^\]]*]>.*?<!\[endif]-->`)
+
+// Gmail's Android app drops max-width on tables and honours the HTML width
+// attribute instead, so a fixed pixel width there overflows the viewport and
+// the message gets clipped. Everything outside the MSO conditionals has to stay
+// fluid; Outlook keeps a fixed width through the ghost table inside them.
+func Test_Build_LayoutIsFluid(t *testing.T) {
+	for _, glob := range emailTemplates {
+		t.Run(glob, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			e := NewEmail(buildClient(ctrl))
+			require.NoError(t, e.Build(glob, emailParams()))
+
+			body := e.body.String()
+			fluid := msoConditional.ReplaceAllString(body, "")
+			require.NotContains(t, fluid, `width="656"`)
+			require.NotContains(t, fluid, `width="582"`)
+			require.NotContains(t, fluid, `style="width: 656px`)
+			require.NotContains(t, fluid, `style="width: 582px`)
+			require.Contains(t, fluid, "max-width: 656px")
+			require.Contains(t, fluid, "@media only screen and (max-width: 600px)")
+			require.Contains(t, fluid, `class="gutter"`)
+			require.Contains(t, fluid, `class="card-pad"`)
+
+			// Outlook ignores max-width, so it needs the ghost table to hold the
+			// 656px column its VML header band is cut for.
+			require.Contains(t, body, `<table role="presentation" width="656"`)
 		})
 	}
 }

--- a/internal/email/email_test.go
+++ b/internal/email/email_test.go
@@ -100,8 +100,14 @@ func Test_Build_FooterRendersCurrentYear(t *testing.T) {
 			require.NoError(t, e.Build(glob, emailParams()))
 
 			body := e.body.String()
-			require.Contains(t, body, fmt.Sprintf("© %d Frain Technologies", time.Now().Year()))
+			require.Contains(t, body, fmt.Sprintf(
+				"© %d Frain Technologies | 2261 Market Street, San Francisco, CA 94114",
+				time.Now().Year()))
 			require.NotContains(t, body, "© 2024")
+			// The footer sits inside the card on the same layer as the copy, in a
+			// lighter grey than the body text.
+			require.Contains(t, body, `class="card-foot"`)
+			require.Contains(t, body, "color: #9B9B9B")
 			require.Contains(t, body, "#0082F9")
 			require.Contains(t, body, "#F7F7F7")
 			require.Contains(t, body, "https://www.getconvoy.io/images/email/email-logo-white.png")

--- a/internal/email/templates/_layout.html
+++ b/internal/email/templates/_layout.html
@@ -14,7 +14,10 @@
             padding-right: 16px !important;
         }
         .card-pad {
-            padding: 24px 20px !important;
+            padding: 24px 20px 16px 20px !important;
+        }
+        .card-foot {
+            padding: 0 20px 24px 20px !important;
         }
     }
 </style>
@@ -62,12 +65,9 @@
 
 {{define "email_footer"}}
 <tr>
-    <td class="gutter" style="padding: 24px 37px 36px 37px; background-color: #ffffff; text-align: center;">
-        <p style="margin: 0; font-family: 'Inter', Arial, sans-serif; font-weight: 400; font-size: 12px; line-height: 22px; color: #46586B;">
-            2261 Market Street, San Francisco, CA 94114
-        </p>
-        <p style="margin: 8px 0 0 0; font-family: 'Inter', Arial, sans-serif; font-weight: 400; font-size: 12px; line-height: 22px; color: #46586B;">
-            © {{ currentYear }} Frain Technologies
+    <td class="card-foot" style="padding: 0 32px 32px 32px; background-color: #F7F7F7;">
+        <p style="margin: 0; font-family: 'Inter', Arial, sans-serif; font-weight: 400; font-size: 11px; line-height: 22px; color: #9B9B9B;">
+            © {{ currentYear }} Frain Technologies | 2261 Market Street, San Francisco, CA 94114
         </p>
     </td>
 </tr>

--- a/internal/email/templates/_layout.html
+++ b/internal/email/templates/_layout.html
@@ -1,10 +1,32 @@
+{{define "email_styles"}}
+<style>
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+    body, table, td, p, a, li {
+        font-family: 'Inter', Arial, sans-serif;
+    }
+
+    /* The desktop gutters are wider than a phone can spare: 37px each side
+       leaves 286px of a 360px screen. Clients that drop this block still lay
+       out correctly, because every table here is fluid. */
+    @media only screen and (max-width: 600px) {
+        .gutter {
+            padding-left: 16px !important;
+            padding-right: 16px !important;
+        }
+        .card-pad {
+            padding: 24px 20px !important;
+        }
+    }
+</style>
+{{end}}
+
 {{define "email_header"}}
 <tr>
     <td style="padding: 0; background-color: #ffffff;">
-        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border: none; border-spacing: 0;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; border: none; border-spacing: 0;">
             <tr>
-                <td align="center" style="padding: 36px 37px 0 37px;">
-                    <table role="presentation" width="582" cellpadding="0" cellspacing="0" style="width: 582px; max-width: 100%; border: none; border-spacing: 0;">
+                <td align="center" class="gutter" style="padding: 36px 37px 0 37px;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; border: none; border-spacing: 0;">
                         <tr>
                             <td background="https://www.getconvoy.io/images/email/email-dots-left.png" bgcolor="#0082F9" valign="middle" align="center" style="
                                     height: 134px;
@@ -23,7 +45,7 @@
                                      alt="Convoy"
                                      width="216"
                                      height="44"
-                                     style="display: block; margin: 0 auto; border: 0; height: 44px; width: 216px;">
+                                     style="display: block; margin: 0 auto; border: 0; height: 44px; width: 216px; max-width: 100%;">
                                 <!--[if gte mso 9]>
                                     </v:textbox>
                                 </v:rect>
@@ -40,7 +62,7 @@
 
 {{define "email_footer"}}
 <tr>
-    <td style="padding: 24px 37px 36px 37px; background-color: #ffffff; text-align: center;">
+    <td class="gutter" style="padding: 24px 37px 36px 37px; background-color: #ffffff; text-align: center;">
         <p style="margin: 0; font-family: 'Inter', Arial, sans-serif; font-weight: 400; font-size: 12px; line-height: 22px; color: #46586B;">
             2261 Market Street, San Francisco, CA 94114
         </p>

--- a/internal/email/templates/endpoint.update.html
+++ b/internal/email/templates/endpoint.update.html
@@ -15,24 +15,20 @@
         </xml>
     </noscript>
     <![endif]-->
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
-        body, table, td, p, a, li {
-            font-family: 'Inter', Arial, sans-serif;
-        }
-    </style>
+    {{template "email_styles" .}}
 </head>
 <body style="margin: 0; padding: 0; background-color: #FFFFFF;">
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border: none; border-spacing: 0; background-color: #FFFFFF;">
     <tr>
         <td align="center">
-            <table role="presentation" width="656" cellpadding="0" cellspacing="0" style="width: 656px; max-width: 100%; border: none; border-spacing: 0; background-color: #FFFFFF;">
+            {{ outlookShellOpen }}
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; max-width: 656px; border: none; border-spacing: 0; background-color: #FFFFFF;">
                 {{template "email_header" .}}
                 <tr>
-                    <td style="padding: 0 37px; background-color: #FFFFFF;">
-                        <table role="presentation" width="582" cellpadding="0" cellspacing="0" style="width: 582px; max-width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
+                    <td class="gutter" style="padding: 0 37px; background-color: #FFFFFF;">
+                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
                             <tr>
-                                <td style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
+                                <td class="card-pad" style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
                                     <p style="margin: 0 0 14px 0; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
                                         Endpoint Status Update
                                     </p>
@@ -87,6 +83,7 @@
                 </tr>
                 {{template "email_footer" .}}
             </table>
+            {{ outlookShellClose }}
         </td>
     </tr>
 </table>

--- a/internal/email/templates/endpoint.update.html
+++ b/internal/email/templates/endpoint.update.html
@@ -28,7 +28,7 @@
                     <td class="gutter" style="padding: 0 37px; background-color: #FFFFFF;">
                         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
                             <tr>
-                                <td class="card-pad" style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
+                                <td class="card-pad" style="padding: 40px 32px 20px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
                                     <p style="margin: 0 0 14px 0; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
                                         Endpoint Status Update
                                     </p>
@@ -78,10 +78,10 @@
                                     {{end}}
                                 </td>
                             </tr>
+                            {{template "email_footer" .}}
                         </table>
                     </td>
                 </tr>
-                {{template "email_footer" .}}
             </table>
             {{ outlookShellClose }}
         </td>

--- a/internal/email/templates/organisation.invite.html
+++ b/internal/email/templates/organisation.invite.html
@@ -15,24 +15,20 @@
         </xml>
     </noscript>
     <![endif]-->
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
-        body, table, td, p, a {
-            font-family: 'Inter', Arial, sans-serif;
-        }
-    </style>
+    {{template "email_styles" .}}
 </head>
 <body style="margin: 0; padding: 0; background-color: #FFFFFF;">
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border: none; border-spacing: 0; background-color: #FFFFFF;">
     <tr>
         <td align="center">
-            <table role="presentation" width="656" cellpadding="0" cellspacing="0" style="width: 656px; max-width: 100%; border: none; border-spacing: 0; background-color: #FFFFFF;">
+            {{ outlookShellOpen }}
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; max-width: 656px; border: none; border-spacing: 0; background-color: #FFFFFF;">
                 {{template "email_header" .}}
                 <tr>
-                    <td style="padding: 0 37px; background-color: #FFFFFF;">
-                        <table role="presentation" width="582" cellpadding="0" cellspacing="0" style="width: 582px; max-width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
+                    <td class="gutter" style="padding: 0 37px; background-color: #FFFFFF;">
+                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
                             <tr>
-                                <td style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
+                                <td class="card-pad" style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
                                     <p style="margin: 0 0 14px 0; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
                                         Hi there,
                                     </p>
@@ -76,6 +72,7 @@
                 </tr>
                 {{template "email_footer" .}}
             </table>
+            {{ outlookShellClose }}
         </td>
     </tr>
 </table>

--- a/internal/email/templates/organisation.invite.html
+++ b/internal/email/templates/organisation.invite.html
@@ -28,7 +28,7 @@
                     <td class="gutter" style="padding: 0 37px; background-color: #FFFFFF;">
                         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
                             <tr>
-                                <td class="card-pad" style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
+                                <td class="card-pad" style="padding: 40px 32px 20px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
                                     <p style="margin: 0 0 14px 0; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
                                         Hi there,
                                     </p>
@@ -67,10 +67,10 @@
                                     </p>
                                 </td>
                             </tr>
+                            {{template "email_footer" .}}
                         </table>
                     </td>
                 </tr>
-                {{template "email_footer" .}}
             </table>
             {{ outlookShellClose }}
         </td>

--- a/internal/email/templates/reset.password.html
+++ b/internal/email/templates/reset.password.html
@@ -28,7 +28,7 @@
                     <td class="gutter" style="padding: 0 37px; background-color: #FFFFFF;">
                         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
                             <tr>
-                                <td class="card-pad" style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
+                                <td class="card-pad" style="padding: 40px 32px 20px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
                                     <p style="margin: 0 0 14px 0; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
                                         Reset your password
                                     </p>
@@ -70,10 +70,10 @@
                                     </p>
                                 </td>
                             </tr>
+                            {{template "email_footer" .}}
                         </table>
                     </td>
                 </tr>
-                {{template "email_footer" .}}
             </table>
             {{ outlookShellClose }}
         </td>

--- a/internal/email/templates/reset.password.html
+++ b/internal/email/templates/reset.password.html
@@ -15,24 +15,20 @@
         </xml>
     </noscript>
     <![endif]-->
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
-        body, table, td, p, a {
-            font-family: 'Inter', Arial, sans-serif;
-        }
-    </style>
+    {{template "email_styles" .}}
 </head>
 <body style="margin: 0; padding: 0; background-color: #FFFFFF;">
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border: none; border-spacing: 0; background-color: #FFFFFF;">
     <tr>
         <td align="center">
-            <table role="presentation" width="656" cellpadding="0" cellspacing="0" style="width: 656px; max-width: 100%; border: none; border-spacing: 0; background-color: #FFFFFF;">
+            {{ outlookShellOpen }}
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; max-width: 656px; border: none; border-spacing: 0; background-color: #FFFFFF;">
                 {{template "email_header" .}}
                 <tr>
-                    <td style="padding: 0 37px; background-color: #FFFFFF;">
-                        <table role="presentation" width="582" cellpadding="0" cellspacing="0" style="width: 582px; max-width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
+                    <td class="gutter" style="padding: 0 37px; background-color: #FFFFFF;">
+                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
                             <tr>
-                                <td style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
+                                <td class="card-pad" style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
                                     <p style="margin: 0 0 14px 0; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
                                         Reset your password
                                     </p>
@@ -79,6 +75,7 @@
                 </tr>
                 {{template "email_footer" .}}
             </table>
+            {{ outlookShellClose }}
         </td>
     </tr>
 </table>

--- a/internal/email/templates/twitter.source.html
+++ b/internal/email/templates/twitter.source.html
@@ -15,24 +15,20 @@
         </xml>
     </noscript>
     <![endif]-->
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
-        body, table, td, p, a {
-            font-family: 'Inter', Arial, sans-serif;
-        }
-    </style>
+    {{template "email_styles" .}}
 </head>
 <body style="margin: 0; padding: 0; background-color: #FFFFFF;">
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border: none; border-spacing: 0; background-color: #FFFFFF;">
     <tr>
         <td align="center">
-            <table role="presentation" width="656" cellpadding="0" cellspacing="0" style="width: 656px; max-width: 100%; border: none; border-spacing: 0; background-color: #FFFFFF;">
+            {{ outlookShellOpen }}
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; max-width: 656px; border: none; border-spacing: 0; background-color: #FFFFFF;">
                 {{template "email_header" .}}
                 <tr>
-                    <td style="padding: 0 37px; background-color: #FFFFFF;">
-                        <table role="presentation" width="582" cellpadding="0" cellspacing="0" style="width: 582px; max-width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
+                    <td class="gutter" style="padding: 0 37px; background-color: #FFFFFF;">
+                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
                             <tr>
-                                <td style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
+                                <td class="card-pad" style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
                                     <p style="margin: 0 0 14px 0; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
                                         Hi there,
                                     </p>
@@ -52,6 +48,7 @@
                 </tr>
                 {{template "email_footer" .}}
             </table>
+            {{ outlookShellClose }}
         </td>
     </tr>
 </table>

--- a/internal/email/templates/twitter.source.html
+++ b/internal/email/templates/twitter.source.html
@@ -28,7 +28,7 @@
                     <td class="gutter" style="padding: 0 37px; background-color: #FFFFFF;">
                         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
                             <tr>
-                                <td class="card-pad" style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
+                                <td class="card-pad" style="padding: 40px 32px 20px 32px; font-family: 'Inter', Arial, sans-serif; font-size: 14px; line-height: 22px; color: #46586B;">
                                     <p style="margin: 0 0 14px 0; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
                                         Hi there,
                                     </p>
@@ -43,10 +43,10 @@
                                     </p>
                                 </td>
                             </tr>
+                            {{template "email_footer" .}}
                         </table>
                     </td>
                 </tr>
-                {{template "email_footer" .}}
             </table>
             {{ outlookShellClose }}
         </td>

--- a/internal/email/templates/user.verify.email.html
+++ b/internal/email/templates/user.verify.email.html
@@ -15,24 +15,20 @@
         </xml>
     </noscript>
     <![endif]-->
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
-        body, table, td, p, a {
-            font-family: 'Inter', Arial, sans-serif;
-        }
-    </style>
+    {{template "email_styles" .}}
 </head>
 <body style="margin: 0; padding: 0; background-color: #FFFFFF;">
 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border: none; border-spacing: 0; background-color: #FFFFFF;">
     <tr>
         <td align="center">
-            <table role="presentation" width="656" cellpadding="0" cellspacing="0" style="width: 656px; max-width: 100%; border: none; border-spacing: 0; background-color: #FFFFFF;">
+            {{ outlookShellOpen }}
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; max-width: 656px; border: none; border-spacing: 0; background-color: #FFFFFF;">
                 {{template "email_header" .}}
                 <tr>
-                    <td style="padding: 0 37px; background-color: #FFFFFF;">
-                        <table role="presentation" width="582" cellpadding="0" cellspacing="0" style="width: 582px; max-width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
+                    <td class="gutter" style="padding: 0 37px; background-color: #FFFFFF;">
+                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
                             <tr>
-                                <td style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
+                                <td class="card-pad" style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
                                     <p style="margin: 0 0 14px 0; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
                                         Hi {{ .recipient_name }},
                                     </p>
@@ -73,6 +69,7 @@
                 </tr>
                 {{template "email_footer" .}}
             </table>
+            {{ outlookShellClose }}
         </td>
     </tr>
 </table>

--- a/internal/email/templates/user.verify.email.html
+++ b/internal/email/templates/user.verify.email.html
@@ -28,7 +28,7 @@
                     <td class="gutter" style="padding: 0 37px; background-color: #FFFFFF;">
                         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; border: none; border-spacing: 0; background-color: #F7F7F7;">
                             <tr>
-                                <td class="card-pad" style="padding: 40px 32px; font-family: 'Inter', Arial, sans-serif; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
+                                <td class="card-pad" style="padding: 40px 32px 20px 32px; font-family: 'Inter', Arial, sans-serif; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
                                     <p style="margin: 0 0 14px 0; font-weight: 600; font-size: 14px; line-height: 22px; color: #46586B;">
                                         Hi {{ .recipient_name }},
                                     </p>
@@ -64,10 +64,10 @@
                                     </p>
                                 </td>
                             </tr>
+                            {{template "email_footer" .}}
                         </table>
                     </td>
                 </tr>
-                {{template "email_footer" .}}
             </table>
             {{ outlookShellClose }}
         </td>


### PR DESCRIPTION
## Summary

The redesigned transactional emails clip on mobile: the header logo is cut
mid-word, body copy mid-sentence, and the footer address is truncated.

The shell and card tables carried fixed `656px` and `582px` widths, with
`max-width: 100%` as the only concession to narrow screens. A phone viewport
cannot honour 656px, so the message overflows and the client clips it. Any
client that does not apply `max-width` to tables falls straight through to the
pixel width, which is why this is invisible in a browser.

Every table is now fluid with a `max-width: 656px` desktop cap, so the layout
fits whatever width the client gives it. Gutters drop from 37px to 16px under
600px, which a 360px screen needs.

Two details worth flagging for review:

- Outlook ignores `max-width`, so fluid alone would stretch the email across a
  wide reading pane. It keeps the fixed 656px column through an MSO ghost table.
- `html/template` strips comments out of template source, so `<!--[if mso]>`
  blocks written in a template never reach the wire. The ghost table is emitted
  at render time from `outlookShellOpen` / `outlookShellClose` instead. Those
  return constant markup and take no arguments, so nothing user-supplied can
  reach `template.HTML`.

The five per-template `<style>` blocks were identical, so they now share one
`email_styles` define in the layout.

Pre-existing, not changed here: the VML header rect in `_layout.html` is subject
to the same comment stripping, so the Outlook dot pattern has never rendered.
Left alone rather than revived or deleted in this change.

## Test plan

- `go test ./internal/email/...` covers all five templates: no fixed widths
  outside the MSO conditionals, the responsive block and gutter classes present,
  and the ghost table present in the rendered output.
- Rendered each template at a 390px viewport against a `max-width`-stripped
  copy, confirming the header, body and footer all fit.
- Measured desktop rendering before and after: `656 / 656 / 582 / 582` table
  widths and identical body height, so desktop is unchanged.
- `golangci-lint run ./internal/email/...` clean.

## Footer placement

The approved design puts the address and copyright on the same layer as the
email copy, in a lighter grey, as one line. They were below the card on white
and centred, which reads as detached from the message.

The footer is now the last row of the card table, left aligned to the copy's
inset, 11px in `#9B9B9B`, reading
`© <year> Frain Technologies | 2261 Market Street, San Francisco, CA 94114`.
The body's bottom padding drops to 20px so the gap above it matches the design.

Verified at desktop and 390px; the responsive block gives the footer row its own
reduced padding so it stays inside the card on narrow screens.