### PR TITLE
fix(controlplane): use plain inner order by for events list paged scans

### DIFF
--- a/internal/events/impl.go
+++ b/internal/events/impl.go
@@ -418,7 +418,7 @@ func (s *Service) loadEventsPagedExists(ctx context.Context, projectID string, f
 		PageLimit:                pgtype.Int8{Int64: int64(filter.Pageable.Limit()), Valid: true},
 	}
 
-	rows, err := s.repo.LoadEventsPagedExists(ctx, params)
+	rows, err := s.loadEventsPagedExistsRows(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -433,6 +433,19 @@ func (s *Service) loadEventsPagedExists(ctx context.Context, projectID string, f
 	}
 
 	return events, nil
+}
+
+func eventsPagedInnerDesc(sortOrder, direction string) bool {
+	return (sortOrder == "DESC" && direction == "next") || (sortOrder == "ASC" && direction == "prev")
+}
+
+func (s *Service) loadEventsPagedExistsRows(ctx context.Context, params repo.LoadEventsPagedExistsParams) ([]repo.LoadEventsPagedExistsRow, error) {
+	sortOrder := params.SortOrder.String
+	direction := params.Direction.String
+	if eventsPagedInnerDesc(sortOrder, direction) {
+		return s.repo.LoadEventsPagedExistsInnerDesc(ctx, params)
+	}
+	return s.repo.LoadEventsPagedExistsInnerAsc(ctx, params)
 }
 
 // loadEventsPagedSearch handles CTE path pagination (with search query)

--- a/internal/events/impl_test.go
+++ b/internal/events/impl_test.go
@@ -1507,3 +1507,12 @@ func TestPartitionEventsTablesNameForRetention(t *testing.T) {
 	require.NoError(t, service.PartitionEventsSearchTable(ctx))
 	testenv.RequirePartitionsAddressableByRetention(t, db, "events_search", project.UID)
 }
+
+func TestEventsPagedInnerDesc(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, eventsPagedInnerDesc("DESC", "next"))
+	require.True(t, eventsPagedInnerDesc("ASC", "prev"))
+	require.False(t, eventsPagedInnerDesc("ASC", "next"))
+	require.False(t, eventsPagedInnerDesc("DESC", "prev"))
+}

