### PR TITLE
fix(dataplane): restore fks after copy unpartition of a partitioned sibling

### DIFF
--- a/internal/delivery_attempts/impl.go
+++ b/internal/delivery_attempts/impl.go
@@ -331,7 +331,7 @@ begin
 
 	RAISE NOTICE 'Successfully un-partitioned delivery_attempts table...';
 end $$ language plpgsql;
-select convoy.un_partition_delivery_attempts_table()
+select convoy.un_partition_delivery_attempts_table();
 `
 
 // Helper function to convert database row to datastore.DeliveryAttempt

--- a/internal/delivery_attempts/partition.go
+++ b/internal/delivery_attempts/partition.go
@@ -21,5 +21,5 @@ var attemptsSpec = attach.Spec{
 	SwapEnd:         []string{attach.AttemptFKSQL},
 	DuringDetach:    []string{attach.AttemptFKSQL},
 	AfterDetach:     []string{attach.RestoreAttemptFKSQL},
-	CopyUnpartition: unPartitionDeliveryAttemptsTableSQL,
+	CopyUnpartition: unPartitionDeliveryAttemptsTableSQL + attach.AttemptFKSQL,
 }

--- a/internal/event_deliveries/impl.go
+++ b/internal/event_deliveries/impl.go
@@ -727,10 +727,11 @@ begin
            latency_seconds, COALESCE(delivery_mode, 'at_least_once')::convoy.delivery_mode, event_bytes
     FROM convoy.event_deliveries;
 
+    -- Drop the inbound FK so event_deliveries_old can go. Do not add a real
+    -- FK onto delivery_attempts here: that table may already be partitioned.
+    -- Revert runs AfterDetach after this function returns.
     ALTER TABLE convoy.delivery_attempts DROP CONSTRAINT if exists delivery_attempts_event_delivery_id_fkey;
-    ALTER TABLE convoy.delivery_attempts
-        ADD CONSTRAINT delivery_attempts_event_delivery_id_fkey
-            FOREIGN KEY (event_delivery_id) REFERENCES convoy.event_deliveries_new (id);
+    ALTER TABLE IF EXISTS convoy.delivery_attempts_default DROP CONSTRAINT IF EXISTS delivery_attempts_event_delivery_id_fkey;
 
     ALTER TABLE convoy.event_deliveries RENAME TO event_deliveries_old;
     ALTER TABLE convoy.event_deliveries_new RENAME TO event_deliveries;
@@ -750,27 +751,7 @@ begin
     create index idx_event_deliveries_status on convoy.event_deliveries (status);
     create index idx_event_deliveries_status_key on convoy.event_deliveries (status);
 
-    -- Same reason as partition_event_deliveries_table: this function also
-    -- rebuilds convoy.event_deliveries, so it also has to put event-id
-    -- enforcement back. Unpartitioning event deliveries says nothing about
-    -- convoy.events, which may still be partitioned and can therefore still only
-    -- be enforced by the trigger.
-    IF EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_class c
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'convoy' AND c.relname = 'events' AND c.relkind = 'p'
-    ) THEN
-        CREATE OR REPLACE TRIGGER event_fk_check
-        BEFORE INSERT ON convoy.event_deliveries
-        FOR EACH ROW EXECUTE FUNCTION convoy.enforce_event_fk();
-    ELSE
-        ALTER TABLE convoy.event_deliveries
-            ADD CONSTRAINT event_deliveries_event_id_fkey
-                FOREIGN KEY (event_id) REFERENCES convoy.events (id);
-    END IF;
-
 	RAISE NOTICE 'Successfully un-partitioned event_deliveries table...';
 end $$ language plpgsql;
-select convoy.un_partition_event_deliveries_table()
+select convoy.un_partition_event_deliveries_table();
 `

--- a/internal/event_deliveries/partition.go
+++ b/internal/event_deliveries/partition.go
@@ -32,5 +32,5 @@ var deliveriesSpec = attach.Spec{
 	AfterAttach:     []string{attach.EventFKSQL},
 	DuringDetach:    []string{attach.EventFKSQL, attach.AttemptFKSQL},
 	AfterDetach:     []string{attach.RestoreAttemptFKSQL, attach.RestoreEventFKSQL},
-	CopyUnpartition: unPartitionEventDeliveriesTableSQL,
+	CopyUnpartition: unPartitionEventDeliveriesTableSQL + attach.AttemptFKSQL + attach.EventFKSQL,
 }

