### PR TITLE
fix(dashboard): show the partition operation the button will run

### DIFF
--- a/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.html
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.html
@@ -47,13 +47,15 @@
       <div class="grid grid-cols-2 gap-24px">
         <convoy-input-field>
           <label for="table" convoy-label>Table</label>
+          <!-- No (selectedOption) handler: convoy-select emits before it writes the
+               control, so a handler here would narrow the operation for the table
+               being replaced. The valueChanges subscription carries the new one. -->
           <convoy-select
             [options]="tables"
             name="table"
             formControlName="table"
             placeholder="Select table"
             [searchable]="false"
-            (selectedOption)="applyOperations()"
           ></convoy-select>
         </convoy-input-field>
 

--- a/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.spec.ts
@@ -1,0 +1,111 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { TablePartitionsComponent } from './table-partitions.component';
+import { SelectComponent } from 'src/app/components/select/select.component';
+import { TagComponent } from 'src/app/components/tag/tag.component';
+import { StatusColorModule } from 'src/app/pipes/status-color/status-color.module';
+import { LabelComponent, InputFieldDirective, InputErrorComponent, InputDirective } from 'src/app/components/input/input.component';
+import { AdminService } from '../admin.service';
+import { GeneralService } from 'src/app/services/general/general.service';
+import { LicensesService } from 'src/app/services/licenses/licenses.service';
+
+// events_search is the shape that matters: converted already, so the only
+// operation left for it is the destructive one.
+const TABLE_STATES = [
+	{ name: 'events', partitioned: false, adopted: false },
+	{ name: 'events_search', partitioned: true, adopted: false },
+	{ name: 'event_deliveries', partitioned: false, adopted: false },
+	{ name: 'delivery_attempts', partitioned: false, adopted: false }
+];
+
+describe('TablePartitionsComponent', () => {
+	let fixture: ComponentFixture<TablePartitionsComponent>;
+	let component: TablePartitionsComponent;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [TablePartitionsComponent],
+			imports: [CommonModule, ReactiveFormsModule, SelectComponent, TagComponent, StatusColorModule, LabelComponent, InputFieldDirective, InputErrorComponent, InputDirective],
+			providers: [
+				// Left pending on purpose. ngOnInit still runs, and a stub that
+				// resolves would land mid-pass and re-render the page from a
+				// half-loaded state while these tests are reading the DOM.
+				{
+					provide: AdminService,
+					useValue: {
+						listPartitionTables: () => new Promise(() => {}),
+						listPartitionRuns: () => new Promise(() => {}),
+						startPartitionRun: () => new Promise(() => {})
+					}
+				},
+				{ provide: GeneralService, useValue: { showNotification: () => {} } },
+				{ provide: LicensesService, useValue: { loadAllLicenses: () => new Promise(() => {}), hasInstanceLicense: () => true } }
+			]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(TablePartitionsComponent);
+		component = fixture.componentInstance;
+
+		// Seeded rather than awaited through ngOnInit: the licence and table-state
+		// fetches resolve across change detection passes, and the resulting
+		// half-loaded renders are not what these tests are about.
+		component.hasRetentionLicense = true;
+		component.tableStates = TABLE_STATES;
+		component.tableStatesKnown = true;
+		component.applyOperations();
+
+		// Angular schedules the render, as it does for a real click. Driving
+		// detectChanges by hand instead leaves the view unrefreshed, because
+		// nothing in the test marked it dirty, and then the page looks stale
+		// whether or not the component is.
+		fixture.autoDetectChanges();
+		await fixture.whenStable();
+	});
+
+	function fieldLabelled(label: string): HTMLElement {
+		const fields = Array.from(fixture.nativeElement.querySelectorAll('convoy-input-field')) as HTMLElement[];
+		return fields.find(candidate => candidate.querySelector('label')?.textContent?.trim() === label)!;
+	}
+
+	// The operation as an operator reads it off the page, not as the form holds it.
+	function renderedOperation(): string {
+		return fieldLabelled('Operation').querySelector('div[convoy-input] span')?.textContent?.trim().toLowerCase() ?? '';
+	}
+
+	// Clicked rather than called: selectOption on its own changes no binding
+	// Angular knows about, so the page would keep the markup it first rendered
+	// and every assertion below would pass on a stale DOM.
+	async function chooseTable(name: string) {
+		const field = fieldLabelled('Table');
+		(field.querySelector('[dropdowntrigger]') as HTMLElement).click();
+		await fixture.whenStable();
+
+		const option = Array.from(field.querySelectorAll('button')).find(candidate => candidate.textContent?.trim() === name);
+		(option as HTMLElement).click();
+		await fixture.whenStable();
+	}
+
+	it('shows the operation the button will run on a table that is not partitioned', () => {
+		expect(component.selectedTable).toBe('events');
+		expect(component.resolvedOperation).toBe('partition');
+		expect(renderedOperation()).toBe('partition');
+	});
+
+	it('shows the operation the button will run after switching to a partitioned table', async () => {
+		await chooseTable('events_search');
+
+		expect(component.resolvedOperation).toBe('unpartition');
+		// The label an operator reads must not disagree with the destructive
+		// operation the button starts.
+		expect(renderedOperation()).toBe('unpartition');
+	});
+
+	it('shows the operation the button will run after switching back to a heap', async () => {
+		await chooseTable('events_search');
+		await chooseTable('delivery_attempts');
+
+		expect(component.resolvedOperation).toBe('partition');
+		expect(renderedOperation()).toBe('partition');
+	});
+});

