### PR TITLE
fix(dataplane): sweep orphaned events_endpoints after partition retention

### DIFF
--- a/internal/pkg/attach/convert.go
+++ b/internal/pkg/attach/convert.go
@@ -126,7 +126,7 @@ func preflight(ctx context.Context, db *pgxpool.Pool, spec Spec) error {
             END IF;
         END $$;`,
 		pgLit(table), table, table,
-		pgLit(table+"_new"), table,
+		pgLit(table+copyNewSuffix), table,
 		pgLit(spec.defaultName()), table,
 		pgLit(spec.pkIndex()), quoteIdent(spec.pkIndex())))
 	if err != nil {

--- a/internal/pkg/attach/spec.go
+++ b/internal/pkg/attach/spec.go
@@ -12,7 +12,35 @@ const (
 	// this has to outlive VALIDATE CONSTRAINT on a large adopted heap.
 	CutoffDays  = 14
 	lockTimeout = "3s"
+
+	// The names a conversion parks a table's rows under while the live name
+	// does not hold all of them.
+	partitionedSuffix = "_partitioned" // detach: the parent, until drain finishes
+	copyNewSuffix     = "_new"         // copy: the rebuilt table, before it takes the live name
+	copyOldSuffix     = "_old"         // copy: the original, until it is dropped
 )
+
+// Leftovers are the relations that exist beside table only while a conversion
+// has the rows split between them, or after one died with them still split.
+//
+// Detach renames the partitioned parent to <table>_partitioned and copies the
+// rows back under the live name on a later statement, so the live name is
+// short of every row written since the conversion for the length of that
+// drain. The copy rewrite fills <table>_new, renames the original to
+// <table>_old and the copy into place; that runs as one statement and so is
+// not observable midway, but the conversion preflight treats a surviving
+// <table>_new as a conversion that died partway, and this agrees with it.
+//
+// Anything reading a table to decide whether a row is gone has to consult this
+// first: while one of these exists, absence from the live name is not a
+// verdict.
+func Leftovers(table string) []string {
+	return []string{
+		table + partitionedSuffix,
+		table + copyNewSuffix,
+		table + copyOldSuffix,
+	}
+}
 
 // Spec is what differs between the four tables.
 type Spec struct {
@@ -50,4 +78,4 @@ func (s Spec) defaultName() string { return s.Table + "_default" }
 func (s Spec) pkIndex() string     { return s.Table + "_pk_part" }
 func (s Spec) idIndex() string     { return s.Table + "_id_key" }
 func (s Spec) bounds() string      { return s.Table + "_default_bounds" }
-func (s Spec) partitioned() string { return s.Table + "_partitioned" }
+func (s Spec) partitioned() string { return s.Table + partitionedSuffix }

--- a/internal/pkg/retention/events_endpoints.go
+++ b/internal/pkg/retention/events_endpoints.go
@@ -1,0 +1,183 @@
+package retention
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	// orphanBatchRows is how many orphaned rows one sweep reads at a time. The
+	// delete that follows removes every row belonging to the events those rows
+	// named, so a batch clears at least this many rows off a backlogged table,
+	// and more wherever the limit fell inside a fan-out.
+	orphanBatchRows = 1000
+
+	// orphanSweepBudget is how long one run spends on the sweep. The asynq job
+	// holds its lock for 30 minutes and cancels the context at that point, and
+	// partition maintenance has already run by the time this starts, so the
+	// sweep takes a small share and leaves the rest to the work that reclaims
+	// whole partitions.
+	orphanSweepBudget = 5 * time.Minute
+)
+
+// sweepOrphanedEventEndpoints removes convoy.events_endpoints rows whose event
+// retention has already dropped.
+//
+// Nothing else can reclaim them. The table holds event_id and endpoint_id and
+// nothing else, so it has no key to partition on and no timestamp to delete by,
+// and it carries no foreign key either: sql/1724932863.sql rebuilt it with
+// LIKE ... INCLUDING CONSTRAINTS, which copies CHECK and NOT NULL but not
+// references. Adding one back is not open to us either, because Postgres
+// refuses an inbound key onto a partitioned table that omits the partition
+// columns. Reading the parent is what is left.
+//
+// Failure policy: best effort inside a fixed budget. Every statement is bounded
+// and nothing records that the sweep finished, so a run that is cut short
+// cannot be mistaken for a complete one. A backlog is cleared by repetition,
+// one budget per night, and a failed batch ends the sweep and is logged rather
+// than failing the retention job, which has already done the work it exists
+// for.
+func (r *PartitionRetentionPolicy) sweepOrphanedEventEndpoints(ctx context.Context) {
+	ctx, cancel := context.WithTimeout(ctx, orphanSweepBudget)
+	defer cancel()
+
+	settled, err := r.eventTablesSettled(ctx)
+	if err != nil {
+		r.reportSweepStopped(0, err)
+		return
+	}
+	if !settled {
+		r.logger.Info("skipped the convoy.events_endpoints sweep: a conversion has not finished draining")
+		return
+	}
+
+	var removed int64
+	for {
+		deleted, err := r.deleteOrphanedEventEndpoints(ctx)
+		removed += deleted
+		if err != nil {
+			r.reportSweepStopped(removed, err)
+			return
+		}
+
+		// A batch that removed nothing ends the sweep. Either the table is
+		// clean, or the read and the delete disagreed about an event because
+		// the schema moved between them, and neither leaves progress to make.
+		if deleted == 0 {
+			break
+		}
+	}
+
+	if removed > 0 {
+		r.logger.Info(fmt.Sprintf("removed %d orphaned convoy.events_endpoints rows", removed))
+	}
+}
+
+// reportSweepStopped separates the clock from a fault. Spending the budget, or
+// having the retention job's lock cancel everything under it, is the expected
+// end of a run with a backlog: the rows already removed are committed and
+// tomorrow's run carries on from there.
+func (r *PartitionRetentionPolicy) reportSweepStopped(removed int64, err error) {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		r.logger.Info(fmt.Sprintf(
+			"convoy.events_endpoints sweep stopped on its budget after removing %d rows", removed))
+		return
+	}
+	r.logger.Error(fmt.Sprintf(
+		"failed to sweep orphaned convoy.events_endpoints rows after removing %d", removed), "error", err)
+}
+
+// deleteOrphanedEventEndpoints resolves one batch of expired events and removes
+// the endpoint rows pointing at them, reporting how many rows went.
+//
+// The delete names events rather than rows so it is driven by
+// idx_events_endpoints_event_id_key and takes each event's fan-out whole. Half
+// a fan-out is a row set no reader wants and the next batch would have to find
+// again.
+func (r *PartitionRetentionPolicy) deleteOrphanedEventEndpoints(ctx context.Context) (int64, error) {
+	ids, err := r.expiredEvents(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if len(ids) == 0 {
+		return 0, nil
+	}
+
+	// The read above ran under its own snapshot, so the delete proves the
+	// events are still gone rather than trusting a list that a conversion could
+	// have republished in between. It costs one index probe per event in the
+	// batch, and it is what keeps the destructive statement from depending on
+	// a read it did not take.
+	tag, err := r.db.GetConn().Exec(ctx, `
+        DELETE FROM convoy.events_endpoints ee
+        WHERE ee.event_id = ANY($1)
+          AND NOT EXISTS (SELECT 1 FROM convoy.events e WHERE e.id = ee.event_id)
+          AND NOT EXISTS (SELECT 1 FROM convoy.events_search s WHERE s.id = ee.event_id)`, ids)
+	if err != nil {
+		return 0, fmt.Errorf("removing orphaned convoy.events_endpoints rows: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// expiredEvents names the events that convoy.events_endpoints still points at
+// and neither event table holds any more.
+//
+// The limit counts rows and the duplicates a fan-out puts in them are folded
+// here rather than by DISTINCT, which plans as a HashAggregate underneath the
+// limit. That node has to read the whole table before it returns its first row,
+// which would make every batch of a long cleanup pay for a full scan of the
+// table the cleanup is shrinking. Limiting rows keeps the scan streaming and it
+// stops as soon as the batch is full.
+func (r *PartitionRetentionPolicy) expiredEvents(ctx context.Context) ([]string, error) {
+	rows, err := r.db.GetConn().Query(ctx, `
+        SELECT ee.event_id
+        FROM convoy.events_endpoints ee
+        WHERE NOT EXISTS (SELECT 1 FROM convoy.events e WHERE e.id = ee.event_id)
+          AND NOT EXISTS (SELECT 1 FROM convoy.events_search s WHERE s.id = ee.event_id)
+        LIMIT $1`, orphanBatchRows)
+	if err != nil {
+		return nil, fmt.Errorf("reading expired events from convoy.events_endpoints: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []string
+	seen := make(map[string]struct{}, orphanBatchRows)
+	for rows.Next() {
+		var id string
+		if err = rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("reading expired events from convoy.events_endpoints: %w", err)
+		}
+		if _, repeated := seen[id]; repeated {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, fmt.Errorf("reading expired events from convoy.events_endpoints: %w", err)
+	}
+	return ids, nil
+}
+
+// eventTablesSettled reports that neither event table is mid-conversion.
+//
+// Detaching renames the partitioned parent to <table>_partitioned and only
+// copies the rows back under the live name on a later statement, so for the
+// length of that drain convoy.events does not hold every event. A sweep reading
+// it then would find live rows whose event it could not see and delete them.
+// The same leftover name is what the stand-in foreign key trigger looks in, so
+// its absence is the signal this codebase already uses for "the swap is done".
+//
+// Fail closed: a read that fails is not a verdict that the tables are settled.
+func (r *PartitionRetentionPolicy) eventTablesSettled(ctx context.Context) (bool, error) {
+	var settled bool
+	err := r.db.GetConn().QueryRow(ctx, `
+        SELECT to_regclass('convoy.events_partitioned') IS NULL
+           AND to_regclass('convoy.events_search_partitioned') IS NULL`).Scan(&settled)
+	if err != nil {
+		return false, fmt.Errorf("checking for an unfinished conversion: %w", err)
+	}
+	return settled, nil
+}

--- a/internal/pkg/retention/events_endpoints.go
+++ b/internal/pkg/retention/events_endpoints.go
@@ -5,7 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/frain-dev/convoy/internal/pkg/attach"
+	"github.com/frain-dev/convoy/internal/pkg/partitions"
 )
+
+// eventTables are the tables that decide whether an event still exists. The
+// sweep reads both, so a conversion of either one has to hold it off.
+var eventTables = []string{"events", "events_search"}
 
 const (
 	// orphanBatchRows is how many orphaned rows one sweep reads at a time. The
@@ -161,21 +168,43 @@ func (r *PartitionRetentionPolicy) expiredEvents(ctx context.Context) ([]string,
 	return ids, nil
 }
 
-// eventTablesSettled reports that neither event table is mid-conversion.
+// eventTablesSettled reports that convoy.events and convoy.events_search each
+// hold every event they are meant to, so absence from them is a verdict.
 //
-// Detaching renames the partitioned parent to <table>_partitioned and only
-// copies the rows back under the live name on a later statement, so for the
-// length of that drain convoy.events does not hold every event. A sweep reading
-// it then would find live rows whose event it could not see and delete them.
-// The same leftover name is what the stand-in foreign key trigger looks in, so
-// its absence is the signal this codebase already uses for "the swap is done".
+// Two separate things can make that false and neither implies the other, so
+// both are required rather than one standing in for the other.
+//
+// A conversion that is running now. convoy.partition_runs carries a row at
+// status running for the whole of it, written by the server on its own
+// connection precisely so it is visible to other sessions while the DDL's own
+// transaction is not. That covers every direction and every intermediate name
+// at once, which name checks cannot: attach, detach, the copy rewrite, and
+// whatever a later conversion adds. The check is instance-wide rather than
+// narrowed to these two tables, because a run is already instance-wide
+// single-active and rare, so the cost of standing down for a conversion of
+// some other table is one night of sweeping, against a table filter that
+// silently stops matching the day the conversion code renames something.
+//
+// A conversion that already ended and left the rows split. A drain that failed
+// after the swap committed leaves the run at failed, not running, with
+// convoy.events still short of everything on convoy.events_partitioned. The
+// names come from attach.Leftovers so the conversion code stays their only
+// author.
 //
 // Fail closed: a read that fails is not a verdict that the tables are settled.
 func (r *PartitionRetentionPolicy) eventTablesSettled(ctx context.Context) (bool, error) {
+	var leftovers []string
+	for _, table := range eventTables {
+		for _, name := range attach.Leftovers(table) {
+			leftovers = append(leftovers, retentionSchema+"."+name)
+		}
+	}
+
 	var settled bool
 	err := r.db.GetConn().QueryRow(ctx, `
-        SELECT to_regclass('convoy.events_partitioned') IS NULL
-           AND to_regclass('convoy.events_search_partitioned') IS NULL`).Scan(&settled)
+        SELECT NOT EXISTS (SELECT 1 FROM convoy.partition_runs WHERE status = $1)
+           AND NOT EXISTS (SELECT 1 FROM unnest($2::TEXT[]) n WHERE to_regclass(n) IS NOT NULL)`,
+		partitions.StatusRunning, leftovers).Scan(&settled)
 	if err != nil {
 		return false, fmt.Errorf("checking for an unfinished conversion: %w", err)
 	}