--- a/internal/events/pagination_routing_test.go
+++ b/internal/events/pagination_routing_test.go
@@ -1,0 +1,121 @@
+package events
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/require"
+
+	"github.com/frain-dev/convoy/internal/events/repo"
+)
+
+type existsPagingRecorder struct {
+	last string
+}
+
+func (r *existsPagingRecorder) LoadEventsPagedExistsInnerDesc(ctx context.Context, arg repo.LoadEventsPagedExistsParams) ([]repo.LoadEventsPagedExistsRow, error) {
+	r.last = "desc"
+	return nil, nil
+}
+
+func (r *existsPagingRecorder) LoadEventsPagedExistsInnerAsc(ctx context.Context, arg repo.LoadEventsPagedExistsParams) ([]repo.LoadEventsPagedExistsRow, error) {
+	r.last = "asc"
+	return nil, nil
+}
+
+func (r *existsPagingRecorder) CopyRowsFromEventsToEventsSearch(context.Context, repo.CopyRowsFromEventsToEventsSearchParams) error {
+	panic("unexpected CopyRowsFromEventsToEventsSearch")
+}
+
+func (r *existsPagingRecorder) CountEvents(context.Context, repo.CountEventsParams) (pgtype.Int8, error) {
+	panic("unexpected CountEvents")
+}
+
+func (r *existsPagingRecorder) CountExportedEvents(context.Context, repo.CountExportedEventsParams) (pgtype.Int8, error) {
+	panic("unexpected CountExportedEvents")
+}
+
+func (r *existsPagingRecorder) CountPrevEvents(context.Context, repo.CountPrevEventsParams) (pgtype.Int8, error) {
+	panic("unexpected CountPrevEvents")
+}
+
+func (r *existsPagingRecorder) CountPrevEventsSearch(context.Context, repo.CountPrevEventsSearchParams) (pgtype.Int8, error) {
+	panic("unexpected CountPrevEventsSearch")
+}
+
+func (r *existsPagingRecorder) CountProjectMessages(context.Context, pgtype.Text) (pgtype.Int8, error) {
+	panic("unexpected CountProjectMessages")
+}
+
+func (r *existsPagingRecorder) CreateEvent(context.Context, repo.CreateEventParams) error {
+	panic("unexpected CreateEvent")
+}
+
+func (r *existsPagingRecorder) CreateEventEndpoint(context.Context, []repo.CreateEventEndpointParams) *repo.CreateEventEndpointBatchResults {
+	panic("unexpected CreateEventEndpoint")
+}
+
+func (r *existsPagingRecorder) ExportEvents(context.Context, repo.ExportEventsParams) ([]repo.ExportEventsRow, error) {
+	panic("unexpected ExportEvents")
+}
+
+func (r *existsPagingRecorder) FindEventByID(context.Context, repo.FindEventByIDParams) (repo.FindEventByIDRow, error) {
+	panic("unexpected FindEventByID")
+}
+
+func (r *existsPagingRecorder) FindEventsByIDs(context.Context, repo.FindEventsByIDsParams) ([]repo.FindEventsByIDsRow, error) {
+	panic("unexpected FindEventsByIDs")
+}
+
+func (r *existsPagingRecorder) FindEventsByIdempotencyKey(context.Context, repo.FindEventsByIdempotencyKeyParams) (bool, error) {
+	panic("unexpected FindEventsByIdempotencyKey")
+}
+
+func (r *existsPagingRecorder) FindFirstEventWithIdempotencyKey(context.Context, repo.FindFirstEventWithIdempotencyKeyParams) (repo.FindFirstEventWithIdempotencyKeyRow, error) {
+	panic("unexpected FindFirstEventWithIdempotencyKey")
+}
+
+func (r *existsPagingRecorder) HardDeleteTokenizedEvents(context.Context, repo.HardDeleteTokenizedEventsParams) error {
+	panic("unexpected HardDeleteTokenizedEvents")
+}
+
+func (r *existsPagingRecorder) LoadEventsPagedSearch(context.Context, repo.LoadEventsPagedSearchParams) ([]repo.LoadEventsPagedSearchRow, error) {
+	panic("unexpected LoadEventsPagedSearch")
+}
+
+func (r *existsPagingRecorder) UpdateEventEndpoints(context.Context, repo.UpdateEventEndpointsParams) error {
+	panic("unexpected UpdateEventEndpoints")
+}
+
+func (r *existsPagingRecorder) UpdateEventStatus(context.Context, repo.UpdateEventStatusParams) error {
+	panic("unexpected UpdateEventStatus")
+}
+
+var _ repo.Querier = (*existsPagingRecorder)(nil)
+
+func TestLoadEventsPagedExistsRowsRouting(t *testing.T) {
+	cases := []struct {
+		sort, direction, want string
+	}{
+		{sort: "DESC", direction: "next", want: "desc"},
+		{sort: "ASC", direction: "prev", want: "desc"},
+		{sort: "ASC", direction: "next", want: "asc"},
+		{sort: "DESC", direction: "prev", want: "asc"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.sort+"_"+tc.direction, func(t *testing.T) {
+			rec := &existsPagingRecorder{}
+			svc := &Service{repo: rec}
+			params := repo.LoadEventsPagedExistsParams{
+				SortOrder: pgtype.Text{String: tc.sort, Valid: true},
+				Direction: pgtype.Text{String: tc.direction, Valid: true},
+			}
+
+			_, err := svc.loadEventsPagedExistsRows(context.Background(), params)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, rec.last)
+		})
+	}
+}

--- a/internal/events/queries.sql
+++ b/internal/events/queries.sql
@@ -158,11 +158,11 @@ WHERE ev.project_id = @project_id
 -- Group 3: Complex Pagination (5 queries) ⚠️ MOST CRITICAL
 -- ============================================================================
 