--- a/internal/event_deliveries/partition_test.go
+++ b/internal/event_deliveries/partition_test.go
@@ -273,6 +273,60 @@ func TestUnPartitionEventDeliveriesTableWhileAttemptsArePartitioned(t *testing.T
 	require.NoError(t, insertAttempt(t, db, project.UID, endpoint.UID, delivery.UID))
 }
 
+func dropAdoptedBounds(t *testing.T, db database.Database, table string) {
+	t.Helper()
+	_, err := db.GetDB().ExecContext(context.Background(),
+		fmt.Sprintf(`ALTER TABLE convoy.%[1]s_default DROP CONSTRAINT %[1]s_default_bounds`, table))
+	require.NoError(t, err)
+}
+
+// Retention can drop the adopted _default. Revert then copies. Copy used to
+// ADD delivery_attempts_event_delivery_id_fkey on the attempts parent, which
+// Postgres rejects when that table is partitioned.
+func TestUnPartitionEventDeliveriesTableCopyWhileAttemptsArePartitioned(t *testing.T) {
+	service, db := setupTestDB(t)
+	ctx := context.Background()
+
+	project := seedTestProject(t, db)
+	endpoint := seedTestEndpoint(t, db, project.UID)
+	source := seedTestSource(t, db, project.UID)
+	subscription := seedSubscription(t, db, project.UID, endpoint.UID, source.UID)
+	event := seedEvent(t, db, project.UID, endpoint.UID, source.UID)
+	delivery := createTestEventDelivery(t, project.UID, event.UID, endpoint.UID, subscription.UID)
+	require.NoError(t, service.CreateEventDelivery(ctx, delivery))
+
+	require.NoError(t, service.PartitionEventDeliveriesTable(ctx))
+	require.NoError(t, delivery_attempts.New(log.New("convoy", log.LevelError), db).PartitionDeliveryAttemptsTable(ctx))
+	dropAdoptedBounds(t, db, "event_deliveries")
+
+	require.NoError(t, service.UnPartitionEventDeliveriesTable(ctx))
+	require.Error(t, insertAttempt(t, db, project.UID, endpoint.UID, ulid.Make().String()),
+		"an attempt referencing a nonexistent delivery was accepted after copy-unpartitioning event_deliveries")
+	require.NoError(t, insertAttempt(t, db, project.UID, endpoint.UID, delivery.UID))
+}
+
+func TestUnPartitionDeliveryAttemptsTableCopyRestoresEnforcement(t *testing.T) {
+	service, db := setupTestDB(t)
+	ctx := context.Background()
+
+	project := seedTestProject(t, db)
+	endpoint := seedTestEndpoint(t, db, project.UID)
+	source := seedTestSource(t, db, project.UID)
+	subscription := seedSubscription(t, db, project.UID, endpoint.UID, source.UID)
+	event := seedEvent(t, db, project.UID, endpoint.UID, source.UID)
+	delivery := createTestEventDelivery(t, project.UID, event.UID, endpoint.UID, subscription.UID)
+	require.NoError(t, service.CreateEventDelivery(ctx, delivery))
+
+	attempts := delivery_attempts.New(log.New("convoy", log.LevelError), db)
+	require.NoError(t, attempts.PartitionDeliveryAttemptsTable(ctx))
+	dropAdoptedBounds(t, db, "delivery_attempts")
+
+	require.NoError(t, attempts.UnPartitionDeliveryAttemptsTable(ctx))
+	require.Error(t, insertAttempt(t, db, project.UID, endpoint.UID, ulid.Make().String()),
+		"copy-unpartition of delivery_attempts left no event_delivery_id enforcement")
+	require.NoError(t, insertAttempt(t, db, project.UID, endpoint.UID, delivery.UID))
+}
+
 // Same one-at-a-time order as events-after-deliveries: attach keeps the real
 // FK on delivery_attempts_default, so Swap has to drop that child too.
 func TestPartitionEventDeliveriesTableDropsAdoptedAttemptFK(t *testing.T) {

--- a/internal/events/impl.go
+++ b/internal/events/impl.go
@@ -679,16 +679,12 @@ BEGIN
            is_duplicate_event, acknowledged_at, status, metadata, failure_reason, raw_bytes, data_bytes
     FROM convoy.events;
 
+    -- Drop the inbound FK so events_old can go. Do not add a real FK onto
+    -- event_deliveries here: that table may already be partitioned, and
+    -- Postgres rejects a key that omits the partition columns. Revert runs
+    -- AfterDetach (RestoreEventFKSQL) after this function returns.
     ALTER TABLE convoy.event_deliveries DROP CONSTRAINT IF EXISTS event_deliveries_event_id_fkey;
-    ALTER TABLE convoy.event_deliveries
-        ADD CONSTRAINT event_deliveries_event_id_fkey
-            FOREIGN KEY (event_id) REFERENCES convoy.events_new (id);
-
-    -- The constraint above is the enforcement the trigger stood in for while
-    -- events was partitioned. Leaving the trigger installed would make every
-    -- delivery insert pay a second existence query, and would report a violation
-    -- through whichever of the two fires first.
-    DROP TRIGGER IF EXISTS event_fk_check ON convoy.event_deliveries;
+    ALTER TABLE IF EXISTS convoy.event_deliveries_default DROP CONSTRAINT IF EXISTS event_deliveries_event_id_fkey;
 
     ALTER TABLE convoy.events RENAME TO events_old;
     ALTER TABLE convoy.events_new RENAME TO events;

--- a/internal/events/impl_test.go
+++ b/internal/events/impl_test.go
@@ -1345,6 +1345,81 @@ func TestUnPartitionEventsTableRemovesTheStandInTrigger(t *testing.T) {
 	require.NotZero(t, constraints, "dropping the trigger left no event-id enforcement at all")
 }
 
+func dropAdoptedBounds(t *testing.T, db database.Database, table string) {
+	t.Helper()
+	_, err := db.GetDB().ExecContext(context.Background(),
+		fmt.Sprintf(`ALTER TABLE convoy.%[1]s_default DROP CONSTRAINT %[1]s_default_bounds`, table))
+	require.NoError(t, err)
+}
+
+func relationKind(t *testing.T, db database.Database, table string) string {
+	t.Helper()
+	var kind string
+	require.NoError(t, db.GetDB().QueryRowContext(context.Background(), `
+        SELECT c.relkind FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'convoy' AND c.relname = $1`, table).Scan(&kind))
+	return kind
+}
+
+func countTrigger(t *testing.T, db database.Database, table, name string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, db.GetDB().QueryRowContext(context.Background(), `
+        SELECT count(*)
+        FROM pg_catalog.pg_trigger t
+        JOIN pg_catalog.pg_class c ON c.oid = t.tgrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'convoy' AND c.relname = $1 AND t.tgname = $2`,
+		table, name).Scan(&n))
+	return n
+}
+
+// Retention can drop the adopted _default while the parent stays partitioned.
+// Revert then copies. Copy used to ADD event_deliveries_event_id_fkey on the
+// deliveries parent, which Postgres rejects when that table is partitioned.
+func TestUnPartitionEventsTableCopyWhileDeliveriesArePartitioned(t *testing.T) {
+	service, db := setupTestDB(t)
+	ctx := context.Background()
+
+	project := seedTestProject(t, db)
+	endpoint := seedTestEndpoint(t, db, project.UID)
+	source := seedTestSource(t, db, project.UID)
+	require.NoError(t, service.CreateEvent(ctx, createTestEvent(t, project.UID, []string{endpoint.UID}, source.UID)))
+
+	require.NoError(t, event_deliveries.New(log.New("convoy", log.LevelError), db).PartitionEventDeliveriesTable(ctx))
+	require.NoError(t, service.PartitionEventsTable(ctx))
+	dropAdoptedBounds(t, db, "events")
+
+	require.NoError(t, service.UnPartitionEventsTable(ctx))
+	require.Equal(t, "r", relationKind(t, db, "events"))
+	require.NotZero(t, countTrigger(t, db, "event_deliveries", "event_fk_check"),
+		"copy-unpartition dropped the stand-in while event_deliveries is still partitioned")
+	require.Zero(t, countNamedConstraint(t, db, "event_deliveries", "event_deliveries_event_id_fkey"),
+		"copy-unpartition installed a real event FK on a partitioned event_deliveries")
+}
+
+// Same copy path, but event_deliveries is still a heap. AfterDetach has to
+// put the real FK back; the copy SQL no longer does.
+func TestUnPartitionEventsTableCopyRestoresEventFK(t *testing.T) {
+	service, db := setupTestDB(t)
+	ctx := context.Background()
+
+	project := seedTestProject(t, db)
+	endpoint := seedTestEndpoint(t, db, project.UID)
+	source := seedTestSource(t, db, project.UID)
+	require.NoError(t, service.CreateEvent(ctx, createTestEvent(t, project.UID, []string{endpoint.UID}, source.UID)))
+
+	require.NoError(t, service.PartitionEventsTable(ctx))
+	dropAdoptedBounds(t, db, "events")
+
+	require.NoError(t, service.UnPartitionEventsTable(ctx))
+	require.Equal(t, "r", relationKind(t, db, "events"))
+	require.Zero(t, countTrigger(t, db, "event_deliveries", "event_fk_check"),
+		"copy-unpartition left the stand-in after both tables are heaps")
+	require.NotZero(t, countNamedConstraint(t, db, "event_deliveries", "event_deliveries_event_id_fkey"),
+		"copy-unpartition left no event-id enforcement")
+}
+
 // Operators convert tables one at a time. After event_deliveries is attached,
 // event_deliveries_event_id_fkey lives on the adopted child. Dropping it only
 // from the parent name leaves a stale FK that still points at events_default