--- a/internal/pkg/retention/events_endpoints.go
+++ b/internal/pkg/retention/events_endpoints.go
@@ -29,6 +29,11 @@ const (
 	orphanSweepBudget = 5 * time.Minute
 )
 
+// afterOrphanSweepBatchHook runs after each successful batch in
+// sweepOrphanedEventEndpoints. Tests set it to simulate a conversion starting
+// mid-sweep; production leaves it nil.
+var afterOrphanSweepBatchHook func()
+
 // sweepOrphanedEventEndpoints removes convoy.events_endpoints rows whose event
 // retention has already dropped.
 //
@@ -50,18 +55,24 @@ func (r *PartitionRetentionPolicy) sweepOrphanedEventEndpoints(ctx context.Conte
 	ctx, cancel := context.WithTimeout(ctx, orphanSweepBudget)
 	defer cancel()
 
-	settled, err := r.eventTablesSettled(ctx)
-	if err != nil {
-		r.reportSweepStopped(0, err)
-		return
-	}
-	if !settled {
-		r.logger.Info("skipped the convoy.events_endpoints sweep: a conversion has not finished draining")
-		return
-	}
-
 	var removed int64
 	for {
+		settled, err := r.eventTablesSettled(ctx)
+		if err != nil {
+			r.reportSweepStopped(removed, err)
+			return
+		}
+		if !settled {
+			if removed > 0 {
+				r.logger.Info(fmt.Sprintf(
+					"stopped the convoy.events_endpoints sweep after removing %d rows: a conversion has not finished draining",
+					removed))
+			} else {
+				r.logger.Info("skipped the convoy.events_endpoints sweep: a conversion has not finished draining")
+			}
+			return
+		}
+
 		deleted, err := r.deleteOrphanedEventEndpoints(ctx)
 		removed += deleted
 		if err != nil {
@@ -74,6 +85,10 @@ func (r *PartitionRetentionPolicy) sweepOrphanedEventEndpoints(ctx context.Conte
 		// the schema moved between them, and neither leaves progress to make.
 		if deleted == 0 {
 			break
+		}
+
+		if afterOrphanSweepBatchHook != nil {
+			afterOrphanSweepBatchHook()
 		}
 	}
 

--- a/internal/pkg/retention/events_endpoints_test.go
+++ b/internal/pkg/retention/events_endpoints_test.go
@@ -1,0 +1,314 @@
+package retention
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/frain-dev/convoy/database"
+)
+
+// convoy.events_endpoints has carried no foreign key since sql/1724932863.sql
+// rebuilt it with LIKE ... INCLUDING CONSTRAINTS, so nothing removed a row when
+// retention dropped the event it points at. On a partitioned instance that had
+// been running for months the table reached 4 GB of rows whose events were long
+// gone.
+func TestSweepRemovesEventEndpointsWhoseEventIsGone(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	projectID := seedProjectWithEvent(t, db)
+	endpointID := seedEndpoint(t, db, projectID)
+	seedEventEndpoint(t, db, ulid.Make().String(), endpointID)
+
+	newDropPolicy(t, db, 24*time.Hour).sweepOrphanedEventEndpoints(ctx)
+
+	require.Zero(t, countEventEndpoints(t, ctx, db),
+		"a row whose event retention already dropped survived the sweep")
+}
+
+func TestSweepKeepsEventEndpointsWhoseEventSurvives(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	projectID := seedProjectWithEvent(t, db)
+	endpointID := seedEndpoint(t, db, projectID)
+	seedEventEndpoint(t, db, liveEventID(t, ctx, db, projectID), endpointID)
+
+	newDropPolicy(t, db, 24*time.Hour).sweepOrphanedEventEndpoints(ctx)
+
+	require.Equal(t, 1, countEventEndpoints(t, ctx, db),
+		"the sweep deleted a row whose event is still in convoy.events")
+}
+
+// An event is written once and fans out to every endpoint it matched, so the
+// unit the sweep has to get right is the event, not the row: every row for a
+// dropped event goes, and every row for a live one stays, even when both events
+// point at the same endpoints.
+func TestSweepRemovesAnExpiredEventsWholeFanOutAndKeepsALiveOnes(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	projectID := seedProjectWithEvent(t, db)
+	live := liveEventID(t, ctx, db, projectID)
+	expired := ulid.Make().String()
+
+	endpoints := []string{
+		seedEndpoint(t, db, projectID),
+		seedEndpoint(t, db, projectID),
+		seedEndpoint(t, db, projectID),
+	}
+	for _, endpointID := range endpoints {
+		seedEventEndpoint(t, db, live, endpointID)
+		seedEventEndpoint(t, db, expired, endpointID)
+	}
+
+	newDropPolicy(t, db, 24*time.Hour).sweepOrphanedEventEndpoints(ctx)
+
+	require.Equal(t, len(endpoints), countEventEndpointsFor(t, ctx, db, live),
+		"the sweep lost part of a live event's fan-out")
+	require.Zero(t, countEventEndpointsFor(t, ctx, db, expired),
+		"the sweep left part of an expired event's fan-out behind")
+}
+
+// The search path reads convoy.events_endpoints joined to convoy.events_search,
+// not to convoy.events, so an event that is still searchable must keep its
+// endpoint rows even after the convoy.events side has expired.
+func TestSweepKeepsEventEndpointsWhoseEventSurvivesOnlyInSearch(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	projectID := seedProjectWithEvent(t, db)
+	endpointID := seedEndpoint(t, db, projectID)
+
+	searchOnly := ulid.Make().String()
+	_, err := db.GetDB().ExecContext(ctx, `
+        INSERT INTO convoy.events_search (id, event_type, project_id, raw, data, url_path)
+        VALUES ($1, 'test.event', $2, '{}', '{}'::bytea, '/')`, searchOnly, projectID)
+	require.NoError(t, err)
+	seedEventEndpoint(t, db, searchOnly, endpointID)
+
+	newDropPolicy(t, db, 24*time.Hour).sweepOrphanedEventEndpoints(ctx)
+
+	require.Equal(t, 1, countEventEndpoints(t, ctx, db),
+		"the sweep deleted a row the search path still reads")
+}
+
+// One statement must not try to delete a backlog in a single pass, which is the
+// failure being fixed rather than an implementation of the fix.
+func TestOneSweepBatchRemovesAtMostTheBatchBound(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	projectID := seedProjectWithEvent(t, db)
+	endpointID := seedEndpoint(t, db, projectID)
+	const excess = 200
+	seedOrphanedEventEndpoints(t, ctx, db, endpointID, orphanBatchRows+excess)
+
+	policy := newDropPolicy(t, db, 24*time.Hour)
+
+	deleted, err := policy.deleteOrphanedEventEndpoints(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, orphanBatchRows, deleted, "one batch was not bounded by orphanBatchRows")
+	require.Equal(t, excess, countEventEndpoints(t, ctx, db))
+
+	// The backlog is cleared by repetition, so the same call run to exhaustion
+	// finishes the table off.
+	policy.sweepOrphanedEventEndpoints(ctx)
+	require.Zero(t, countEventEndpoints(t, ctx, db))
+}
+
+// The read bounds itself by rows, so a batch's limit can fall inside an event's
+// fan-out. The delete names events rather than rows, so it takes the rest of
+// that fan-out with it instead of leaving a part of one behind.
+func TestOneSweepBatchNeverLeavesPartOfAFanOut(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	projectID := seedProjectWithEvent(t, db)
+	const fanOut = 3
+	// More events than one batch can name, so a remainder is left to inspect.
+	const events = orphanBatchRows + 500
+	for range fanOut {
+		seedOrphanedEventEndpoints(t, ctx, db, seedEndpoint(t, db, projectID), events)
+	}
+
+	deleted, err := newDropPolicy(t, db, 24*time.Hour).deleteOrphanedEventEndpoints(ctx)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, deleted, int64(orphanBatchRows),
+		"the batch stopped at the row limit and left the rest of a fan-out behind")
+	require.Empty(t, partialFanOuts(t, ctx, db, fanOut),
+		"the batch left events holding some of their rows and not others")
+}
+
+func TestSweepIsANoopOnACleanTable(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	policy := newDropPolicy(t, db, 24*time.Hour)
+	policy.sweepOrphanedEventEndpoints(ctx)
+
+	deleted, err := policy.deleteOrphanedEventEndpoints(ctx)
+	require.NoError(t, err)
+	require.Zero(t, deleted)
+	require.Zero(t, countEventEndpoints(t, ctx, db))
+}
+
+// Detaching renames the partitioned parent to convoy.events_partitioned and
+// only copies the rows back under the live name on a later statement. Reading
+// convoy.events during that window reports live events as missing, so the sweep
+// has to stand down until the leftover name is gone.
+func TestSweepSkipsWhileADetachHasNotDrained(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	projectID := seedProjectWithEvent(t, db)
+	endpointID := seedEndpoint(t, db, projectID)
+	seedEventEndpoint(t, db, ulid.Make().String(), endpointID)
+
+	_, err := db.GetDB().ExecContext(ctx,
+		`CREATE TABLE convoy.events_partitioned (LIKE convoy.events)`)
+	require.NoError(t, err)
+
+	newDropPolicy(t, db, 24*time.Hour).sweepOrphanedEventEndpoints(ctx)
+
+	require.Equal(t, 1, countEventEndpoints(t, ctx, db),
+		"the sweep ran mid-detach, when absence from convoy.events is not a verdict")
+}
+
+// The instance this was found on had convoy.events partitioned, which is the
+// only shape retention runs on, and it is also the shape that makes the lookup
+// fan out across every child.
+func TestSweepRemovesOrphansOnAPartitionedEventsTable(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	projectID := seedProjectWithEvent(t, db)
+	endpointID := seedEndpoint(t, db, projectID)
+	live := liveEventID(t, ctx, db, projectID)
+	seedEventEndpoint(t, db, live, endpointID)
+	seedEventEndpoint(t, db, ulid.Make().String(), endpointID)
+
+	partitionTable(t, ctx, db, "events")
+	partitionTable(t, ctx, db, "events_search")
+
+	newDropPolicy(t, db, 24*time.Hour).sweepOrphanedEventEndpoints(ctx)
+
+	require.Equal(t, 1, countEventEndpoints(t, ctx, db))
+	require.Equal(t, 1, countEventEndpointsFor(t, ctx, db, live))
+}
+
+// Running out of budget is how a run with a backlog is meant to end, so it has
+// to stay distinguishable from a fault after the driver has wrapped it, or
+// every night of a long cleanup reports an error it should not.
+func TestSweepReportsACancelledRunAsTheClock(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	projectID := seedProjectWithEvent(t, db)
+	seedEventEndpoint(t, db, ulid.Make().String(), seedEndpoint(t, db, projectID))
+
+	spent, cancel := context.WithCancel(ctx)
+	cancel()
+
+	_, err := newDropPolicy(t, db, 24*time.Hour).deleteOrphanedEventEndpoints(spent)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, countEventEndpoints(t, ctx, db))
+}
+
+// The sweep is only worth anything if the nightly job runs it, and it runs
+// after the partition maintenance that creates the orphans in the first place.
+func TestPerformSweepsOrphanedEventEndpoints(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	projectID := seedProjectWithEvent(t, db)
+	endpointID := seedEndpoint(t, db, projectID)
+	live := liveEventID(t, ctx, db, projectID)
+	seedEventEndpoint(t, db, live, endpointID)
+	seedEventEndpoint(t, db, ulid.Make().String(), endpointID)
+
+	partitionAll(t, ctx, db)
+
+	require.NoError(t, newDropPolicy(t, db, 24*time.Hour).Perform(ctx))
+
+	require.Equal(t, 1, countEventEndpoints(t, ctx, db))
+	require.Equal(t, 1, countEventEndpointsFor(t, ctx, db, live))
+}
+
+func liveEventID(t *testing.T, ctx context.Context, db database.Database, projectID string) string {
+	t.Helper()
+
+	var id string
+	require.NoError(t, db.GetDB().QueryRowContext(ctx,
+		`SELECT id FROM convoy.events WHERE project_id = $1`, projectID).Scan(&id))
+	return id
+}
+
+func seedEndpoint(t *testing.T, db database.Database, projectID string) string {
+	t.Helper()
+
+	endpointID := ulid.Make().String()
+	_, err := db.GetDB().ExecContext(context.Background(), `
+        INSERT INTO convoy.endpoints (
+            id, name, status, url, http_timeout, rate_limit, rate_limit_duration,
+            advanced_signatures, project_id, secrets)
+        VALUES ($1, $2, 'active', 'https://example.com', 10000, 1000, 60, false, $3, '[]'::jsonb)`,
+		endpointID, "retention-"+endpointID, projectID)
+	require.NoError(t, err)
+
+	return endpointID
+}
+
+func seedEventEndpoint(t *testing.T, db database.Database, eventID, endpointID string) {
+	t.Helper()
+
+	_, err := db.GetDB().ExecContext(context.Background(),
+		`INSERT INTO convoy.events_endpoints (event_id, endpoint_id) VALUES ($1, $2)`, eventID, endpointID)
+	require.NoError(t, err)
+}
+
+// seedOrphanedEventEndpoints writes count rows naming events that were never
+// inserted, which is the state retention leaves behind once it drops the
+// partition an event lived in.
+func seedOrphanedEventEndpoints(t *testing.T, ctx context.Context, db database.Database, endpointID string, count int) {
+	t.Helper()
+
+	_, err := db.GetDB().ExecContext(ctx, `
+        INSERT INTO convoy.events_endpoints (event_id, endpoint_id)
+        SELECT 'expired' || LPAD(i::TEXT, 19, '0'), $1
+        FROM generate_series(1, $2) AS i`, endpointID, count)
+	require.NoError(t, err)
+}
+
+// partialFanOuts names the events left holding a number of rows other than the
+// fan-out they were written with.
+func partialFanOuts(t *testing.T, ctx context.Context, db database.Database, fanOut int) []string {
+	t.Helper()
+
+	rows, err := db.GetDB().QueryContext(ctx, `
+        SELECT event_id FROM convoy.events_endpoints
+        GROUP BY event_id HAVING count(*) <> $1`, fanOut)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var ids []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Err())
+
+	return ids
+}
+
+func countEventEndpoints(t *testing.T, ctx context.Context, db database.Database) int {
+	t.Helper()
+
+	var count int
+	require.NoError(t, db.GetDB().QueryRowContext(ctx,
+		`SELECT count(*) FROM convoy.events_endpoints`).Scan(&count))
+	return count
+}
+
+func countEventEndpointsFor(t *testing.T, ctx context.Context, db database.Database, eventID string) int {
+	t.Helper()
+
+	var count int
+	require.NoError(t, db.GetDB().QueryRowContext(ctx,
+		`SELECT count(*) FROM convoy.events_endpoints WHERE event_id = $1`, eventID).Scan(&count))
+	return count
+}