--- name: LoadEventsPagedExists :many
+-- name: LoadEventsPagedExistsInnerDesc :many
 -- Fast pagination using EXISTS subquery (no search query)
--- Uses CTE with direction-based sort for correct backward pagination
+-- Inner scan uses plain ORDER BY id DESC so generic plans keep the events_pkey index.
 -- @direction: 'next' or 'prev' (pagination direction)
--- @sort_order: 'ASC' or 'DESC' (user-requested sort order)
+-- @sort_order: 'ASC' or 'DESC' (user-requested sort order for cursor + outer re-sort)
 WITH filtered_events AS (
     SELECT ev.id,
            ev.project_id,
@@ -188,7 +188,6 @@ WITH filtered_events AS (
     FROM convoy.events ev
              LEFT JOIN convoy.sources s ON s.id = ev.source_id
     WHERE ev.deleted_at IS NULL
-      -- EXISTS subquery for endpoint/owner filters (enables index usage)
       AND (
         CASE
             WHEN @has_endpoint_or_owner_filter::BOOLEAN THEN
@@ -204,20 +203,16 @@ WITH filtered_events AS (
             ELSE true
             END
         )
-      -- Base filters
       AND ev.project_id = @project_id
       AND (CASE
                WHEN @has_idempotency_key::BOOLEAN THEN ev.idempotency_key = @idempotency_key
                ELSE true END)
       AND ev.created_at >= @start_date
       AND ev.created_at <= @end_date
-      -- Source filter
       AND (CASE WHEN @has_source_ids::BOOLEAN THEN ev.source_id = ANY (@source_ids::TEXT[]) ELSE true END)
-      -- Broker message ID filter
       AND (CASE
                WHEN @has_broker_message_id::BOOLEAN THEN ev.headers -> 'x-broker-message-id' ->> 0 = @broker_message_id
                ELSE true END)
-      -- Cursor pagination: DESC+next or ASC+prev → id <= cursor; ASC+next or DESC+prev → id >= cursor
       AND (
         CASE
             WHEN @cursor = '' THEN true
@@ -226,13 +221,81 @@ WITH filtered_events AS (
             ELSE true
         END
       )
-    -- Inner sort: DESC+next or ASC+prev → DESC; ASC+next or DESC+prev → ASC
-    ORDER BY
-        CASE WHEN (@sort_order::text = 'DESC' AND @direction::text = 'next') OR (@sort_order::text = 'ASC' AND @direction::text = 'prev') THEN ev.id END DESC,
-        CASE WHEN (@sort_order::text = 'ASC' AND @direction::text = 'next') OR (@sort_order::text = 'DESC' AND @direction::text = 'prev') THEN ev.id END ASC
+    ORDER BY ev.id DESC
     LIMIT @page_limit
 )
--- Outer sort: always the user-requested sort order (re-reverses backward fetches)
+SELECT id, project_id, event_type, is_duplicate_event, source_id, endpoints,
+       headers, raw, data, created_at, idempotency_key, url_query_params, url_path,
+       updated_at, deleted_at, acknowledged_at, metadata, status, failure_reason,
+       "source_metadata.id", "source_metadata.name"
+FROM filtered_events
+ORDER BY
+    CASE WHEN @sort_order::text = 'DESC' THEN id END DESC,
+    CASE WHEN @sort_order::text = 'ASC' THEN id END ASC;
+
+-- name: LoadEventsPagedExistsInnerAsc :many
+-- Same as LoadEventsPagedExistsInnerDesc but inner scan uses ORDER BY id ASC.
+WITH filtered_events AS (
+    SELECT ev.id,
+           ev.project_id,
+           ev.event_type,
+           ev.is_duplicate_event,
+           COALESCE(ev.source_id, '')        AS source_id,
+           ev.endpoints,
+           ev.headers,
+           ev.raw,
+           ev.data,
+           ev.created_at,
+           COALESCE(ev.idempotency_key, '')  AS idempotency_key,
+           COALESCE(ev.url_query_params, '') AS url_query_params,
+           COALESCE(ev.url_path, '')         AS url_path,
+           ev.updated_at,
+           ev.deleted_at,
+           ev.acknowledged_at,
+           ev.metadata,
+           ev.status,
+           COALESCE(ev.failure_reason, '')   AS failure_reason,
+           COALESCE(s.id, '')                AS "source_metadata.id",
+           COALESCE(s.name, '')              AS "source_metadata.name"
+    FROM convoy.events ev
+             LEFT JOIN convoy.sources s ON s.id = ev.source_id
+    WHERE ev.deleted_at IS NULL
+      AND (
+        CASE
+            WHEN @has_endpoint_or_owner_filter::BOOLEAN THEN
+                EXISTS (SELECT 1
+                        FROM convoy.events_endpoints ee
+                                 JOIN convoy.endpoints e ON e.id = ee.endpoint_id
+                        WHERE ee.event_id = ev.id
+                          AND (CASE WHEN @has_owner_id::BOOLEAN THEN e.owner_id = @owner_id ELSE true END)
+                          AND (CASE
+                                   WHEN @has_endpoint_ids::BOOLEAN THEN ee.endpoint_id = ANY (@endpoint_ids::TEXT[])
+                                   ELSE true END)
+                )
+            ELSE true
+            END
+        )
+      AND ev.project_id = @project_id
+      AND (CASE
+               WHEN @has_idempotency_key::BOOLEAN THEN ev.idempotency_key = @idempotency_key
+               ELSE true END)
+      AND ev.created_at >= @start_date
+      AND ev.created_at <= @end_date
+      AND (CASE WHEN @has_source_ids::BOOLEAN THEN ev.source_id = ANY (@source_ids::TEXT[]) ELSE true END)
+      AND (CASE
+               WHEN @has_broker_message_id::BOOLEAN THEN ev.headers -> 'x-broker-message-id' ->> 0 = @broker_message_id
+               ELSE true END)
+      AND (
+        CASE
+            WHEN @cursor = '' THEN true
+            WHEN (@sort_order::text = 'DESC' AND @direction::text = 'next') OR (@sort_order::text = 'ASC' AND @direction::text = 'prev') THEN ev.id <= @cursor
+            WHEN (@sort_order::text = 'ASC' AND @direction::text = 'next') OR (@sort_order::text = 'DESC' AND @direction::text = 'prev') THEN ev.id >= @cursor
+            ELSE true
+        END
+      )
+    ORDER BY ev.id ASC
+    LIMIT @page_limit
+)
 SELECT id, project_id, event_type, is_duplicate_event, source_id, endpoints,
        headers, raw, data, created_at, idempotency_key, url_query_params, url_path,
        updated_at, deleted_at, acknowledged_at, metadata, status, failure_reason,

--- a/internal/events/repo/querier.go
+++ b/internal/events/repo/querier.go
@@ -48,11 +48,11 @@ type Querier interface {
 	// Group 3: Complex Pagination (5 queries) ⚠️ MOST CRITICAL
 	// ============================================================================
 	// Fast pagination using EXISTS subquery (no search query)
-	// Uses CTE with direction-based sort for correct backward pagination
+	// Inner scan uses plain ORDER BY id DESC or ASC for index-friendly generic plans.
 	// @direction: 'next' or 'prev' (pagination direction)
 	// @sort_order: 'ASC' or 'DESC' (user-requested sort order)
-	// Outer sort: always the user-requested sort order (re-reverses backward fetches)
-	LoadEventsPagedExists(ctx context.Context, arg LoadEventsPagedExistsParams) ([]LoadEventsPagedExistsRow, error)
+	LoadEventsPagedExistsInnerDesc(ctx context.Context, arg LoadEventsPagedExistsParams) ([]LoadEventsPagedExistsRow, error)
+	LoadEventsPagedExistsInnerAsc(ctx context.Context, arg LoadEventsPagedExistsParams) ([]LoadEventsPagedExistsRow, error)
 	// Full-text search pagination using CTE + JOIN + GROUP BY
 	// Uses convoy.events_search table for search_token matching
 	// @direction: 'next' or 'prev' (pagination direction)

--- a/internal/events/repo/queries.sql.go
+++ b/internal/events/repo/queries.sql.go
@@ -682,7 +682,7 @@ func (q *Queries) HardDeleteTokenizedEvents(ctx context.Context, arg HardDeleteT
 	return err
 }
 
-const loadEventsPagedExists = `-- name: LoadEventsPagedExists :many
+const loadEventsPagedExistsInnerDesc = `-- name: LoadEventsPagedExistsInnerDesc :many
 
 WITH filtered_events AS (
     SELECT ev.id,
@@ -747,10 +747,85 @@ WITH filtered_events AS (
             ELSE true
         END
       )
-    -- Inner sort: DESC+next or ASC+prev → DESC; ASC+next or DESC+prev → ASC
-    ORDER BY
-        CASE WHEN ($1::text = 'DESC' AND $17::text = 'next') OR ($1::text = 'ASC' AND $17::text = 'prev') THEN ev.id END DESC,
-        CASE WHEN ($1::text = 'ASC' AND $17::text = 'next') OR ($1::text = 'DESC' AND $17::text = 'prev') THEN ev.id END ASC
+    ORDER BY ev.id DESC
+    LIMIT $18
+)
+SELECT id, project_id, event_type, is_duplicate_event, source_id, endpoints,
+       headers, raw, data, created_at, idempotency_key, url_query_params, url_path,
+       updated_at, deleted_at, acknowledged_at, metadata, status, failure_reason,
+       "source_metadata.id", "source_metadata.name"
+FROM filtered_events
+ORDER BY
+    CASE WHEN $1::text = 'DESC' THEN id END DESC,
+    CASE WHEN $1::text = 'ASC' THEN id END ASC
+`
+
+const loadEventsPagedExistsInnerAsc = `-- name: LoadEventsPagedExistsInnerAsc :many
+
+WITH filtered_events AS (
+    SELECT ev.id,
+           ev.project_id,
+           ev.event_type,
+           ev.is_duplicate_event,
+           COALESCE(ev.source_id, '')        AS source_id,
+           ev.endpoints,
+           ev.headers,
+           ev.raw,
+           ev.data,
+           ev.created_at,
+           COALESCE(ev.idempotency_key, '')  AS idempotency_key,
+           COALESCE(ev.url_query_params, '') AS url_query_params,
+           COALESCE(ev.url_path, '')         AS url_path,
+           ev.updated_at,
+           ev.deleted_at,
+           ev.acknowledged_at,
+           ev.metadata,
+           ev.status,
+           COALESCE(ev.failure_reason, '')   AS failure_reason,
+           COALESCE(s.id, '')                AS "source_metadata.id",
+           COALESCE(s.name, '')              AS "source_metadata.name"
+    FROM convoy.events ev
+             LEFT JOIN convoy.sources s ON s.id = ev.source_id
+    WHERE ev.deleted_at IS NULL
+      -- EXISTS subquery for endpoint/owner filters (enables index usage)
+      AND (
+        CASE
+            WHEN $2::BOOLEAN THEN
+                EXISTS (SELECT 1
+                        FROM convoy.events_endpoints ee
+                                 JOIN convoy.endpoints e ON e.id = ee.endpoint_id
+                        WHERE ee.event_id = ev.id
+                          AND (CASE WHEN $3::BOOLEAN THEN e.owner_id = $4 ELSE true END)
+                          AND (CASE
+                                   WHEN $5::BOOLEAN THEN ee.endpoint_id = ANY ($6::TEXT[])
+                                   ELSE true END)
+                )
+            ELSE true
+            END
+        )
+      -- Base filters
+      AND ev.project_id = $7
+      AND (CASE
+               WHEN $8::BOOLEAN THEN ev.idempotency_key = $9
+               ELSE true END)
+      AND ev.created_at >= $10
+      AND ev.created_at <= $11
+      -- Source filter
+      AND (CASE WHEN $12::BOOLEAN THEN ev.source_id = ANY ($13::TEXT[]) ELSE true END)
+      -- Broker message ID filter
+      AND (CASE
+               WHEN $14::BOOLEAN THEN ev.headers -> 'x-broker-message-id' ->> 0 = $15
+               ELSE true END)
+      -- Cursor pagination: DESC+next or ASC+prev → id <= cursor; ASC+next or DESC+prev → id >= cursor
+      AND (
+        CASE
+            WHEN $16 = '' THEN true
+            WHEN ($1::text = 'DESC' AND $17::text = 'next') OR ($1::text = 'ASC' AND $17::text = 'prev') THEN ev.id <= $16
+            WHEN ($1::text = 'ASC' AND $17::text = 'next') OR ($1::text = 'DESC' AND $17::text = 'prev') THEN ev.id >= $16
+            ELSE true
+        END
+      )
+    ORDER BY ev.id ASC
     LIMIT $18
 )
 SELECT id, project_id, event_type, is_duplicate_event, source_id, endpoints,
@@ -812,12 +887,73 @@ type LoadEventsPagedExistsRow struct {
 // Group 3: Complex Pagination (5 queries) ⚠️ MOST CRITICAL
 // ============================================================================
 // Fast pagination using EXISTS subquery (no search query)
-// Uses CTE with direction-based sort for correct backward pagination
+// Inner scan uses plain ORDER BY id DESC or ASC for index-friendly generic plans
 // @direction: 'next' or 'prev' (pagination direction)
 // @sort_order: 'ASC' or 'DESC' (user-requested sort order)
 // Outer sort: always the user-requested sort order (re-reverses backward fetches)
-func (q *Queries) LoadEventsPagedExists(ctx context.Context, arg LoadEventsPagedExistsParams) ([]LoadEventsPagedExistsRow, error) {
-	rows, err := q.db.Query(ctx, loadEventsPagedExists,
+func (q *Queries) LoadEventsPagedExistsInnerDesc(ctx context.Context, arg LoadEventsPagedExistsParams) ([]LoadEventsPagedExistsRow, error) {
+	rows, err := q.db.Query(ctx, loadEventsPagedExistsInnerDesc,
+		arg.SortOrder,
+		arg.HasEndpointOrOwnerFilter,
+		arg.HasOwnerID,
+		arg.OwnerID,
+		arg.HasEndpointIds,
+		arg.EndpointIds,
+		arg.ProjectID,
+		arg.HasIdempotencyKey,
+		arg.IdempotencyKey,
+		arg.StartDate,
+		arg.EndDate,
+		arg.HasSourceIds,
+		arg.SourceIds,
+		arg.HasBrokerMessageID,
+		arg.BrokerMessageID,
+		arg.Cursor,
+		arg.Direction,
+		arg.PageLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []LoadEventsPagedExistsRow
+	for rows.Next() {
+		var i LoadEventsPagedExistsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.EventType,
+			&i.IsDuplicateEvent,
+			&i.SourceID,
+			&i.Endpoints,
+			&i.Headers,
+			&i.Raw,
+			&i.Data,
+			&i.CreatedAt,
+			&i.IdempotencyKey,
+			&i.UrlQueryParams,
+			&i.UrlPath,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.AcknowledgedAt,
+			&i.Metadata,
+			&i.Status,
+			&i.FailureReason,
+			&i.SourceMetadataID,
+			&i.SourceMetadataName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+func (q *Queries) LoadEventsPagedExistsInnerAsc(ctx context.Context, arg LoadEventsPagedExistsParams) ([]LoadEventsPagedExistsRow, error) {
+	rows, err := q.db.Query(ctx, loadEventsPagedExistsInnerAsc,
 		arg.SortOrder,
 		arg.HasEndpointOrOwnerFilter,
 		arg.HasOwnerID,

--- a/internal/events/repo/queries_pagination_test.go
+++ b/internal/events/repo/queries_pagination_test.go
@@ -1,0 +1,63 @@
+package repo
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func readQueriesSQL(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join("..", "queries.sql")
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(b)
+}
+
+func extractNamedQuery(t *testing.T, sql, name string) string {
+	t.Helper()
+	marker := "-- name: " + name
+	i := strings.Index(sql, marker)
+	require.NotEqual(t, -1, i, "missing query %s", name)
+	rest := sql[i+len(marker):]
+	j := strings.Index(rest, "\n-- name:")
+	if j == -1 {
+		return rest
+	}
+	return rest[:j]
+}
+
+func innerCTEOrderBy(t *testing.T, query string) string {
+	t.Helper()
+	upper := strings.ToUpper(query)
+	start := strings.Index(upper, "WITH FILTERED_EVENTS AS (")
+	require.NotEqual(t, -1, start)
+	limitIdx := strings.Index(upper[start:], "LIMIT")
+	require.NotEqual(t, -1, limitIdx)
+	cte := upper[start : start+limitIdx]
+	orderIdx := strings.LastIndex(cte, "ORDER BY")
+	require.NotEqual(t, -1, orderIdx)
+	return strings.TrimSpace(cte[orderIdx:])
+}
+
+func TestLoadEventsPagedExistsInnerQueriesUsePlainOrderBy(t *testing.T) {
+	sql := readQueriesSQL(t)
+
+	desc := extractNamedQuery(t, sql, "LoadEventsPagedExistsInnerDesc")
+	asc := extractNamedQuery(t, sql, "LoadEventsPagedExistsInnerAsc")
+
+	descInner := innerCTEOrderBy(t, desc)
+	ascInner := innerCTEOrderBy(t, asc)
+	require.Equal(t, "ORDER BY EV.ID DESC", descInner)
+	require.Equal(t, "ORDER BY EV.ID ASC", ascInner)
+
+	caseOrder := regexp.MustCompile(`ORDER BY\s*\n\s*CASE\s+WHEN`)
+	require.False(t, caseOrder.MatchString(descInner), "inner DESC scan must not use CASE ORDER BY")
+	require.False(t, caseOrder.MatchString(ascInner), "inner ASC scan must not use CASE ORDER BY")
+
+	require.NotContains(t, sql, "-- name: LoadEventsPagedExists :many")
+}


### PR DESCRIPTION
## Summary
- Split `LoadEventsPagedExists` into `LoadEventsPagedExistsInnerDesc` and `LoadEventsPagedExistsInnerAsc` with plain `ORDER BY ev.id` in the inner CTE.
- Route in Go from `sort_order` + pagination direction so generic plans can use `events_pkey` instead of a parameter-dependent `CASE` sort key.
- Add routing and SQL shape tests; search-path query unchanged.

## Test plan
- [x] `go test ./internal/events/... ./internal/events/repo/... -run 'LoadEventsPagedExists|EventsPagedInner|PlainOrderBy'`
- [ ] Deploy to staging and compare events list deep-pagination latency before vs after

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the most critical events list pagination SQL and routing; semantics are intended to match prior cursor/ASC/DESC behavior but regressions would affect every filtered events API page without a search query.
> 
> **Overview**
> Improves **events list pagination** on the no-search-query (EXISTS) path by replacing a single SQL query whose inner CTE used a parameter-dependent `CASE` `ORDER BY` with two queries that use fixed **`ORDER BY ev.id DESC`** or **`ORDER BY ev.id ASC`**, so Postgres can use **`events_pkey`** in generic plans (especially for deep pages).
> 
> **Go** picks the query via `loadEventsPagedExistsRows` and `eventsPagedInnerDesc` from `sort_order` and pagination direction; cursor filters and the outer re-sort for user-facing order are unchanged. The full-text **search** pagination query is untouched.
> 
> Adds unit tests for routing and for asserting the inner CTE shape in `queries.sql`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99c27a02d6b05ee908f4b8e26f50725a2272326d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->