### PR TITLE
fix(controlplane): repair indexes postgres left invalid, rebuild them on demand

### DIFF
--- a/cmd/utils/indexes.go
+++ b/cmd/utils/indexes.go
@@ -1,0 +1,150 @@
+package utils
+
+import (
+	"fmt"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/frain-dev/convoy/internal/pkg/cli"
+	"github.com/frain-dev/convoy/internal/pkg/indexes"
+)
+
+func AddIndexesCommand(a *cli.App) *cobra.Command {
+	var rebuild bool
+
+	cmd := &cobra.Command{
+		Use:   "indexes",
+		Short: "Report indexes Postgres left invalid, and rebuild the ones that were dropped",
+		Long: `Reports two things: indexes that are invalid right now, and indexes a
+migration dropped because they were invalid and has not rebuilt.
+
+An index build that is interrupted, by a pod restart during an upgrade for
+example, leaves the index behind marked invalid. The planner ignores it from
+then on, so the table performs as if the index had never been created, and no
+query fails to say so. Migrations drop what they find, which is instant, and
+record the definition so the build can happen here instead of stalling a boot.
+
+--rebuild builds those indexes again, concurrently, one at a time. On a large
+table this takes hours per index and can be interrupted and run again: it
+resumes rather than starting over. It is cheapest after retention has dropped
+the largest partition of a converted table.`,
+		Annotations: map[string]string{
+			"CheckMigration":  "true",
+			"ShouldBootstrap": "false",
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if rebuild {
+				return rebuildIndexes(cmd, a)
+			}
+			return reportIndexes(cmd, a)
+		},
+	}
+
+	cmd.Flags().BoolVar(&rebuild, "rebuild", false, "Rebuild the indexes that were dropped, concurrently")
+
+	return cmd
+}
+
+func reportIndexes(cmd *cobra.Command, a *cli.App) error {
+	ctx := cmd.Context()
+	db := a.DB.GetConn()
+
+	invalid, err := indexes.ListInvalid(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	dropped, err := indexes.ListDropped(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	if len(invalid) == 0 && len(dropped) == 0 {
+		fmt.Fprintln(out, "No invalid indexes, and none waiting to be rebuilt.")
+		return nil
+	}
+
+	if len(invalid) > 0 {
+		fmt.Fprintf(out, "%d invalid index(es). The planner is ignoring these:\n\n", len(invalid))
+		w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "TABLE\tINDEX\tSTATE")
+		for _, i := range invalid {
+			// A build in progress is marked invalid until it finishes, so it is
+			// reported and left alone rather than treated as a failure.
+			state := "abandoned by a failed build"
+			if i.Busy {
+				state = "being built now, leave it"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\n", i.Table, i.Name, state)
+		}
+		if err := w.Flush(); err != nil {
+			return err
+		}
+		fmt.Fprintln(out)
+	}
+
+	if len(dropped) > 0 {
+		fmt.Fprintf(out, "%d index(es) dropped and not rebuilt. Rebuild them with --rebuild:\n\n", len(dropped))
+		w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "TABLE\tINDEX\tDROPPED\tCOSTS")
+		unique := 0
+		for _, d := range dropped {
+			// A missing index costs speed. A missing unique index also costs the
+			// uniqueness it enforced, which is worth saying out loud.
+			costs := "slower queries"
+			if d.Unique() {
+				costs = "slower queries, and its key is no longer unique"
+				unique++
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", d.Table, d.Name, d.DroppedAt.Format("2006-01-02 15:04 MST"), costs)
+		}
+		if err := w.Flush(); err != nil {
+			return err
+		}
+		if unique > 0 {
+			fmt.Fprintf(out, "\nNothing stops a duplicate row on %d of these until it is rebuilt, so --rebuild starts there.\n", unique)
+		}
+	}
+
+	return nil
+}
+
+func rebuildIndexes(cmd *cobra.Command, a *cli.App) error {
+	ctx := cmd.Context()
+	db := a.DB.GetConn()
+	out := cmd.OutOrStdout()
+
+	dropped, err := indexes.ListDropped(ctx, db)
+	if err != nil {
+		return err
+	}
+	if len(dropped) == 0 {
+		fmt.Fprintln(out, "Nothing to rebuild.")
+		return nil
+	}
+
+	for _, d := range dropped {
+		fmt.Fprintf(out, "Building %s on convoy.%s. This holds no lock against traffic but can take hours.\n", d.Name, d.Table)
+
+		// One failure does not stop the rest: the indexes are independent, and a
+		// table that cannot take one now should not keep the others missing.
+		if err = indexes.Rebuild(ctx, db, d); err != nil {
+			fmt.Fprintf(out, "  failed: %v\n", err)
+			continue
+		}
+		fmt.Fprintf(out, "  done: %s\n", d.Name)
+	}
+
+	remaining, err := indexes.ListDropped(ctx, db)
+	if err != nil {
+		return err
+	}
+	if len(remaining) > 0 {
+		return fmt.Errorf("%d of %d index(es) were not rebuilt, see the failures above", len(remaining), len(dropped))
+	}
+
+	fmt.Fprintln(out, "All dropped indexes rebuilt.")
+	return nil
+}

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -18,6 +18,7 @@ var utilsCmd = &cobra.Command{
 func AddUtilsCommand(app *cli.App) *cobra.Command {
 	utilsCmd.AddCommand(AddPartitionCommand(app))
 	utilsCmd.AddCommand(AddUnPartitionCommand(app))
+	utilsCmd.AddCommand(AddIndexesCommand(app))
 
 	utilsCmd.AddCommand(AddInitEncryptionCommand(app))
 	utilsCmd.AddCommand(AddRotateKeyCommand(app))

--- a/internal/pkg/indexes/indexes.go
+++ b/internal/pkg/indexes/indexes.go
@@ -1,0 +1,421 @@
+// Package indexes reports indexes Postgres left invalid, and rebuilds the ones a
+// migration dropped.
+//
+// An index whose build died partway stays in the catalog marked invalid, and the
+// planner ignores it from then on, so the table performs as if the index had
+// never been created. Migrations cannot repair that themselves: they build
+// CONCURRENTLY, which cannot run in a transaction, so a failed build is not
+// recorded and the retry's CREATE INDEX CONCURRENTLY IF NOT EXISTS is skipped by
+// the invalid index still holding the name. The migration is then recorded as
+// applied.
+//
+// Migrations drop what they find instead, which is instant, and record the
+// definition in convoy.dropped_indexes so the build can happen here, when an
+// operator chooses. Rebuilding is the expensive half: hours on a large table, and
+// it must not run at boot.
+package indexes
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// maxIdentifier is Postgres's identifier length. A name built past it is
+// truncated by the server, silently, which would make two derived names collide.
+const maxIdentifier = 63
+
+// lockTimeout bounds the statements that take a lock on the table: creating the
+// parent index and attaching to it. A rebuild is elective, so it gives way to
+// traffic rather than queueing ahead of it.
+const lockTimeout = "3s"
+
+// Invalid is an index the planner is ignoring.
+type Invalid struct {
+	Table string
+	Name  string
+
+	// Busy reports a live build or another session working on the index. It is
+	// not a failure and must not be touched: an index under construction is
+	// marked invalid until it finishes.
+	Busy bool
+}
+
+// Dropped is an index a migration removed because it was invalid, held with the
+// definition needed to build it again.
+type Dropped struct {
+	Table      string
+	Name       string
+	Definition string
+	DroppedAt  time.Time
+}
+
+// Unique reports whether the index enforced uniqueness, which is the one thing a
+// missing index can cost beyond speed.
+//
+// An invalid index is ignored by the planner but is still maintained by writes
+// if it got as far as the validation scan, and a unique one enforces its key
+// while it is there. Dropping it takes that enforcement away, so these are the
+// rebuilds to run first.
+func (d Dropped) Unique() bool {
+	return strings.HasPrefix(d.Definition, "CREATE UNIQUE ")
+}
+
+// ListInvalid reads the catalog, not convoy.dropped_indexes: these are indexes
+// that are invalid right now, whatever put them that way.
+//
+// Partitioned indexes are left out. One of those is invalid until every
+// partition has an index attached, which is an ordinary intermediate state of a
+// conversion rather than a failure.
+func ListInvalid(ctx context.Context, db *pgxpool.Pool) ([]Invalid, error) {
+	rows, err := db.Query(ctx, `
+        SELECT t.relname,
+               c.relname,
+               EXISTS (SELECT 1 FROM pg_stat_progress_create_index p WHERE p.index_relid = i.indexrelid)
+                   OR EXISTS (SELECT 1 FROM pg_locks l
+                               WHERE l.relation = i.indexrelid AND l.granted AND l.pid <> pg_backend_pid())
+          FROM pg_index i
+          JOIN pg_class c ON c.oid = i.indexrelid
+          JOIN pg_class t ON t.oid = i.indrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'convoy'
+           AND c.relkind = 'i'
+           AND NOT i.indisvalid
+         ORDER BY t.relname, c.relname`)
+	if err != nil {
+		return nil, fmt.Errorf("reading invalid indexes: %w", err)
+	}
+	defer rows.Close()
+
+	var invalid []Invalid
+	for rows.Next() {
+		var i Invalid
+		if err = rows.Scan(&i.Table, &i.Name, &i.Busy); err != nil {
+			return nil, fmt.Errorf("reading invalid indexes: %w", err)
+		}
+		invalid = append(invalid, i)
+	}
+	return invalid, rows.Err()
+}
+
+// ListDropped returns the indexes still owed a rebuild, unique ones first.
+//
+// That order is the order a rebuild should run in, and this is the only place it
+// is decided, so the list an operator reads and the list --rebuild works through
+// cannot disagree. A unique index that is missing is not just slower, it is not
+// enforcing its key, and a rebuild that spends hours on a large non-unique index
+// first leaves that gap open for those hours.
+func ListDropped(ctx context.Context, db *pgxpool.Pool) ([]Dropped, error) {
+	rows, err := db.Query(ctx, `
+        SELECT table_name, index_name, definition, dropped_at
+          FROM convoy.dropped_indexes
+         WHERE rebuilt_at IS NULL
+         ORDER BY (definition LIKE 'CREATE UNIQUE %') DESC, dropped_at`)
+	if err != nil {
+		return nil, fmt.Errorf("reading dropped indexes: %w", err)
+	}
+	defer rows.Close()
+
+	var dropped []Dropped
+	for rows.Next() {
+		var d Dropped
+		if err = rows.Scan(&d.Table, &d.Name, &d.Definition, &d.DroppedAt); err != nil {
+			return nil, fmt.Errorf("reading dropped indexes: %w", err)
+		}
+		dropped = append(dropped, d)
+	}
+	return dropped, rows.Err()
+}
+
+// Rebuild builds one dropped index again and marks it rebuilt.
+//
+// The whole rebuild runs on a single connection so that lock_timeout applies to
+// every statement in it, and so the parent index and the children attached to it
+// cannot be split across connections mid-way.
+//
+// Every statement is written to be safe to run again, because a rebuild on a
+// large table can be interrupted and has to resume rather than start over.
+func Rebuild(ctx context.Context, db *pgxpool.Pool, d Dropped) error {
+	conn, err := db.Acquire(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Release()
+
+	if _, err = conn.Exec(ctx, `SET lock_timeout = '`+lockTimeout+`'`); err != nil {
+		return err
+	}
+
+	partitioned, err := isPartitioned(ctx, conn, d.Table)
+	if err != nil {
+		return err
+	}
+
+	if partitioned {
+		err = rebuildPartitioned(ctx, conn, d)
+	} else {
+		err = rebuildHeap(ctx, conn, d)
+	}
+	if err != nil {
+		return err
+	}
+
+	if _, err = conn.Exec(ctx, `
+        UPDATE convoy.dropped_indexes SET rebuilt_at = NOW()
+         WHERE index_name = $1 AND rebuilt_at IS NULL`, d.Name); err != nil {
+		return fmt.Errorf("index %s was rebuilt but recording that failed, it will be offered again: %w", d.Name, err)
+	}
+	return nil
+}
+
+// rebuildHeap builds the index as it was, online.
+func rebuildHeap(ctx context.Context, conn *pgxpool.Conn, d Dropped) error {
+	// An earlier attempt that died leaves an invalid index holding the name,
+	// which IF NOT EXISTS would skip: the same trap that produced the dropped
+	// index in the first place.
+	if err := dropIfInvalid(ctx, conn, d.Name); err != nil {
+		return err
+	}
+
+	stmt, err := concurrently(d.Definition)
+	if err != nil {
+		return err
+	}
+	if _, err = conn.Exec(ctx, stmt); err != nil {
+		return fmt.Errorf("building %s on convoy.%s: %w", d.Name, d.Table, err)
+	}
+
+	return assertValid(ctx, conn, d.Name,
+		"the name is still held by an index the drop declined to remove, a build in progress or one a constraint owns")
+}
+
+// rebuildPartitioned builds the index across a partitioned table.
+//
+// CREATE INDEX CONCURRENTLY is not supported on a partitioned table, and the
+// plain form recurses into every partition while holding the parent under an
+// exclusive lock for the whole build, which a live instance cannot give. The
+// supported online route is an empty parent index, a concurrent build on each
+// partition, and an attach: the parent turns valid by itself once every partition
+// is covered.
+func rebuildPartitioned(ctx context.Context, conn *pgxpool.Conn, d Dropped) error {
+	parent, err := parentStatement(d.Name, d.Table, d.Definition)
+	if err != nil {
+		return err
+	}
+	if _, err = conn.Exec(ctx, parent); err != nil {
+		return fmt.Errorf("creating the parent index %s on convoy.%s: %w", d.Name, d.Table, err)
+	}
+
+	partitions, err := unindexedPartitions(ctx, conn, d.Table, d.Name)
+	if err != nil {
+		return err
+	}
+
+	for _, partition := range partitions {
+		child := childName(d.Name, partition)
+		create, attach, err := childStatements(d.Name, partition, d.Definition)
+		if err != nil {
+			return err
+		}
+
+		if err := dropIfInvalid(ctx, conn, child); err != nil {
+			return err
+		}
+
+		if _, err = conn.Exec(ctx, create); err != nil {
+			return fmt.Errorf("building %s on partition convoy.%s: %w", child, partition, err)
+		}
+
+		if _, err = conn.Exec(ctx, attach); err != nil {
+			return fmt.Errorf("attaching %s to %s: %w", child, d.Name, err)
+		}
+	}
+
+	// The parent turning valid is the only proof every partition is covered. A
+	// partition added while this ran leaves it invalid, and saying nothing would
+	// record a rebuild that did not finish.
+	return assertValid(ctx, conn, d.Name,
+		fmt.Sprintf("%d partitions were covered, run the rebuild again to pick up the rest", len(partitions)))
+}
+
+// assertValid is what stands between a build that did not happen and a
+// rebuilt_at that says the debt is paid. Every build statement here carries
+// IF NOT EXISTS, which is what lets a rebuild resume, and the same clause makes
+// Postgres silent when the name was already taken by an index it declined to
+// drop. Validity is read from the catalog because that is what the planner
+// reads: an index it ignores is a table with no index, whatever the build
+// returned.
+func assertValid(ctx context.Context, conn *pgxpool.Conn, name, because string) error {
+	var valid bool
+	err := conn.QueryRow(ctx, `
+        SELECT i.indisvalid
+          FROM pg_index i
+          JOIN pg_class c ON c.oid = i.indexrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'convoy' AND c.relname = $1`, name).Scan(&valid)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		return fmt.Errorf("%s is not there after the rebuild, so it stays on the list", name)
+	case err != nil:
+		return fmt.Errorf("checking %s after rebuild: %w", name, err)
+	case !valid:
+		return fmt.Errorf("%s is still invalid after the rebuild: %s", name, because)
+	}
+	return nil
+}
+
+// dropIfInvalid clears an invalid index left by an interrupted attempt, through
+// the same function migrations use, so a build here cannot be skipped by the name
+// already existing.
+//
+// Nothing is recorded. The debt is already on the books as the row being
+// rebuilt, and a partition's copy of an index has no life of its own: recording
+// one would queue a name that only means anything attached to a parent, and
+// rebuilding it alone would leave the parent no closer to valid.
+func dropIfInvalid(ctx context.Context, conn *pgxpool.Conn, name string) error {
+	if _, err := conn.Exec(ctx, `SELECT convoy.drop_invalid_index($1, FALSE)`, name); err != nil {
+		return fmt.Errorf("clearing the invalid index %s: %w", name, err)
+	}
+	return nil
+}
+
+func isPartitioned(ctx context.Context, conn *pgxpool.Conn, table string) (bool, error) {
+	var kind string
+	if err := conn.QueryRow(ctx, `
+        SELECT c.relkind
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'convoy' AND c.relname = $1`, table).Scan(&kind); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, fmt.Errorf("convoy.%s no longer exists", table)
+		}
+		return false, fmt.Errorf("reading the shape of convoy.%s: %w", table, err)
+	}
+	return kind == "p", nil
+}
+
+// unindexedPartitions lists the partitions with no index attached to the parent
+// yet, which is what makes a rebuild resumable: an interrupted run picks up where
+// it stopped instead of re-attaching what is already attached.
+func unindexedPartitions(ctx context.Context, conn *pgxpool.Conn, table, index string) ([]string, error) {
+	rows, err := conn.Query(ctx, `
+        SELECT part.relname
+          FROM pg_inherits h
+          JOIN pg_class part ON part.oid = h.inhrelid
+          JOIN pg_class parent ON parent.oid = h.inhparent
+          JOIN pg_namespace n ON n.oid = parent.relnamespace
+         WHERE n.nspname = 'convoy'
+           AND parent.relname = $1
+           AND NOT EXISTS (
+               SELECT 1
+                 FROM pg_inherits attached
+                 JOIN pg_index child ON child.indexrelid = attached.inhrelid
+                 JOIN pg_class parent_index ON parent_index.oid = attached.inhparent
+                WHERE parent_index.relname = $2
+                  AND parent_index.relnamespace = n.oid
+                  AND child.indrelid = part.oid
+           )
+         ORDER BY part.relname`, table, index)
+	if err != nil {
+		return nil, fmt.Errorf("listing the partitions of convoy.%s: %w", table, err)
+	}
+	defer rows.Close()
+
+	var partitions []string
+	for rows.Next() {
+		var name string
+		if err = rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("listing the partitions of convoy.%s: %w", table, err)
+		}
+		partitions = append(partitions, name)
+	}
+	return partitions, rows.Err()
+}
+
+// concurrently turns a recorded definition into an online build.
+// pg_get_indexdef never writes CONCURRENTLY, and IF NOT EXISTS makes a resumed
+// rebuild skip what an earlier run finished.
+func concurrently(def string) (string, error) {
+	if rest, ok := strings.CutPrefix(def, "CREATE UNIQUE INDEX "); ok {
+		return "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS " + rest, nil
+	}
+	if rest, ok := strings.CutPrefix(def, "CREATE INDEX "); ok {
+		return "CREATE INDEX CONCURRENTLY IF NOT EXISTS " + rest, nil
+	}
+	return "", fmt.Errorf("cannot read the recorded definition: %q", def)
+}
+
+// parentStatement creates the index on the parent alone. It scans nothing and
+// stays invalid until every partition is attached, so it is only a declaration of
+// the shape the children must match.
+func parentStatement(index, table, def string) (string, error) {
+	shape, unique, err := indexShape(def)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(`CREATE %sINDEX IF NOT EXISTS %s ON ONLY %s%s`,
+		unique, ident(index), qualified(table), shape), nil
+}
+
+// childStatements build one partition's copy of the index and hand it to the
+// parent. The build is concurrent because it is the part that reads the data.
+func childStatements(index, partition, def string) (create, attach string, err error) {
+	shape, unique, err := indexShape(def)
+	if err != nil {
+		return "", "", err
+	}
+
+	child := childName(index, partition)
+	create = fmt.Sprintf(`CREATE %sINDEX CONCURRENTLY IF NOT EXISTS %s ON %s%s`,
+		unique, ident(child), qualified(partition), shape)
+	attach = fmt.Sprintf(`ALTER INDEX %s ATTACH PARTITION %s`, qualified(index), qualified(child))
+	return create, attach, nil
+}
+
+// indexShape splits a definition into the part that describes the index, from
+// USING onwards, and whether it is unique. Everything before USING names the
+// index and the table, which a rebuild is replacing.
+func indexShape(def string) (shape, unique string, err error) {
+	at := strings.Index(def, " USING ")
+	if at < 0 {
+		return "", "", fmt.Errorf("cannot read the recorded definition: %q", def)
+	}
+	if strings.HasPrefix(def, "CREATE UNIQUE ") {
+		unique = "UNIQUE "
+	}
+	return def[at:], unique, nil
+}
+
+// childName derives the name of a partition's copy of an index.
+//
+// Partition names already run long, so the obvious index_partition would be
+// truncated by the server to 63 bytes, and truncation cuts the date that
+// distinguishes one partition from the next: two partitions would collide on one
+// name, and IF NOT EXISTS would then attach the first partition's index to the
+// second. A digest of the partition keeps the name both short and distinct, and
+// keeps it a function of its inputs so a resumed rebuild derives the same name.
+func childName(index, partition string) string {
+	sum := sha256.Sum256([]byte(index + "\x00" + partition))
+	digest := hex.EncodeToString(sum[:5])
+
+	base := index
+	if len(base) > maxIdentifier-len(digest)-1 {
+		base = base[:maxIdentifier-len(digest)-1]
+	}
+	return base + "_" + digest
+}
+
+func ident(name string) string {
+	return pgx.Identifier{name}.Sanitize()
+}
+
+func qualified(name string) string {
+	return pgx.Identifier{"convoy", name}.Sanitize()
+}

--- a/internal/pkg/indexes/indexes.go
+++ b/internal/pkg/indexes/indexes.go
@@ -37,6 +37,11 @@ const maxIdentifier = 63
 // traffic rather than queueing ahead of it.
 const lockTimeout = "3s"
 
+// resetTimeout bounds undoing lockTimeout when the connection goes back to the
+// pool. It is short because the alternative to waiting is closing the connection,
+// which is cheap next to leaving a session-wide timeout on a pooled connection.
+const resetTimeout = 5 * time.Second
+
 // Invalid is an index the planner is ignoring.
 type Invalid struct {
 	Table string
@@ -147,8 +152,11 @@ func Rebuild(ctx context.Context, db *pgxpool.Pool, d Dropped) error {
 	if err != nil {
 		return err
 	}
-	defer conn.Release()
+	defer release(ctx, conn)
 
+	// SET, not SET LOCAL: a concurrent index build cannot run in a transaction,
+	// so there is no transaction for the setting to be local to. That makes it
+	// session state on a pooled connection, which release has to undo.
 	if _, err = conn.Exec(ctx, `SET lock_timeout = '`+lockTimeout+`'`); err != nil {
 		return err
 	}
@@ -173,6 +181,25 @@ func Rebuild(ctx context.Context, db *pgxpool.Pool, d Dropped) error {
 		return fmt.Errorf("index %s was rebuilt but recording that failed, it will be offered again: %w", d.Name, err)
 	}
 	return nil
+}
+
+// release hands the connection back with the lock_timeout undone.
+//
+// The pool this came from serves ordinary traffic, where a 3s lock_timeout is
+// wrong: a row-lock wait that is supposed to queue would abort instead. The
+// reset gets a context of its own because it also has to run when the rebuild's
+// context is already cancelled, which is exactly when the setting would
+// otherwise be left behind. If the reset cannot be confirmed, the connection
+// leaves the pool rather than going back carrying it.
+func release(ctx context.Context, conn *pgxpool.Conn) {
+	reset, cancel := context.WithTimeout(context.WithoutCancel(ctx), resetTimeout)
+	defer cancel()
+
+	if _, err := conn.Exec(reset, `RESET lock_timeout`); err != nil {
+		_ = conn.Hijack().Close(reset)
+		return
+	}
+	conn.Release()
 }
 
 // rebuildHeap builds the index as it was, online.

--- a/internal/pkg/indexes/indexes_test.go
+++ b/internal/pkg/indexes/indexes_test.go
@@ -1,0 +1,119 @@
+package indexes
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These are what pg_get_indexdef returns for real indexes in this schema. A
+// partial index and a unique partial one are the two shapes a rebuild has to
+// reproduce exactly: drop either the WHERE or the UNIQUE and the index built is
+// not the index that was dropped.
+const (
+	statusCreatedDef = `CREATE INDEX idx_event_deliveries_endpoint_status_created ON convoy.event_deliveries ` +
+		`USING btree (project_id, endpoint_id, status, created_at) WHERE (deleted_at IS NULL)`
+	uniqueDef = `CREATE UNIQUE INDEX idx_partition_runs_single_active ON convoy.partition_runs ` +
+		`USING btree (status) WHERE (status = 'running'::text)`
+)
+
+func TestConcurrently(t *testing.T) {
+	stmt, err := concurrently(statusCreatedDef)
+	require.NoError(t, err)
+	require.Equal(t, `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_event_deliveries_endpoint_status_created `+
+		`ON convoy.event_deliveries USING btree (project_id, endpoint_id, status, created_at) `+
+		`WHERE (deleted_at IS NULL)`, stmt)
+}
+
+func TestConcurrentlyKeepsUnique(t *testing.T) {
+	stmt, err := concurrently(uniqueDef)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(stmt, "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "), stmt)
+}
+
+// Uniqueness is the one thing a dropped index costs beyond speed, so the report
+// has to be able to tell those apart.
+func TestUniqueIsReadFromTheDefinition(t *testing.T) {
+	require.True(t, Dropped{Definition: uniqueDef}.Unique())
+	require.False(t, Dropped{Definition: statusCreatedDef}.Unique())
+}
+
+// A definition that cannot be read must stop the rebuild. Guessing at it would
+// build an index that is not the one that was dropped.
+func TestConcurrentlyRejectsUnreadableDefinition(t *testing.T) {
+	_, err := concurrently(`ALTER TABLE convoy.events ADD COLUMN x TEXT`)
+	require.Error(t, err)
+}
+
+func TestParentStatementCoversNoRowsYet(t *testing.T) {
+	stmt, err := parentStatement("idx_event_deliveries_endpoint_status_created", "event_deliveries", statusCreatedDef)
+	require.NoError(t, err)
+	require.Equal(t, `CREATE INDEX IF NOT EXISTS "idx_event_deliveries_endpoint_status_created" `+
+		`ON ONLY "convoy"."event_deliveries" USING btree (project_id, endpoint_id, status, created_at) `+
+		`WHERE (deleted_at IS NULL)`, stmt)
+
+	// ON ONLY is what keeps this from recursing into every partition under an
+	// exclusive lock, and CONCURRENTLY is not supported here.
+	require.Contains(t, stmt, " ON ONLY ")
+	require.NotContains(t, stmt, "CONCURRENTLY")
+}
+
+func TestChildStatementsBuildConcurrentlyThenAttach(t *testing.T) {
+	const partition = "event_deliveries_01J8ZQ4T6K9WCS0M3XN7HB2VDR_20260819"
+
+	create, attach, err := childStatements("idx_event_deliveries_endpoint_status_created", partition, statusCreatedDef)
+	require.NoError(t, err)
+
+	child := childName("idx_event_deliveries_endpoint_status_created", partition)
+	require.Contains(t, create, "CREATE INDEX CONCURRENTLY IF NOT EXISTS ")
+	require.Contains(t, create, `ON "convoy".`+`"`+partition+`"`)
+	require.Contains(t, create, "WHERE (deleted_at IS NULL)")
+	require.Equal(t, `ALTER INDEX "convoy"."idx_event_deliveries_endpoint_status_created" `+
+		`ATTACH PARTITION "convoy"."`+child+`"`, attach)
+}
+
+func TestChildStatementsCarryUnique(t *testing.T) {
+	create, _, err := childStatements("idx_partition_runs_single_active", "partition_runs_20260819", uniqueDef)
+	require.NoError(t, err)
+
+	// A child index of a unique parent has to be unique too, or the attach is
+	// rejected and the parent never turns valid.
+	require.Contains(t, create, "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ")
+}
+
+func TestChildNameFitsAnIdentifier(t *testing.T) {
+	long := "idx_event_deliveries_project_endpoint_status_created_at_partial_covering"
+	require.Greater(t, len(long), maxIdentifier)
+
+	name := childName(long, "event_deliveries_01J8ZQ4T6K9WCS0M3XN7HB2VDR_20260819")
+	require.LessOrEqual(t, len(name), maxIdentifier)
+}
+
+// Partition names differ at the end, in the date, which is exactly what a
+// truncated name loses. Two partitions of one table must not derive the same
+// child name: IF NOT EXISTS would then skip the second build and attach the
+// first partition's index in its place.
+func TestChildNameSeparatesPartitionsThatShareAPrefix(t *testing.T) {
+	const index = "idx_event_deliveries_endpoint_status_created_at_partial_covering"
+
+	first := childName(index, "event_deliveries_01J8ZQ4T6K9WCS0M3XN7HB2VDR_20260819")
+	second := childName(index, "event_deliveries_01J8ZQ4T6K9WCS0M3XN7HB2VDR_20260820")
+
+	require.NotEqual(t, first, second)
+	require.LessOrEqual(t, len(first), maxIdentifier)
+	require.LessOrEqual(t, len(second), maxIdentifier)
+}
+
+// A resumed rebuild derives names again rather than reading them back, so the
+// same inputs have to give the same name.
+func TestChildNameIsStable(t *testing.T) {
+	first := childName("idx_events_created_at", "events_01J8ZQ4T6K9WCS0M3XN7HB2VDR_20260819")
+	second := childName("idx_events_created_at", "events_01J8ZQ4T6K9WCS0M3XN7HB2VDR_20260819")
+	require.Equal(t, first, second)
+}
+
+func TestIndexShapeRejectsUnreadableDefinition(t *testing.T) {
+	_, _, err := indexShape(`CREATE INDEX broken ON convoy.events (created_at)`)
+	require.Error(t, err)
+}

--- a/internal/pkg/indexes/repair_test.go
+++ b/internal/pkg/indexes/repair_test.go
@@ -312,6 +312,50 @@ func TestDroppedIndexesAreOfferedUniqueFirst(t *testing.T) {
 	require.True(t, owed[0].Unique())
 }
 
+// A concurrent build cannot run in a transaction, so the rebuild's lock_timeout
+// is session state on a pooled connection. Left behind, it would abort row-lock
+// waits in ordinary traffic that are supposed to queue.
+func TestRebuildLeavesNoLockTimeoutOnThePool(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+
+	_, err := db.Exec(ctx, `CREATE TABLE convoy.idx_test_reset (k TEXT)`)
+	require.NoError(t, err)
+
+	owed := Dropped{
+		Table:      "idx_test_reset",
+		Name:       "idx_test_reset_k",
+		Definition: `CREATE INDEX idx_test_reset_k ON convoy.idx_test_reset USING btree (k)`,
+	}
+	_, err = db.Exec(ctx, `
+        INSERT INTO convoy.dropped_indexes (index_name, table_name, definition)
+        VALUES ($1, $2, $3)`, owed.Name, owed.Table, owed.Definition)
+	require.NoError(t, err)
+
+	require.NoError(t, Rebuild(ctx, db, owed))
+
+	// Check every connection the pool is holding, not one, since the rebuild's
+	// connection is only the one most likely to be handed back first.
+	idle := int(db.Stat().IdleConns())
+	require.Positive(t, idle, "the rebuild's connection should be back in the pool")
+
+	held := make([]*pgxpool.Conn, 0, idle)
+	defer func() {
+		for _, c := range held {
+			c.Release()
+		}
+	}()
+	for i := 0; i < idle; i++ {
+		conn, err := db.Acquire(ctx)
+		require.NoError(t, err)
+		held = append(held, conn)
+
+		var timeout string
+		require.NoError(t, conn.QueryRow(ctx, `SHOW lock_timeout`).Scan(&timeout))
+		require.Equal(t, "0", timeout, "a pooled connection is still carrying the rebuild's lock_timeout")
+	}
+}
+
 func TestRebuildRejectsAMissingTable(t *testing.T) {
 	db := setupDB(t)
 

--- a/internal/pkg/indexes/repair_test.go
+++ b/internal/pkg/indexes/repair_test.go
@@ -1,0 +1,345 @@
+package indexes
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+
+	"github.com/frain-dev/convoy/database/postgres"
+	"github.com/frain-dev/convoy/testenv"
+)
+
+var testEnv *testenv.Environment
+
+func TestMain(m *testing.M) {
+	res, cleanup, err := testenv.Launch(context.Background())
+	if err != nil {
+		fmt.Printf("Failed to launch test environment: %v\n", err)
+		os.Exit(1)
+	}
+
+	testEnv = res
+
+	code := m.Run()
+
+	if err := cleanup(); err != nil {
+		fmt.Printf("Failed to cleanup test infrastructure: %v\n", err)
+	}
+
+	os.Exit(code)
+}
+
+// The repair reads and writes the catalog and one table, so it needs a migrated
+// database and nothing else from the application's config.
+func setupDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	conn, err := testEnv.CloneTestDatabase(t, "convoy")
+	require.NoError(t, err)
+
+	return postgres.NewFromConnection(conn).GetConn()
+}
+
+// A unique build over duplicate rows is how an invalid index is produced here.
+// It fails the way an interrupted build does, leaving the index in the catalog
+// marked invalid, and it does so without writing to the catalog by hand, so the
+// test exercises the state Postgres actually leaves behind.
+func TestInvalidIndexIsReportedDroppedAndRebuilt(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+
+	_, err := db.Exec(ctx, `
+        CREATE TABLE convoy.idx_test_heap (project_id TEXT NOT NULL, created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `INSERT INTO convoy.idx_test_heap (project_id) VALUES ('dup'), ('dup')`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `CREATE UNIQUE INDEX CONCURRENTLY idx_test_heap_project ON convoy.idx_test_heap (project_id)`)
+	require.Error(t, err, "the build has to fail for there to be an invalid index to repair")
+
+	invalid, err := ListInvalid(ctx, db)
+	require.NoError(t, err)
+	require.Contains(t, names(invalid), "idx_test_heap_project")
+
+	// The build is over, so nothing should read as busy. Reporting it busy would
+	// make the migration refuse to drop it.
+	for _, i := range invalid {
+		if i.Name == "idx_test_heap_project" {
+			require.False(t, i.Busy, "a failed build is not a build in progress")
+		}
+	}
+
+	var dropped bool
+	require.NoError(t, db.QueryRow(ctx,
+		`SELECT convoy.drop_invalid_index('idx_test_heap_project')`).Scan(&dropped))
+	require.True(t, dropped)
+
+	owed, err := ListDropped(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, owed, 1)
+	require.Equal(t, "idx_test_heap_project", owed[0].Name)
+	require.Equal(t, "idx_test_heap", owed[0].Table)
+	require.Contains(t, owed[0].Definition, "CREATE UNIQUE INDEX")
+
+	// The definition is what the rebuild is built from, so it has to describe the
+	// index that was dropped, not a plain one. While the duplicates are still
+	// there a unique build cannot succeed, and the debt has to survive that.
+	require.Error(t, Rebuild(ctx, db, owed[0]))
+	owed, err = ListDropped(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, owed, 1, "a rebuild that failed still owes the index")
+
+	_, err = db.Exec(ctx, `DELETE FROM convoy.idx_test_heap WHERE ctid = (
+        SELECT MIN(ctid) FROM convoy.idx_test_heap WHERE project_id = 'dup')`)
+	require.NoError(t, err)
+
+	require.NoError(t, Rebuild(ctx, db, owed[0]))
+	require.True(t, valid(t, db, "idx_test_heap_project"))
+
+	owed, err = ListDropped(ctx, db)
+	require.NoError(t, err)
+	require.Empty(t, owed, "a rebuilt index must not be offered again")
+}
+
+// The index has to be rebuildable after the table is partitioned, which is the
+// order the repair happens in: the drop unblocks the conversion, and the rebuild
+// comes later, once retention has dropped the largest partition.
+func TestRebuildOnPartitionedTableAttachesEveryPartition(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+
+	_, err := db.Exec(ctx, `
+        CREATE TABLE convoy.idx_test_part (project_id TEXT NOT NULL, created_at TIMESTAMPTZ NOT NULL)
+            PARTITION BY RANGE (project_id, created_at)`)
+	require.NoError(t, err)
+
+	for _, day := range []struct{ suffix, from, to string }{
+		{"19", "2026-08-19", "2026-08-20"},
+		{"20", "2026-08-20", "2026-08-21"},
+	} {
+		_, err = db.Exec(ctx, fmt.Sprintf(`
+            CREATE TABLE convoy.idx_test_part_%s PARTITION OF convoy.idx_test_part
+                FOR VALUES FROM ('p1', '%s') TO ('p1', '%s')`, day.suffix, day.from, day.to))
+		require.NoError(t, err)
+	}
+
+	_, err = db.Exec(ctx, `
+        INSERT INTO convoy.idx_test_part (project_id, created_at)
+        SELECT 'p1', '2026-08-19'::TIMESTAMPTZ FROM generate_series(1, 50)`)
+	require.NoError(t, err)
+
+	owed := Dropped{
+		Table: "idx_test_part",
+		Name:  "idx_test_part_created",
+		Definition: `CREATE INDEX idx_test_part_created ON convoy.idx_test_part ` +
+			`USING btree (project_id, created_at)`,
+	}
+	_, err = db.Exec(ctx, `
+        INSERT INTO convoy.dropped_indexes (index_name, table_name, definition)
+        VALUES ($1, $2, $3)`, owed.Name, owed.Table, owed.Definition)
+	require.NoError(t, err)
+
+	require.NoError(t, Rebuild(ctx, db, owed))
+
+	// The parent index only turns valid once every partition has one attached, so
+	// this single assertion covers the whole recipe.
+	require.True(t, valid(t, db, owed.Name),
+		"the parent index is invalid, so a partition was left uncovered")
+
+	var attached int
+	require.NoError(t, db.QueryRow(ctx, `
+        SELECT COUNT(*)
+          FROM pg_inherits h
+          JOIN pg_class parent ON parent.oid = h.inhparent
+         WHERE parent.relname = $1`, owed.Name).Scan(&attached))
+	require.Equal(t, 2, attached)
+
+	// A rebuild that is interrupted has to be safe to run again. Nothing is left
+	// to cover, so this must neither fail nor duplicate an attach.
+	require.NoError(t, Rebuild(ctx, db, owed))
+	require.True(t, valid(t, db, owed.Name))
+}
+
+// A partition added after the rebuild leaves the parent invalid again, and the
+// next run has to cover it rather than report success.
+func TestRebuildCoversPartitionsAddedLater(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+
+	_, err := db.Exec(ctx, `
+        CREATE TABLE convoy.idx_test_late (project_id TEXT NOT NULL, created_at TIMESTAMPTZ NOT NULL)
+            PARTITION BY RANGE (project_id, created_at)`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+        CREATE TABLE convoy.idx_test_late_19 PARTITION OF convoy.idx_test_late
+            FOR VALUES FROM ('p1', '2026-08-19') TO ('p1', '2026-08-20')`)
+	require.NoError(t, err)
+
+	owed := Dropped{
+		Table:      "idx_test_late",
+		Name:       "idx_test_late_created",
+		Definition: `CREATE INDEX idx_test_late_created ON convoy.idx_test_late USING btree (project_id, created_at)`,
+	}
+	_, err = db.Exec(ctx, `
+        INSERT INTO convoy.dropped_indexes (index_name, table_name, definition)
+        VALUES ($1, $2, $3)`, owed.Name, owed.Table, owed.Definition)
+	require.NoError(t, err)
+
+	require.NoError(t, Rebuild(ctx, db, owed))
+
+	_, err = db.Exec(ctx, `
+        CREATE TABLE convoy.idx_test_late_20 PARTITION OF convoy.idx_test_late
+            FOR VALUES FROM ('p1', '2026-08-20') TO ('p1', '2026-08-21')`)
+	require.NoError(t, err)
+
+	require.NoError(t, Rebuild(ctx, db, owed))
+	require.True(t, valid(t, db, owed.Name))
+}
+
+// Every build statement carries IF NOT EXISTS so a rebuild can resume, which
+// means Postgres says nothing when the name is already held by an index it
+// declined to drop: a build in progress, or one a constraint owns. Without this
+// check the rebuild would return success and mark the debt paid while the
+// planner still ignores the index.
+func TestARebuildIsNotDoneWhileTheIndexIsStillInvalid(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+
+	_, err := db.Exec(ctx, `
+        CREATE TABLE convoy.idx_test_guard (project_id TEXT NOT NULL)`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `INSERT INTO convoy.idx_test_guard (project_id) VALUES ('dup'), ('dup')`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `CREATE UNIQUE INDEX CONCURRENTLY idx_test_guard_project ON convoy.idx_test_guard (project_id)`)
+	require.Error(t, err)
+
+	conn, err := db.Acquire(ctx)
+	require.NoError(t, err)
+	defer conn.Release()
+
+	require.ErrorContains(t, assertValid(ctx, conn, "idx_test_guard_project", "because"), "still invalid")
+	require.ErrorContains(t, assertValid(ctx, conn, "idx_test_guard_absent", "because"), "not there")
+}
+
+// A partition's copy of an index has no meaning on its own. The rebuild drops an
+// invalid one on its way past, and recording that would queue a name whose
+// rebuild leaves the parent no closer to valid.
+func TestAPartitionsCopyIsNotQueuedAsItsOwnDebt(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+
+	_, err := db.Exec(ctx, `
+        CREATE TABLE convoy.idx_test_copy (project_id TEXT NOT NULL, created_at TIMESTAMPTZ NOT NULL)
+            PARTITION BY RANGE (project_id, created_at)`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+        CREATE TABLE convoy.idx_test_copy_19 PARTITION OF convoy.idx_test_copy
+            FOR VALUES FROM ('p1', '2026-08-19') TO ('p1', '2026-08-20')`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(ctx, `
+        INSERT INTO convoy.idx_test_copy (project_id, created_at)
+        VALUES ('p1', '2026-08-19'), ('p1', '2026-08-19')`)
+	require.NoError(t, err)
+
+	owed := Dropped{
+		Table: "idx_test_copy",
+		Name:  "idx_test_copy_created",
+		Definition: `CREATE UNIQUE INDEX idx_test_copy_created ON convoy.idx_test_copy ` +
+			`USING btree (project_id, created_at)`,
+	}
+	_, err = db.Exec(ctx, `
+        INSERT INTO convoy.dropped_indexes (index_name, table_name, definition)
+        VALUES ($1, $2, $3)`, owed.Name, owed.Table, owed.Definition)
+	require.NoError(t, err)
+
+	// An earlier run that died on this partition is what leaves a copy behind
+	// under the name the next run will want.
+	child := childName(owed.Name, "idx_test_copy_19")
+	_, err = db.Exec(ctx, fmt.Sprintf(
+		`CREATE UNIQUE INDEX CONCURRENTLY %s ON convoy.idx_test_copy_19 (project_id, created_at)`, child))
+	require.Error(t, err, "the duplicate rows are there to make this build fail")
+
+	_, err = db.Exec(ctx, `
+        DELETE FROM convoy.idx_test_copy
+         WHERE ctid = (SELECT MIN(ctid) FROM convoy.idx_test_copy)`)
+	require.NoError(t, err)
+
+	require.NoError(t, Rebuild(ctx, db, owed))
+	require.True(t, valid(t, db, owed.Name))
+
+	var queued []string
+	rows, err := db.Query(ctx, `SELECT index_name FROM convoy.dropped_indexes WHERE rebuilt_at IS NULL`)
+	require.NoError(t, err)
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		queued = append(queued, name)
+	}
+	require.NoError(t, rows.Err())
+	require.Empty(t, queued, "the parent is rebuilt and its partitions were never debts of their own")
+}
+
+// A rebuild works through this list in order, and a unique index that is missing
+// is not enforcing its key, so it cannot wait behind hours of work on a large
+// non-unique one.
+func TestDroppedIndexesAreOfferedUniqueFirst(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+
+	_, err := db.Exec(ctx, `
+        INSERT INTO convoy.dropped_indexes (index_name, table_name, definition, dropped_at)
+        VALUES ('idx_test_plain', 'events', 'CREATE INDEX idx_test_plain ON convoy.events USING btree (created_at)',
+                NOW() - INTERVAL '2 days'),
+               ('idx_test_uniq', 'partition_runs', 'CREATE UNIQUE INDEX idx_test_uniq ON convoy.partition_runs USING btree (status)',
+                NOW())`)
+	require.NoError(t, err)
+
+	owed, err := ListDropped(ctx, db)
+	require.NoError(t, err)
+	require.Len(t, owed, 2)
+	require.Equal(t, "idx_test_uniq", owed[0].Name, "the unique index waited two days less and still goes first")
+	require.True(t, owed[0].Unique())
+}
+
+func TestRebuildRejectsAMissingTable(t *testing.T) {
+	db := setupDB(t)
+
+	err := Rebuild(context.Background(), db, Dropped{
+		Table:      "idx_test_gone",
+		Name:       "idx_test_gone_created",
+		Definition: `CREATE INDEX idx_test_gone_created ON convoy.idx_test_gone USING btree (created_at)`,
+	})
+	require.ErrorContains(t, err, "no longer exists")
+}
+
+func names(invalid []Invalid) []string {
+	out := make([]string, 0, len(invalid))
+	for _, i := range invalid {
+		out = append(out, i.Name)
+	}
+	return out
+}
+
+func valid(t *testing.T, db *pgxpool.Pool, index string) bool {
+	t.Helper()
+
+	var isValid bool
+	require.NoError(t, db.QueryRow(context.Background(), `
+        SELECT i.indisvalid
+          FROM pg_index i
+          JOIN pg_class c ON c.oid = i.indexrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'convoy' AND c.relname = $1`, index).Scan(&isValid))
+	return isValid
+}

--- a/sql/1787153561.sql
+++ b/sql/1787153561.sql
@@ -1,0 +1,43 @@
+-- +migrate Up
+SET lock_timeout = '2s';
+SET statement_timeout = '30s';
+
+-- An index build that dies partway leaves the index behind, marked invalid. The
+-- planner ignores it from then on, so the table reads as if the index was never
+-- created, and nothing in Convoy noticed: the only reader of pg_index.indisvalid
+-- was the partition preflight, which is why the first report of this came from an
+-- operator trying to partition a table.
+--
+-- Nothing repaired it either. Index migrations build CONCURRENTLY, which cannot
+-- run inside a transaction, so they are marked notransaction: when the build
+-- fails, sql-migrate returns the error without recording the migration and
+-- without a transaction to roll back. The retry on the next boot runs
+-- CREATE INDEX CONCURRENTLY IF NOT EXISTS, which sees the invalid index already
+-- holding the name, skips the build, and succeeds. The migration is then recorded
+-- as applied and the index stays invalid for good.
+--
+-- This table is what makes dropping such an index recoverable. An invalid index
+-- cannot be rebuilt cheaply on a large table, and doing it at boot would stall an
+-- upgrade for hours, so the repair is split: drop now, which is instant and
+-- unblocks partitioning, and rebuild later on an operator's schedule from the
+-- definition recorded here. The drop itself is the next migration, which cannot
+-- share this one: index operations and table DDL belong in separate blocks.
+CREATE TABLE IF NOT EXISTS convoy.dropped_indexes (
+    index_name TEXT PRIMARY KEY,
+    table_name TEXT NOT NULL,
+    definition TEXT NOT NULL,
+    dropped_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    rebuilt_at TIMESTAMPTZ
+);
+
+RESET lock_timeout;
+RESET statement_timeout;
+
+-- +migrate Down
+SET lock_timeout = '2s';
+SET statement_timeout = '30s';
+
+DROP TABLE IF EXISTS convoy.dropped_indexes;
+
+RESET lock_timeout;
+RESET statement_timeout;

--- a/sql/1787153562.sql
+++ b/sql/1787153562.sql
@@ -87,11 +87,17 @@ BEGIN
 
     EXECUTE FORMAT('DROP INDEX convoy.%I', p_index);
 
-    -- An invalid index is ignored by the planner but is still maintained by
-    -- writes once it reached the validation scan, so a unique one was enforcing
-    -- its key right up to this drop. Losing an index costs speed; losing this
-    -- one also costs the uniqueness, which the operator has to hear about.
-    IF v_def LIKE 'CREATE UNIQUE %' THEN
+    -- Only a recorded drop leaves work behind to advise about. The unrecorded
+    -- one is a rebuild clearing a leftover on its way to building the index
+    -- back, so pointing the caller at --rebuild would name what they are
+    -- already running.
+    IF NOT p_record THEN
+        RAISE NOTICE 'cleared the invalid index convoy.% left by an earlier attempt', p_index;
+    ELSIF v_def LIKE 'CREATE UNIQUE %' THEN
+        -- An invalid index is ignored by the planner but is still maintained by
+        -- writes once it reached the validation scan, so a unique one was
+        -- enforcing its key right up to this drop. Losing an index costs speed;
+        -- losing this one also costs the uniqueness.
         RAISE WARNING 'dropped invalid unique index convoy.%: its key is no longer unique until rebuilt with convoy utils indexes --rebuild', p_index;
     ELSE
         RAISE NOTICE 'dropped invalid index convoy.%, rebuild it with: convoy utils indexes --rebuild', p_index;

--- a/sql/1787153562.sql
+++ b/sql/1787153562.sql
@@ -1,0 +1,138 @@
+-- +migrate Up
+SET lock_timeout = '2s';
+SET statement_timeout = '30s';
+
+-- Capture and drop one invalid index, reporting whether it dropped anything. The
+-- definition goes into convoy.dropped_indexes first, because after the drop there
+-- is nothing left to read it from.
+--
+-- Future migrations that build an index concurrently call this first, so a retry
+-- after a killed build drops the invalid leftover and rebuilds it, rather than
+-- being skipped by IF NOT EXISTS and recorded as done.
+--
+-- The drop is not CONCURRENTLY: that cannot run inside a function, and it does not
+-- need to. The index is invalid, so no plan depends on it, and the brief ACCESS
+-- EXCLUSIVE it takes is bounded by the caller's lock_timeout.
+--
+-- p_record is FALSE for a drop whose debt is already recorded elsewhere: the
+-- rebuild of a partitioned index clears each partition's copy on the way, and
+-- those names mean nothing on their own. Rebuilding one alone would leave the
+-- parent no closer to valid, so queueing it would be queueing the wrong work.
+-- +migrate StatementBegin
+CREATE OR REPLACE FUNCTION convoy.drop_invalid_index(p_index TEXT, p_record BOOLEAN DEFAULT TRUE) RETURNS BOOLEAN
+    LANGUAGE plpgsql AS $$
+DECLARE
+    v_oid   OID;
+    v_table TEXT;
+    v_def   TEXT;
+BEGIN
+    -- relkind 'i' excludes a partitioned index, which is invalid for a reason
+    -- that is not a failure: it stays that way until every partition has an
+    -- index attached, which is a normal intermediate state of a conversion. The
+    -- pg_inherits check excludes a child of one, which Postgres refuses to drop
+    -- on its own anyway.
+    SELECT i.indexrelid, t.relname, pg_get_indexdef(i.indexrelid)
+      INTO v_oid, v_table, v_def
+      FROM pg_index i
+      JOIN pg_class c ON c.oid = i.indexrelid
+      JOIN pg_class t ON t.oid = i.indrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = 'convoy'
+       AND c.relname = p_index
+       AND c.relkind = 'i'
+       AND NOT i.indisvalid
+       AND NOT EXISTS (SELECT 1 FROM pg_inherits WHERE inhrelid = i.indexrelid);
+
+    IF v_oid IS NULL THEN
+        RETURN FALSE;
+    END IF;
+
+    -- An index still being built is also marked invalid, and the catalog alone
+    -- cannot tell that apart from one abandoned by a dead build. Dropping it
+    -- would destroy work someone is waiting on, so leave it: it either finishes
+    -- and turns valid, or it fails and the next caller finds it idle.
+    --
+    -- The progress view is checked first but cannot be trusted on its own: a role
+    -- without pg_read_all_stats sees only its own sessions there, so a build
+    -- started by the application would look absent. A lock nobody else should be
+    -- holding is the reliable half. The planner ignores invalid indexes, so no
+    -- ordinary query locks this one, which leaves a live build or another repair
+    -- as the explanations. Both checks fail towards leaving the index alone.
+    IF EXISTS (SELECT 1 FROM pg_stat_progress_create_index WHERE index_relid = v_oid)
+        OR EXISTS (SELECT 1 FROM pg_locks
+                    WHERE relation = v_oid AND granted AND pid <> pg_backend_pid()) THEN
+        RAISE NOTICE 'convoy.% is invalid but a build is in progress, leaving it alone', p_index;
+        RETURN FALSE;
+    END IF;
+
+    -- A constraint owns its index and the drop has to go through the constraint,
+    -- which changes what the table enforces. That is not this function's call.
+    IF EXISTS (SELECT 1 FROM pg_constraint WHERE conindid = v_oid) THEN
+        RAISE NOTICE 'convoy.% is invalid but a constraint depends on it, leaving it alone', p_index;
+        RETURN FALSE;
+    END IF;
+
+    -- REINDEX CONCURRENTLY leftovers are transient copies of an index that still
+    -- exists under its own name. Recording one would queue a rebuild that
+    -- recreates the copy rather than the index, so drop it without recording.
+    IF p_record AND p_index NOT LIKE '%\_ccnew%' AND p_index NOT LIKE '%\_ccold%' THEN
+        INSERT INTO convoy.dropped_indexes (index_name, table_name, definition)
+        VALUES (p_index, v_table, v_def)
+        ON CONFLICT (index_name) DO UPDATE
+            SET table_name = EXCLUDED.table_name,
+                definition = EXCLUDED.definition,
+                dropped_at = NOW(),
+                rebuilt_at = NULL;
+    END IF;
+
+    EXECUTE FORMAT('DROP INDEX convoy.%I', p_index);
+
+    -- An invalid index is ignored by the planner but is still maintained by
+    -- writes once it reached the validation scan, so a unique one was enforcing
+    -- its key right up to this drop. Losing an index costs speed; losing this
+    -- one also costs the uniqueness, which the operator has to hear about.
+    IF v_def LIKE 'CREATE UNIQUE %' THEN
+        RAISE WARNING 'dropped invalid unique index convoy.%: its key is no longer unique until rebuilt with convoy utils indexes --rebuild', p_index;
+    ELSE
+        RAISE NOTICE 'dropped invalid index convoy.%, rebuild it with: convoy utils indexes --rebuild', p_index;
+    END IF;
+    RETURN TRUE;
+END $$;
+-- +migrate StatementEnd
+
+-- Repair what earlier upgrades left behind. This runs inside the migration's
+-- transaction, so each capture and its drop commit together or not at all, and a
+-- lock_timeout means a table busy with long queries fails the migration rather
+-- than blocking the boot. A failed migration is not recorded, so the next boot
+-- retries this cleanly.
+-- +migrate StatementBegin
+DO $$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT c.relname
+          FROM pg_index i
+          JOIN pg_class c ON c.oid = i.indexrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'convoy'
+           AND c.relkind = 'i'
+           AND NOT i.indisvalid
+         ORDER BY c.relname
+        LOOP
+            PERFORM convoy.drop_invalid_index(r.relname);
+        END LOOP;
+END $$;
+-- +migrate StatementEnd
+
+RESET lock_timeout;
+RESET statement_timeout;
+
+-- +migrate Down
+SET lock_timeout = '2s';
+SET statement_timeout = '30s';
+
+DROP FUNCTION IF EXISTS convoy.drop_invalid_index(TEXT, BOOLEAN);
+
+RESET lock_timeout;
+RESET statement_timeout;


### PR DESCRIPTION
## Summary

An index build that dies partway leaves the index in the catalog marked invalid. The planner ignores it from then on, so the table performs as if the index had never been created, and nothing reports it: the only reader of `pg_index.indisvalid` was the partition preflight, so the first sign of one is a conversion refusing to start.

Nothing repaired it either. Index migrations build `CONCURRENTLY`, which cannot run in a transaction, so those blocks are `notransaction`: a killed build is not recorded and has no transaction to roll back. The retry on the next boot runs `CREATE INDEX CONCURRENTLY IF NOT EXISTS`, which the invalid index holding the name causes to be skipped, and the migration is then recorded as applied. 26 migrations build this way, so any instance restarted mid-upgrade can carry silently dead indexes.

The repair is split along the cost line, because the two halves are nothing alike:

- **Migration** captures `pg_get_indexdef` into `convoy.dropped_indexes` and drops the index. Instant, and it unblocks partitioning.
- **`convoy utils indexes`** reports what is invalid now and what is owed a rebuild. `--rebuild` does the expensive half on an operator's schedule: hours per index on a large table, resumable rather than starting over, and giving way to traffic on a lock. A partitioned table gets the only online recipe there is, an empty parent index, a concurrent build per partition, then attach.

`convoy.drop_invalid_index` is also what future concurrent-index migrations call first, so a retry after a killed build drops the leftover and rebuilds instead of being skipped. That is the root fix; the rest is cleaning up what the old behaviour left behind.

The function declines to touch an index it cannot safely drop: a build in progress (progress view plus a lock nobody else should hold), one a constraint owns, or a partitioned index, which is invalid until every partition is attached and is a normal intermediate state of a conversion rather than a failure.

## Unique indexes cost more than speed

An invalid index is ignored by the planner but is still maintained by writes once it reached the validation scan, so a unique one was enforcing its key right up to the drop. A build that fails on duplicate keys leaves `indisready=false` and enforces nothing; an interrupted one does not. Dropping a unique invalid index therefore does take enforcement away, so the drop raises a `WARNING`, the report names the cost, and `ListDropped` orders unique indexes first so `--rebuild` cannot spend hours on a large non-unique index while a key is unenforced.

## Rebuild cannot claim work it did not do

Every build statement carries `IF NOT EXISTS` so a rebuild can resume, and the same clause makes Postgres silent when the name is already held by an index the drop declined to remove. Validity is re-read from the catalog before `rebuilt_at` is written, so a skipped build stays on the list instead of reporting success. A definition that names a different index than its row fails the same check.

## Test plan

- `go test ./internal/pkg/indexes/...` — 18 tests, four against a real Postgres via testcontainers, covering: an invalid index produced the way Postgres produces one (unique build over duplicate rows), report then drop then rebuild, a failed rebuild keeping the debt, both rebuild recipes, resumability, a partition added after a rebuild, a partition's copy not being queued as its own debt, unique-first ordering, and the validity guard.
- `go run cmd/validate-migrations/main.go` and `squawk sql/1787153561.sql sql/1787153562.sql` both clean. The migration is two files because index operations and table DDL cannot share a block.
- `golangci-lint run ./internal/pkg/indexes/... ./cmd/utils/...` clean.
- On an instance: `convoy utils indexes` reports, `convoy utils indexes --rebuild` builds them back and the report empties.

Admin dashboard surface for the same information follows in a second PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches database catalog, migrations at boot, and optional long-running concurrent index builds that can temporarily remove unique constraint enforcement until `--rebuild` completes.
> 
> **Overview**
> Fixes a path where interrupted **concurrent** index builds leave indexes invalid in the catalog while migrations still mark as applied (`IF NOT EXISTS` skips the rebuild).
> 
> **Migrations** add `convoy.dropped_indexes` and `convoy.drop_invalid_index` to capture `pg_get_indexdef`, drop invalid indexes at boot (with guards for in-progress builds, constraints, and partitioned indexes), and clean up existing invalid indexes. Future concurrent index migrations can call the same drop helper so retries actually rebuild instead of no-op.
> 
> **`convoy utils indexes`** reports currently invalid indexes and indexes owed a rebuild; **`--rebuild`** runs **CREATE INDEX CONCURRENTLY** (heap tables) or the partitioned recipe (parent `ON ONLY`, per-partition concurrent child indexes, attach), resumable with catalog validity checks before clearing debt. Unique dropped indexes are prioritized because dropping them removes uniqueness enforcement.
> 
> **`internal/pkg/indexes`** implements list/rebuild logic, pool `lock_timeout` hygiene, and integration tests against real Postgres.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a7c43938c9c73a3626634c7aaed848043ca0a7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->