--- a/internal/events/partition.go
+++ b/internal/events/partition.go
@@ -33,9 +33,12 @@ var eventsSpec = attach.Spec{
 		attach.DropConstraintSQL("event_deliveries", "event_deliveries_event_id_fkey"),
 		attach.EventFKSQL,
 	),
-	DuringDetach:    []string{attach.EventFKSQL},
-	AfterDetach:     []string{attach.RestoreEventFKSQL},
-	CopyUnpartition: unPartitionEventsTableSQL,
+	DuringDetach: []string{attach.EventFKSQL},
+	AfterDetach:  []string{attach.RestoreEventFKSQL},
+	// Stand-in is part of the copy script so the rewrite cannot commit
+	// without enforcement. AfterDetach then upgrades to a real FK when
+	// event_deliveries is also a heap.
+	CopyUnpartition: unPartitionEventsTableSQL + attach.EventFKSQL,
 }
 
 var eventsSearchSpec = attach.Spec{

--- a/internal/pkg/attach/detach.go
+++ b/internal/pkg/attach/detach.go
@@ -16,8 +16,17 @@ func Revert(ctx context.Context, db *pgxpool.Pool, spec Spec) error {
 		return err
 	}
 	if !adopted {
-		_, err = db.Exec(ctx, spec.CopyUnpartition)
-		return err
+		if _, err = db.Exec(ctx, spec.CopyUnpartition); err != nil {
+			return err
+		}
+		// Copy SQL drops inbound FKs and appends the stand-in so the
+		// rewrite cannot commit without enforcement. DuringDetach is
+		// the same SQL again (CREATE OR REPLACE). AfterDetach then
+		// upgrades to a real FK when both sides are heaps.
+		if err := installDuringDetach(ctx, db, spec); err != nil {
+			return err
+		}
+		return restoreAfterDetach(ctx, db, spec)
 	}
 	return detach(ctx, db, spec)
 }
