### PR TITLE
fix(dataplane): drop leftover pk after copy unpartition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@
 - fix(dataplane): correct partition naming, retention adoption and event-id enforcement (#2781)
 - fix(controlplane): fit transactional emails to mobile and move the footer inside the card (#2783)
 - fix(controlplane): load endpoint failure rates after the list (#2785)
-- fix(dataplane): drop leftover primary key when attaching after a copy unpartition
-- fix(dashboard): keep instance admins on admin after a full reload
-- fix(dashboard): start the partition operation the selected table allows
+- fix(dataplane): drop leftover primary key when attaching after a copy unpartition (#2786)
+- fix(dashboard): keep instance admins on admin after a full reload (#2786)
+- fix(dashboard): start the partition operation the selected table allows (#2786)
 
 ## 26.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - fix(dataplane): correct partition naming, retention adoption and event-id enforcement (#2781)
 - fix(controlplane): fit transactional emails to mobile and move the footer inside the card (#2783)
 - fix(controlplane): load endpoint failure rates after the list (#2785)
+- fix(dataplane): drop leftover primary key when attaching after a copy unpartition
+- fix(dashboard): keep instance admins on admin after a full reload
+- fix(dashboard): start the partition operation the selected table allows
 
 ## 26.7.1
 

--- a/internal/events/impl_test.go
+++ b/internal/events/impl_test.go
@@ -1257,6 +1257,34 @@ func TestPartitionEventsSearchTableAdoptsTheExistingTable(t *testing.T) {
 	require.Equal(t, original, adopted, "the adopted partition has a different relfilenode, so the table was rewritten, not attached")
 }
 
+// Copy-unpartition creates events_search_new with PRIMARY KEY, then renames the
+// table. RENAME TABLE keeps the constraint name, so the heap's PK is
+// events_search_new_pkey. Swap used to drop only events_search_pkey and then
+// failed with "multiple primary keys for table events_search_default".
+func TestPartitionEventsSearchTableDropsCopyUnpartitionPrimaryKey(t *testing.T) {
+	service, db := setupTestDB(t)
+	ctx := context.Background()
+
+	var current string
+	require.NoError(t, db.GetDB().QueryRowContext(ctx, `
+        SELECT con.conname
+        FROM pg_constraint con
+        JOIN pg_class c ON c.oid = con.conrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'convoy' AND c.relname = 'events_search' AND con.contype = 'p'`).Scan(&current))
+
+	_, err := db.GetDB().ExecContext(ctx, `ALTER TABLE convoy.events_search RENAME CONSTRAINT `+current+` TO events_search_new_pkey`)
+	require.NoError(t, err)
+
+	require.NoError(t, service.PartitionEventsSearchTable(ctx))
+
+	var kind string
+	require.NoError(t, db.GetDB().QueryRowContext(ctx, `
+        SELECT c.relkind FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'convoy' AND c.relname = 'events_search'`).Scan(&kind))
+	require.Equal(t, "p", kind, "attach after a copy-unpartition PK name should still convert")
+}
+
 func TestPartitionFunctions(t *testing.T) {
 	service, _ := setupTestDB(t)
 	ctx := context.Background()

--- a/internal/pkg/attach/convert.go
+++ b/internal/pkg/attach/convert.go
@@ -269,8 +269,7 @@ func swap(ctx context.Context, db *pgxpool.Pool, spec Spec) error {
 	}, spec.Swap...)
 
 	statements = append(statements,
-		fmt.Sprintf(`ALTER TABLE convoy.%s DROP CONSTRAINT IF EXISTS %s`,
-			quoteIdent(spec.defaultName()), quoteIdent(spec.Table+"_pkey")),
+		dropExistingPrimaryKeySQL(spec.defaultName()),
 		fmt.Sprintf(`ALTER TABLE convoy.%s ADD CONSTRAINT %s PRIMARY KEY USING INDEX %s`,
 			quoteIdent(spec.defaultName()), quoteIdent(spec.defaultName()+"_pkey"), quoteIdent(spec.pkIndex())),
 		fmt.Sprintf(`
@@ -367,6 +366,31 @@ func dropInvalidIndex(ctx context.Context, db *pgxpool.Pool, name string) error 
 		return fmt.Errorf("dropping invalid index %s: %w", name, err)
 	}
 	return nil
+}
+
+// dropExistingPrimaryKeySQL drops whatever primary key the heap still carries.
+// Copy-unpartition creates {table}_new with PRIMARY KEY, then renames the table;
+// RENAME TABLE does not rename the constraint, so the leftover name is
+// {table}_new_pkey, not {table}_pkey. Dropping only the latter leaves two
+// primary keys when swap promotes {table}_pk_part.
+func dropExistingPrimaryKeySQL(relname string) string {
+	return fmt.Sprintf(`
+DO $drop_pk$
+DECLARE
+    pk TEXT;
+BEGIN
+    SELECT con.conname INTO pk
+    FROM pg_constraint con
+    JOIN pg_class c ON c.oid = con.conrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'convoy'
+      AND c.relname = %s
+      AND con.contype = 'p';
+    IF pk IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE convoy.%s DROP CONSTRAINT %%I', pk);
+    END IF;
+END
+$drop_pk$`, pgLit(relname), quoteIdent(relname))
 }
 
 func notice(ctx context.Context, db *pgxpool.Pool, message string) {

--- a/internal/pkg/attach/spec_test.go
+++ b/internal/pkg/attach/spec_test.go
@@ -15,6 +15,15 @@ func TestDropConstraintSQLIncludesAdoptedChild(t *testing.T) {
 	}, got)
 }
 
+func TestDropExistingPrimaryKeySQLLooksUpTheConstraint(t *testing.T) {
+	got := dropExistingPrimaryKeySQL("events_search_default")
+	require.Contains(t, got, `c.relname = 'events_search_default'`)
+	require.Contains(t, got, `con.contype = 'p'`)
+	require.Contains(t, got, `ALTER TABLE convoy."events_search_default" DROP CONSTRAINT %I`)
+	require.NotContains(t, got, `events_search_pkey`,
+		"the leftover copy-unpartition name is {table}_new_pkey; do not hardcode {table}_pkey")
+}
+
 func TestCutoffIsUTCMidnightFourteenDaysOut(t *testing.T) {
 	now := time.Date(2026, 8, 15, 3, 4, 5, 0, time.FixedZone("behind", -4*3600))
 	got := Cutoff(now)

--- a/web/ui/dashboard/src/app/guards/instance-admin.guard.ts
+++ b/web/ui/dashboard/src/app/guards/instance-admin.guard.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { RbacService } from '../services/rbac/rbac.service';
+import { PrivateService } from '../private/private.service';
 
 @Injectable({
 	providedIn: 'root'
@@ -8,17 +9,20 @@ import { RbacService } from '../services/rbac/rbac.service';
 export class InstanceAdminGuard  {
 	constructor(
 		private rbacService: RbacService,
+		private privateService: PrivateService,
 		private router: Router
 	) {}
 
 	async canActivate(): Promise<boolean> {
 		try {
-			// Require a live role check for admin route access.
+			// Membership is org-scoped. A full reload of /admin runs this guard
+			// before the shell has fetched organisations, and getUserRole then
+			// reads an empty cache as PROJECT_VIEWER.
+			await this.privateService.getOrganizations();
 			const userRole = await this.rbacService.getUserRole({ allowCachedOnError: false });
 			if (userRole === 'INSTANCE_ADMIN') {
 				return true;
 			}
-			// Redirect to projects if not instance admin
 			this.router.navigate(['/projects']);
 			return false;
 		} catch (error) {

--- a/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.html
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.html
@@ -16,7 +16,7 @@
     <div class="bg-warning-500/5 border border-warning-500/20 rounded-12px p-16px mb-24px">
       <p class="font-body font-semibold text-[14px] leading-normal text-new.text-primary mb-4px">Run this in a maintenance window</p>
       <p class="font-body font-normal text-[13px] leading-[20px] text-new.text-secondary">
-        This table was partitioned by copying, so converting it back copies it into a plain table and swaps that in. Rows written while the copy runs are not carried over, so pause ingestion before starting. On a large table this takes hours and cannot be safely interrupted once it begins.
+        Converting this table back copies remaining rows into a plain table and swaps that in. Rows written while the copy runs are not carried over, so pause ingestion before starting. On a large table this takes hours and cannot be safely interrupted once it begins.
       </p>
     </div>
   }
@@ -53,6 +53,7 @@
             formControlName="table"
             placeholder="Select table"
             [searchable]="false"
+            (selectedOption)="applyOperations()"
           ></convoy-select>
         </convoy-input-field>
 
@@ -97,7 +98,7 @@
           @if (!isStarting) {
             <!-- The operation alone: capitalizing a snake_case table name reads as
                  "Event_deliveries", and the table is already named above. -->
-            <span class="capitalize">{{ selectedOperation }}</span>
+            <span class="capitalize">{{ resolvedOperation }}</span>
           }
           @if (isStarting) {
             <span>Starting...</span>

--- a/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.ts
@@ -97,17 +97,30 @@ export class TablePartitionsComponent implements OnInit, OnDestroy {
 		return this.partitionForm.value.operation;
 	}
 
+	// The table's current shape, not the form or the select. Switching tables
+	// can leave both of those on the previous operation.
+	get resolvedOperation(): PartitionOperation {
+		const state = this.stateOf(this.selectedTable);
+		if (state) {
+			return state.partitioned ? 'unpartition' : 'partition';
+		}
+		return this.selectedOperation;
+	}
+
 	get isAttachConversion(): boolean {
-		return this.selectedOperation === 'partition';
+		return this.resolvedOperation === 'partition';
 	}
 
 	get isDetachConversion(): boolean {
-		return this.selectedOperation === 'unpartition' && !!this.stateOf(this.selectedTable)?.adopted;
+		return this.resolvedOperation === 'unpartition' && !!this.stateOf(this.selectedTable)?.adopted;
 	}
 
 	get isCopyUnpartition(): boolean {
-		if (this.selectedOperation !== 'unpartition' || !this.tableStatesKnown) return false;
+		if (this.resolvedOperation !== 'unpartition' || !this.tableStatesKnown) return false;
 		const state = this.stateOf(this.selectedTable);
+		// !adopted is also true after retention drops the attach-converted
+		// _default: there is no heap to detach, so unpartition copies. The
+		// banner describes that copy, not how the table was first converted.
 		return !!state && state.partitioned && !state.adopted;
 	}
 
@@ -151,13 +164,18 @@ export class TablePartitionsComponent implements OnInit, OnDestroy {
 		return this.tableStates.find(state => state.name === table);
 	}
 
-	private applyOperations() {
+	applyOperations() {
 		const state = this.stateOf(this.selectedTable);
-		this.operations = state ? [state.partitioned ? UNPARTITION : PARTITION] : ALL_OPERATIONS;
+		const next = state ? [state.partitioned ? UNPARTITION : PARTITION] : ALL_OPERATIONS;
 
-		if (!this.operations.some(operation => operation.uid === this.selectedOperation)) {
-			this.partitionForm.patchValue({ operation: this.operations[0].uid });
+		// Patch before replacing options so writeValue can still find the new
+		// uid in the previous list. Assigning options first leaves the select
+		// showing Unpartition on a heap.
+		if (next.length === 1 && this.selectedOperation !== next[0].uid) {
+			this.partitionForm.patchValue({ operation: next[0].uid });
 		}
+
+		this.operations = next;
 	}
 
 	// The sentence under the selects: what the table is now, and what the
@@ -216,9 +234,9 @@ export class TablePartitionsComponent implements OnInit, OnDestroy {
 
 		this.isStarting = true;
 		try {
-			await this.adminService.startPartitionRun({ table: this.selectedTable, operation: this.selectedOperation });
+			await this.adminService.startPartitionRun({ table: this.selectedTable, operation: this.resolvedOperation });
 			this.partitionForm.patchValue({ confirmation: '' });
-			const outcome = this.selectedOperation === 'partition' ? `${this.selectedTable} to a partitioned table` : `${this.selectedTable} back to a plain table`;
+			const outcome = this.resolvedOperation === 'partition' ? `${this.selectedTable} to a partitioned table` : `${this.selectedTable} back to a plain table`;
 			this.generalService.showNotification({ message: `Started converting ${outcome}`, style: 'success' });
 			await this.loadRuns();
 		} catch (error: any) {


### PR DESCRIPTION
## Summary
- Swap drops whichever primary key the heap still carries, so attach after a copy unpartition no longer fails with two primary keys.
- The table partitions form posts the operation the selected table's shape allows, not a stale Operation select.
- A full reload of `/admin` fetches organisations before reading membership, so instance admins stay on Table partitions.

## Test plan
- [ ] `go test ./internal/pkg/attach/ ./internal/events/ -run 'DropExisting|CopyUnpartition|PartitionEventsSearch'`
- [ ] On a licensed instance, copy-unpartition a table (or drop adopted `_default`), then Partition from the admin page. The run completes and the table is `relkind=p`.
- [ ] Select a heap table after a partitioned one. The start button says Partition and the attach banner shows, even if the Operation select still shows Unpartition.
- [ ] While logged in as instance admin, open `/admin?activePage=table%20partitions` in a new tab. The page stays on Table partitions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dataplane changes affect partition swap DDL on production tables (high impact if wrong), but scope is narrow and covered by new integration tests; dashboard fixes are routing/UI only.
> 
> **Overview**
> Fixes **attach-based partitioning** after a copy unpartition: the swap step now drops whichever primary key the adopted heap still has (via `dropExistingPrimaryKeySQL`), instead of only `{table}_pkey`, so re-partitioning no longer fails with duplicate primary keys when the leftover constraint is named `{table}_new_pkey`.
> 
> **Table partitions admin UI** derives the real operation from the selected table’s server state (`resolvedOperation`), patches the operation control before narrowing select options, refreshes operations when the table changes, and starts runs with that resolved value so labels, banners, and API calls stay aligned when switching between partitioned and heap tables.
> 
> **Instance admin guard** loads organisations before resolving RBAC on a cold `/admin` reload so instance admins are not treated as `PROJECT_VIEWER` and redirected off admin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3900b7f6a4eb71931359c994ddb8c91fe886960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->