### PR TITLE
fix(controlplane): mark event payload jsonb function parallel unsafe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ bin
 # Convoy specific
 convoy
 convoy.json
+convoy.local.json
 convoy.sentinel.json
 docker-compose.yml
 configs/local/convoy.install.generated.json

--- a/internal/pkg/indexes/indexes_test.go
+++ b/internal/pkg/indexes/indexes_test.go
@@ -138,3 +138,13 @@ func TestPayloadGINDefinitionMatchesMigration(t *testing.T) {
 	require.Contains(t, string(body), PayloadGINDefinition)
 	require.NotRegexp(t, `(?m)^CREATE INDEX`, string(body))
 }
+
+func TestEventPayloadJsonbIsParallelUnsafe(t *testing.T) {
+	for _, name := range []string{"../../../sql/1787200000.sql", "../../../sql/1787200002.sql"} {
+		body, err := os.ReadFile(name)
+		require.NoError(t, err)
+		up := strings.SplitN(string(body), "-- +migrate Down", 2)[0]
+		require.Contains(t, up, "PARALLEL UNSAFE")
+		require.NotRegexp(t, `(?m)^\s*PARALLEL SAFE\s*$`, up)
+	}
+}

--- a/sql/1787200000.sql
+++ b/sql/1787200000.sql
@@ -3,12 +3,14 @@ SET lock_timeout = '2s';
 SET statement_timeout = '30s';
 -- Safe jsonb projection of events.data (BYTEA). Invalid UTF-8 or JSON
 -- becomes NULL so containment misses the row instead of aborting the query.
+-- plpgsql EXCEPTION uses a subtransaction, so this cannot be PARALLEL SAFE:
+-- a parallel seq scan fails with SQLSTATE 25000.
 -- +migrate StatementBegin
 CREATE OR REPLACE FUNCTION convoy.event_payload_jsonb(data bytea)
 RETURNS jsonb
 LANGUAGE plpgsql
 IMMUTABLE
-PARALLEL SAFE
+PARALLEL UNSAFE
 AS $$
 BEGIN
     IF data IS NULL THEN

--- a/sql/1787200002.sql
+++ b/sql/1787200002.sql
@@ -1,0 +1,54 @@
+-- +migrate Up
+SET lock_timeout = '2s';
+SET statement_timeout = '30s';
+-- CREATE OR REPLACE on already-migrated instances. plpgsql EXCEPTION
+-- handlers are subtransactions; PARALLEL SAFE made parallel seq scans
+-- fail with SQLSTATE 25000. Fail closed to serial execution so invalid
+-- rows still become NULL instead of aborting the query.
+-- +migrate StatementBegin
+CREATE OR REPLACE FUNCTION convoy.event_payload_jsonb(data bytea)
+RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL UNSAFE
+AS $$
+BEGIN
+    IF data IS NULL THEN
+        RETURN NULL;
+    END IF;
+    RETURN convert_from(data, 'UTF8')::jsonb;
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN NULL;
+END;
+$$;
+-- +migrate StatementEnd
+
+RESET lock_timeout;
+RESET statement_timeout;
+
+-- +migrate Down
+SET lock_timeout = '2s';
+SET statement_timeout = '30s';
+-- Restore the previous marker. Do not drop the function; 1787200000 owns it.
+-- +migrate StatementBegin
+CREATE OR REPLACE FUNCTION convoy.event_payload_jsonb(data bytea)
+RETURNS jsonb
+LANGUAGE plpgsql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+BEGIN
+    IF data IS NULL THEN
+        RETURN NULL;
+    END IF;
+    RETURN convert_from(data, 'UTF8')::jsonb;
+EXCEPTION
+    WHEN OTHERS THEN
+        RETURN NULL;
+END;
+$$;
+-- +migrate StatementEnd
+
+RESET lock_timeout;
+RESET statement_timeout;


### PR DESCRIPTION
## Summary
- `convoy.event_payload_jsonb` is plpgsql with an `EXCEPTION` handler, which starts a subtransaction. Marking it `PARALLEL SAFE` made parallel seq scans fail with SQLSTATE 25000 (`cannot start subtransactions during a parallel operation`).
- Mark the function `PARALLEL UNSAFE` in the original migration, and add a follow-up `CREATE OR REPLACE` so already-migrated instances pick up the same definition. Invalid UTF-8/JSON still returns NULL.

## Test plan
- [x] `go test ./internal/pkg/indexes -run TestEventPayloadJsonbIsParallelUnsafe`
- [ ] Apply `1787200002` on an instance that already ran `1787200000`
- [ ] JSON body search on a large `events` table completes without SQLSTATE 25000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Database function used in event payload search; changing parallel safety can alter query plans and scan performance, but it is a correctness fix for a hard failure.
> 
> **Overview**
> Fixes JSON body search failing on large `events` scans with SQLSTATE 25000 (`cannot start subtransactions during a parallel operation`).
> 
> `convoy.event_payload_jsonb` is plpgsql with an `EXCEPTION` handler, which starts a subtransaction and cannot be `PARALLEL SAFE`. The original migration now creates it as `PARALLEL UNSAFE`, and a follow-up `CREATE OR REPLACE` (`1787200002`) updates already-migrated instances. Invalid UTF-8/JSON still returns NULL instead of aborting the query.
> 
> A test asserts both migrations’ Up sections contain `PARALLEL UNSAFE`. `.gitignore` also ignores `convoy.local.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 707b67e93f00fb712c0b61cdee302a35c4a272bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->