@@ -70,13 +79,8 @@ func detach(ctx context.Context, db *pgxpool.Pool, spec Spec) error {
 	// drain, when both names hold the full row set. Reinstall the stand-in
 	// on the live name now, or the drain window writes orphans and child
 	// lookups miss rows that still live only on _partitioned.
-	if len(spec.DuringDetach) > 0 {
-		notice(ctx, db, "Keeping enforcement during the drain...")
-		for _, stmt := range spec.DuringDetach {
-			if _, err := db.Exec(ctx, stmt); err != nil {
-				return fmt.Errorf("table is unpartitioned but enforcement was not restored: %w", err)
-			}
-		}
+	if err := installDuringDetach(ctx, db, spec); err != nil {
+		return err
 	}
 
 	notice(ctx, db, "Migrating rows written since the conversion...")
@@ -89,16 +93,37 @@ func detach(ctx context.Context, db *pgxpool.Pool, spec Spec) error {
 		return err
 	}
 
-	if len(spec.AfterDetach) > 0 {
-		notice(ctx, db, "Restoring enforcement...")
-		for _, stmt := range spec.AfterDetach {
-			if _, err := db.Exec(ctx, stmt); err != nil {
-				return fmt.Errorf("table is unpartitioned but enforcement was not restored: %w", err)
-			}
-		}
+	if err := restoreAfterDetach(ctx, db, spec); err != nil {
+		return err
 	}
 
 	notice(ctx, db, "Successfully un-partitioned "+spec.Table+" table...")
+	return nil
+}
+
+func installDuringDetach(ctx context.Context, db *pgxpool.Pool, spec Spec) error {
+	if len(spec.DuringDetach) == 0 {
+		return nil
+	}
+	notice(ctx, db, "Keeping enforcement...")
+	for _, stmt := range spec.DuringDetach {
+		if _, err := db.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("table is unpartitioned but enforcement was not restored: %w", err)
+		}
+	}
+	return nil
+}
+
+func restoreAfterDetach(ctx context.Context, db *pgxpool.Pool, spec Spec) error {
+	if len(spec.AfterDetach) == 0 {
+		return nil
+	}
+	notice(ctx, db, "Restoring enforcement...")
+	for _, stmt := range spec.AfterDetach {
+		if _, err := db.Exec(ctx, stmt); err != nil {
+			return fmt.Errorf("table is unpartitioned but enforcement was not restored: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/internal/pkg/attach/triggers.go
+++ b/internal/pkg/attach/triggers.go
@@ -39,7 +39,7 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE TRIGGER event_fk_check
     BEFORE INSERT ON convoy.event_deliveries
-    FOR EACH ROW EXECUTE FUNCTION convoy.enforce_event_fk()`
+    FOR EACH ROW EXECUTE FUNCTION convoy.enforce_event_fk();`
 
 // AttemptFKSQL stands in for delivery_attempts.event_delivery_id → event_deliveries
 // for the same reason. Deliveries install it in Swap (attempts still has its
@@ -62,7 +62,7 @@ $$ LANGUAGE plpgsql;
 
 CREATE OR REPLACE TRIGGER event_delivery_fk_check
     BEFORE INSERT ON convoy.delivery_attempts
-    FOR EACH ROW EXECUTE FUNCTION convoy.enforce_event_delivery_fk()`
+    FOR EACH ROW EXECUTE FUNCTION convoy.enforce_event_delivery_fk();`
 
 // RestoreEventFKSQL keeps the stand-in trigger while either table is still
 // partitioned, and restores the real FK once both are ordinary tables.


### PR DESCRIPTION
## Summary
- Copy-unpartition no longer adds a real foreign key onto `event_deliveries` or `delivery_attempts`. Postgres rejects that key when the referencing table is already partitioned, which is the path after retention drops `_default`.
- The copy script only drops the inbound constraint (parent and `_default`) and installs the stand-in trigger in the same batch, so the rewrite cannot commit without enforcement.
- `Revert` then runs the same after-detach restore as detach: stand-in while a sibling is still partitioned, real FK once both sides are heaps.

## Test plan
- [x] `go test ./internal/events/ ./internal/event_deliveries/` for copy-unpartition while the sibling is partitioned, copy-unpartition with a heap sibling, and detach-path stand-in/FK restore
- [ ] After merge, do not tag until this is on `main`