--- a/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.ts
@@ -89,12 +89,18 @@ export class TablePartitionsComponent implements OnInit, OnDestroy {
 		this.tableChanges = this.partitionForm.get('table')!.valueChanges.subscribe(() => this.applyOperations());
 	}
 
+	// Read off the controls, not partitionForm.value. The group's aggregate value
+	// trails a child write, so a getter built on it can still name the table the
+	// operator just switched away from. applyOperations runs in that window, off
+	// the table's own valueChanges, and would narrow the operation for the
+	// previous table: pick a converted table and the select still offers, and
+	// starts, the operation that suited the heap you left.
 	get selectedTable(): string {
-		return this.partitionForm.value.table;
+		return this.partitionForm.get('table')!.value;
 	}
 
 	get selectedOperation(): PartitionOperation {
-		return this.partitionForm.value.operation;
+		return this.partitionForm.get('operation')!.value;
 	}
 
 	// The table's current shape, not the form or the select. Switching tables
@@ -168,9 +174,9 @@ export class TablePartitionsComponent implements OnInit, OnDestroy {
 		const state = this.stateOf(this.selectedTable);
 		const next = state ? [state.partitioned ? UNPARTITION : PARTITION] : ALL_OPERATIONS;
 
-		// Patch before replacing options so writeValue can still find the new
-		// uid in the previous list. Assigning options first leaves the select
-		// showing Unpartition on a heap.
+		// Once the table's shape is known only one operation applies, so move the
+		// control onto it rather than leaving the select on a stale choice the
+		// server would refuse.
 		if (next.length === 1 && this.selectedOperation !== next[0].uid) {
 			this.partitionForm.patchValue({ operation: next[0].uid });
 		}


### PR DESCRIPTION
## Summary

On the instance-admin **Table partitions** page, the Operation select could label an already-converted table with `Partition` while the hint, the confirmation prompt and the button all correctly described `Unpartition`. The label an operator reads disagreed with the destructive operation the page would start.

`selectedTable` and `selectedOperation` read `partitionForm.value`. The group's aggregate value trails a child control write, and `applyOperations()` runs inside that window (off the table control's own `valueChanges`), so selecting a converted table narrowed the operation list for the table just switched away from and patched that uid onto the control. The select then faithfully rendered the wrong operation. Both getters now read their controls directly.

This also drops `(selectedOption)="applyOperations()"` from the table select. `convoy-select` emits `selectedOption` before it calls `control.setValue`, so that handler narrowed for the table being replaced; the `valueChanges` subscription already carries the new one, so the subscription is the single source.

`resolvedOperation` (what `startRun` actually sends) is derived from table state, so a run started from the mislabelled page still sent the correct operation. The bug was the label, not the request.

## Test plan

New spec at `web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.spec.ts` asserts the rendered Operation text, not just the form value, across three states: a heap table, after switching to a partitioned table, and after switching back to a heap.

```
cd web/ui/dashboard
npx ng test --watch=false --browsers=ChromeHeadless --include='**/table-partitions.component.spec.ts'
```

All three fail on `main` (two of them on `resolvedOperation` itself, one on the rendered label) and pass with this change. `ng lint` and `npm run build` are clean.

Note that CI does not run the dashboard unit tests, only lint and build, so this spec is local-only verification for now.

Manual check: as an instance admin with a retention license, open Admin -> Table partitions, select a table that is already partitioned, and confirm the Operation select reads `Unpartition` and agrees with the hint, the banner and the button.