--- a/internal/pkg/retention/events_endpoints_test.go
+++ b/internal/pkg/retention/events_endpoints_test.go
@@ -154,6 +154,30 @@ func TestSweepIsANoopOnACleanTable(t *testing.T) {
 // only copies the rows back under the live name on a later statement. Reading
 // convoy.events during that window reports live events as missing, so the sweep
 // has to stand down until the leftover name is gone.
+// Retention and conversion use different locks, so a conversion can start after
+// the sweep's first settlement check. Re-checking before each batch keeps later
+// iterations from deleting rows whose events still live on leftover relations.
+func TestSweepStopsWhenSettlementBecomesFalseMidRun(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	projectID := seedProjectWithEvent(t, db)
+	endpointID := seedEndpoint(t, db, projectID)
+	const excess = 200
+	seedOrphanedEventEndpoints(t, ctx, db, endpointID, orphanBatchRows+excess)
+
+	afterOrphanSweepBatchHook = func() {
+		_, err := db.GetDB().ExecContext(ctx,
+			`CREATE TABLE convoy.events_partitioned (LIKE convoy.events)`)
+		require.NoError(t, err)
+	}
+	t.Cleanup(func() { afterOrphanSweepBatchHook = nil })
+
+	newDropPolicy(t, db, 24*time.Hour).sweepOrphanedEventEndpoints(ctx)
+
+	require.Equal(t, excess, countEventEndpoints(t, ctx, db),
+		"the sweep kept deleting after event tables became unsettled")
+}
+
 func TestSweepSkipsWhileADetachHasNotDrained(t *testing.T) {
 	db, ctx := setupTestDB(t)
 

--- a/internal/pkg/retention/retention.go
+++ b/internal/pkg/retention/retention.go
@@ -18,6 +18,10 @@ import (
 // RetentionTables are the tables the partition retention policy manages.
 // They must be converted to partitioned parents (`convoy utils partition`) before
 // retention can run.
+//
+// convoy.events_endpoints is deliberately not one of them: it has no created_at
+// and no project_id, so there is no partition key to range on. It is reclaimed
+// by sweepOrphanedEventEndpoints instead, once these have been maintained.
 var RetentionTables = []string{"events", "events_search", "event_deliveries", "delivery_attempts"}
 
 const (
@@ -375,6 +379,7 @@ func (r *PartitionRetentionPolicy) Perform(ctx context.Context) error {
 	}
 
 	r.dropExpiredAdoptedPartitions(ctx)
+	r.sweepOrphanedEventEndpoints(ctx)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Nightly partition retention now sweeps orphaned `convoy.events_endpoints` rows whose parent events were already dropped
- Conversion safety gates block the sweep while partition runs are active or attach leftover relations exist; settlement is re-checked before each batch
- Shared `attach.Leftovers` helper centralizes conversion leftover table names used by the settlement guard

## Test plan

- [x] `CONVOY_JWT_SECRET=... CONVOY_JWT_REFRESH_SECRET=... go test ./internal/pkg/retention/... -run 'EventsEndpoints|Orphan|Settled|Sweep'`
- [ ] Licensed instance with partitioned events: confirm orphaned junction rows shrink after retention job
- [ ] During an active partition conversion: confirm sweep logs skip/stop rather than deleting rows on leftover relations

Closes PDE-1010