### PR TITLE
fix(dashboard): show delivered URL from attempts on delivery details

### DIFF
--- a/web/ui/dashboard/src/app/models/event.model.ts
+++ b/web/ui/dashboard/src/app/models/event.model.ts
@@ -56,6 +56,7 @@ export interface EVENT_DELIVERY {
 }
 
 export interface EVENT_DELIVERY_ATTEMPT {
+	url?: string;
 	ip_address: string;
 	http_status: string;
 	api_version: string;

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.html
@@ -219,14 +219,14 @@
         }
       </div>
 
-      <convoy-copy-button [text]="eventDelsDetails?.target_url || eventDelsDetails?.endpoint_metadata?.url || ''" show-icon="false" notificationText="Endpoint URL copied to clipboard">
+      <convoy-copy-button [text]="deliveredToUrl()" show-icon="false" notificationText="Delivered URL copied to clipboard">
         <span class="relative inline-flex items-center max-w-[370px] group cursor-pointer">
-          <span class="truncate font-body text-[13px] text-new.text-secondary">{{ eventDelsDetails?.target_url || eventDelsDetails?.endpoint_metadata?.url || '-' }}</span>
+          <span class="truncate font-body text-[13px] text-new.text-secondary">{{ deliveredToUrl() || '-' }}</span>
           <svg class="ml-6px h-12px w-12px shrink-0 opacity-0 transition-opacity group-hover:opacity-100 stroke-neutral-10">
             <use xlink:href="#copy-icon-3"></use>
           </svg>
           <span class="pointer-events-none absolute left-0 bottom-[calc(100%+8px)] z-50 max-w-[560px] truncate whitespace-nowrap rounded-6px bg-neutral-12 px-8px py-4px text-10 text-white-100 opacity-0 shadow-md transition-opacity group-hover:opacity-100">
-            {{ eventDelsDetails?.target_url || eventDelsDetails?.endpoint_metadata?.url }}
+            {{ deliveredToUrl() }}
           </span>
         </span>
       </convoy-copy-button>

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.spec.ts
@@ -23,4 +23,39 @@ describe('EventDeliveryDetailsComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('deliveredToUrl', () => {
+    it('prefers delivery target_url over attempt url', () => {
+      component.eventDelsDetails = { target_url: 'https://old.example/hook' } as any;
+      component.eventDeliveryAtempt = { url: 'https://attempt.example/hook' } as any;
+
+      expect(component.deliveredToUrl()).toBe('https://old.example/hook');
+    });
+
+    it('uses latest attempt url when target_url is empty', () => {
+      component.eventDelsDetails = {
+        target_url: '',
+        endpoint_metadata: { url: 'https://live.example/hook' }
+      } as any;
+      component.eventDeliveryAtempt = { url: 'https://attempt.example/hook' } as any;
+
+      expect(component.deliveredToUrl()).toBe('https://attempt.example/hook');
+    });
+
+    it('does not fall back to endpoint_metadata.url', () => {
+      component.eventDelsDetails = {
+        endpoint_metadata: { url: 'https://live.example/hook' }
+      } as any;
+
+      expect(component.deliveredToUrl()).toBe('');
+    });
+
+    it('uses selected attempt when user picks an older attempt', () => {
+      component.eventDelsDetails = {} as any;
+      component.eventDeliveryAtempt = { url: 'https://newest.example/hook' } as any;
+      component.selectedDeliveryAttempt = { url: 'https://older.example/hook' } as any;
+
+      expect(component.deliveredToUrl()).toBe('https://older.example/hook');
+    });
+  });
 });

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-delivery-details/event-delivery-details.component.ts
@@ -150,6 +150,16 @@ export class EventDeliveryDetailsComponent implements OnInit, AfterViewInit {
 		return !!this.eventDelsDetails?.endpoint_metadata?.deleted_at;
 	}
 
+	// Per-delivery URL truth lives on target_url (dynamic paths) or delivery_attempts.url.
+	// Do not fall back to endpoint_metadata.url; that is the live endpoint template.
+	deliveredToUrl(): string {
+		const targetUrl = this.eventDelsDetails?.target_url?.trim();
+		if (targetUrl) return targetUrl;
+
+		const attemptUrl = (this.selectedDeliveryAttempt ?? this.eventDeliveryAtempt)?.url?.trim();
+		return attemptUrl || '';
+	}
+
 	checkScreenSize() {
 		this.screenWidth > 1010 ? (this.shouldRenderSmallSize = false) : (this.shouldRenderSmallSize = true);
 	}


### PR DESCRIPTION
## Summary

- Event delivery details no longer falls back to `endpoint_metadata.url` (the live endpoint template) for the URL hit row when `target_url` is empty.
- The row now resolves from `target_url` (dynamic paths) or `delivery_attempts.url` (the URL actually hit), matching per-delivery truth from attempts.
- The endpoint template chip still shows the current endpoint URL separately.

Closes PDE-995.

## Test plan

- [ ] Open a delivery whose endpoint URL changed after the delivery was sent; details URL row shows the attempt URL, not the current endpoint URL.
- [ ] Dynamic-path delivery with `target_url` set still shows `target_url`.
- [ ] Delivery with no attempts yet shows `-` until attempts load (no live endpoint fallback).
- [ ] Selecting an older attempt in the strip updates the URL row to that attempt's URL.
- [ ] Unit tests: `event-delivery-details.component.spec.ts` (`deliveredToUrl` cases).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard display and typing only; no delivery or API behavior changes.
> 
> **Overview**
> **Event delivery details** now shows the URL that was actually hit for that delivery, instead of mixing in the live endpoint template.
> 
> The endpoint section’s URL row uses a new **`deliveredToUrl()`** resolver: **`target_url`** first (dynamic paths), then the selected or latest attempt’s **`url`**. It no longer falls back to **`endpoint_metadata.url`**, so if the endpoint changed after send, reviewers see the attempt URL (or `-` until attempts load). The separate endpoint template chip still shows the current endpoint URL.
> 
> **`EVENT_DELIVERY_ATTEMPT`** gains an optional **`url`** field. Unit tests cover precedence and attempt selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 284963a2cbe067d3ce24f03258f2b4f9991b4018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->