### PR TITLE
fix(dashboard): show event log search progress and load sidebar deliveries

### DIFF
--- a/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.html
@@ -101,7 +101,11 @@
       <div class="border-b border-new.border" [class.bg-new.surface-muted]="!canSearchEvents">
         @if (canSearchEvents) {
           <div class="flex items-center gap-8px px-12px h-40px">
-            <img src="/assets/img/svg/search-gray.svg" class="w-16px h-16px shrink-0" alt="search" />
+            @if (isSearchingEvents) {
+              <img src="/assets/img/svg/deliveries-loading.svg" class="w-16px h-16px shrink-0 animate-spin" alt="" />
+            } @else {
+              <img src="/assets/img/svg/search-gray.svg" class="w-16px h-16px shrink-0" alt="search" />
+            }
             <input
               type="search"
               placeholder="Search events..."
@@ -109,6 +113,8 @@
               (input)="onSearch()"
               [ngModelOptions]="{ standalone: true }"
               spellcheck="false"
+              [attr.aria-busy]="isSearchingEvents"
+              aria-label="Search events"
               class="event-log-search-input flex-1 min-w-0 font-body font-normal text-[14px] text-new.text-primary placeholder:text-new.text-placeholder outline-none bg-transparent"
               />
             <convoy-tooltip size="sm" position="bottom" class="shrink-0 ml-4px" className="!min-w-[300px] max-w-[340px] whitespace-normal !text-left !font-normal">
@@ -169,6 +175,7 @@
         }
       </div>
 
+      <div [class.opacity-60]="isSearchingEvents && !isloadingEvents" [class.pointer-events-none]="isSearchingEvents && !isloadingEvents">
       @if (isloadingEvents) {
         <!-- Loading state -->
         <div class="flex flex-col items-center justify-center gap-16px py-56px px-32px">
@@ -319,10 +326,11 @@
           </div>
         </div>
       }
+      </div>
     </div>
 
     <!-- Details sidebar -->
-    <div class="bg-white-100 border border-new.border rounded-12px p-20px flex flex-col gap-16px">
+    <div class="bg-white-100 border border-new.border rounded-12px p-20px flex flex-col gap-16px" [class.opacity-60]="isSearchingEvents && !isloadingEvents">
       @if (isloadingEvents) {
         <div class="flex flex-col gap-16px">
           <div class="bg-new.surface-muted rounded-[24px] animate-pulse h-4 w-80px"></div>

--- a/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.ts
@@ -74,6 +74,7 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 	private eventsFetchId = 0;
 	private sidebarFetchId = 0;
 	private sidebarLoadedForEventId = '';
+	private sidebarLoadedRange = '';
 
 	constructor(
 		private eventsLogService: EventLogsService,
@@ -440,6 +441,7 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 
 	getEventsAtInterval() {
 		this.getEventsInterval = setInterval(() => {
+			if (this.isSearchingEvents) return;
 			this.getEventLogs();
 		}, 5000);
 	}
@@ -454,7 +456,7 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 	async getEventLogs(requestDetails?: { showLoader?: boolean; showSearchProgress?: boolean }) {
 		const fetchId = ++this.eventsFetchId;
 		if (requestDetails?.showLoader) this.isloadingEvents = true;
-		this.isSearchingEvents = requestDetails?.showSearchProgress === true;
+		if (requestDetails?.showSearchProgress) this.isSearchingEvents = true;
 		this.fetchError = false;
 		this.fetchErrorMessage = '';
 		this.searchTimedOut = false;
@@ -476,7 +478,7 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 			}
 
 			if (this.eventsDetailsItem?.uid) {
-				if (this.sidebarLoadedForEventId !== this.eventsDetailsItem.uid) {
+				if (this.sidebarLoadedForEventId !== this.eventsDetailsItem.uid || this.sidebarLoadedRange !== this.sidebarDateWindowKey()) {
 					this.getEventDeliveriesForSidebar(this.eventsDetailsItem.uid);
 					this.getDuplicateEvents(this.eventsDetailsItem);
 				}
@@ -485,6 +487,7 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 				this.isLoadingSidebarDeliveries = false;
 				this.sidebarEventDeliveries = [];
 				this.sidebarLoadedForEventId = '';
+				this.sidebarLoadedRange = '';
 			}
 
 			this.isloadingEvents = false;
@@ -523,16 +526,19 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 			this.isLoadingSidebarDeliveries = false;
 			this.sidebarEventDeliveries = [];
 			this.sidebarLoadedForEventId = '';
+			this.sidebarLoadedRange = '';
 			return;
 		}
 
 		const fetchId = ++this.sidebarFetchId;
+		const range = this.eventsListQueryParams();
+		const rangeKey = this.sidebarDateWindowKey(range);
 		this.isLoadingSidebarDeliveries = true;
 		this.sidebarEventDeliveries = [];
 		this.sidebarLoadedForEventId = '';
+		this.sidebarLoadedRange = '';
 
 		try {
-			const range = this.eventsListQueryParams();
 			const response = await this.eventsService.getEventDeliveries({
 				eventId,
 				startDate: range.startDate,
@@ -542,6 +548,7 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 			this.sidebarEventDeliveries = response.data?.content || [];
 			this.isLoadingSidebarDeliveries = false;
 			this.sidebarLoadedForEventId = eventId;
+			this.sidebarLoadedRange = rangeKey;
 			return;
 		} catch (error) {
 			if (fetchId !== this.sidebarFetchId) return;
@@ -549,6 +556,10 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 			this.isLoadingSidebarDeliveries = false;
 			return error;
 		}
+	}
+
+	private sidebarDateWindowKey(range: FILTER_QUERY_PARAM = this.eventsListQueryParams()): string {
+		return `${range.startDate || ''}\0${range.endDate || ''}`;
 	}
 
 	// ------- pagination -------

--- a/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.ts
@@ -44,6 +44,7 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 	@ViewChild('datePicker') datePicker?: DatePickerComponent;
 
 	isloadingEvents: boolean = false;
+	isSearchingEvents = false;
 	fetchError = false;
 	fetchErrorMessage = '';
 	searchTimedOut = false;
@@ -55,7 +56,7 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 	portalToken = this.route.snapshot.params?.token;
 	filterSources: SOURCE[] = [];
 	selectedSourceData?: SOURCE;
-	isLoadingSidebarDeliveries = true;
+	isLoadingSidebarDeliveries = false;
 	fetchingCount = false;
 	isRetrying = false;
 	isFetchingDuplicateEvents = false;
@@ -70,6 +71,9 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 	payloadAutoScrollKey = '';
 
 	private searchTimeout: any;
+	private eventsFetchId = 0;
+	private sidebarFetchId = 0;
+	private sidebarLoadedForEventId = '';
 
 	constructor(
 		private eventsLogService: EventLogsService,
@@ -309,12 +313,12 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 		return `${format(this.queryParams.startDate)} - ${format(this.queryParams.endDate)}`;
 	}
 
-	refreshEvents(showLoader = false) {
+	refreshEvents(options?: { showLoader?: boolean; showSearchProgress?: boolean }) {
 		this.currentPage = 1;
 		delete this.queryParams.next_page_cursor;
 		delete this.queryParams.prev_page_cursor;
 		delete this.queryParams.direction;
-		this.getEventLogs({ showLoader });
+		this.getEventLogs({ showLoader: options?.showLoader === true, showSearchProgress: options?.showSearchProgress === true });
 	}
 
 	private payloadSearchLeftoverText(raw: string): string {
@@ -337,7 +341,7 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 			if (!raw) {
 				this.payloadAutoScrollKey = '';
 				this.queryParams = this.generalService.addFilterToURL({ ...this.queryParams, query: '', body: '' });
-				this.refreshEvents();
+				this.refreshEvents({ showSearchProgress: true });
 				return;
 			}
 
@@ -350,7 +354,7 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 					query: leftover || payloadQuery,
 					body: leftover ? payloadQuery : ''
 				});
-				this.refreshEvents();
+				this.refreshEvents({ showSearchProgress: true });
 				return;
 			}
 			if (this.looksLikePayloadSearchInput(raw)) {
@@ -359,7 +363,7 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 
 			this.updatePayloadAutoScrollKey();
 			this.queryParams = this.generalService.addFilterToURL({ ...this.queryParams, query: raw, body: '' });
-			this.refreshEvents();
+			this.refreshEvents({ showSearchProgress: true });
 		}, 400);
 	}
 
@@ -447,8 +451,10 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 
 	// ------- data fetching -------
 
-	async getEventLogs(requestDetails?: { showLoader?: boolean }) {
+	async getEventLogs(requestDetails?: { showLoader?: boolean; showSearchProgress?: boolean }) {
+		const fetchId = ++this.eventsFetchId;
 		if (requestDetails?.showLoader) this.isloadingEvents = true;
+		this.isSearchingEvents = requestDetails?.showSearchProgress === true;
 		this.fetchError = false;
 		this.fetchErrorMessage = '';
 		this.searchTimedOut = false;
@@ -459,26 +465,36 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 			if (cleanedQuery.query) cleanedQuery.query = this.queryParamString(cleanedQuery.query);
 			if (cleanedQuery.body) cleanedQuery.body = this.queryParamString(cleanedQuery.body);
 			const eventsResponse = await this.eventsService.getEvents(this.eventsListQueryParams(cleanedQuery));
+			if (fetchId !== this.eventsFetchId) return eventsResponse;
 			this.events = eventsResponse.data;
 
 			this.displayedEvents = await this.generalService.setContentDisplayed(eventsResponse.data.content, this.queryParams?.sort || 'desc');
-			this.isloadingEvents = false;
 
 			const selectedStillVisible = !!this.events?.content?.some(event => event.uid === this.eventsDetailsItem?.uid);
 			if (!this.eventsDetailsItem || !selectedStillVisible) {
 				this.eventsDetailsItem = this.events?.content?.[0];
-				if (this.eventsDetailsItem?.uid) {
+			}
+
+			if (this.eventsDetailsItem?.uid) {
+				if (this.sidebarLoadedForEventId !== this.eventsDetailsItem.uid) {
 					this.getEventDeliveriesForSidebar(this.eventsDetailsItem.uid);
 					this.getDuplicateEvents(this.eventsDetailsItem);
-					this.updatePayloadAutoScrollKey(this.eventsDetailsItem.uid);
-				} else {
-					this.isLoadingSidebarDeliveries = false;
 				}
+				this.updatePayloadAutoScrollKey(this.eventsDetailsItem.uid);
+			} else {
+				this.isLoadingSidebarDeliveries = false;
+				this.sidebarEventDeliveries = [];
+				this.sidebarLoadedForEventId = '';
 			}
+
+			this.isloadingEvents = false;
+			this.isSearchingEvents = false;
 
 			return eventsResponse;
 		} catch (error: unknown) {
+			if (fetchId !== this.eventsFetchId) return error;
 			this.isloadingEvents = false;
+			this.isSearchingEvents = false;
 			this.fetchError = true;
 			const classified = classifyEventLogsFetchError(error);
 			this.searchTimedOut = classified.searchTimedOut;
@@ -503,16 +519,33 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 	}
 
 	async getEventDeliveriesForSidebar(eventId: string) {
+		if (!eventId) {
+			this.isLoadingSidebarDeliveries = false;
+			this.sidebarEventDeliveries = [];
+			this.sidebarLoadedForEventId = '';
+			return;
+		}
+
+		const fetchId = ++this.sidebarFetchId;
 		this.isLoadingSidebarDeliveries = true;
 		this.sidebarEventDeliveries = [];
+		this.sidebarLoadedForEventId = '';
 
 		try {
-			const response = await this.eventsService.getEventDeliveries({ eventId });
-			this.sidebarEventDeliveries = response.data.content;
+			const range = this.eventsListQueryParams();
+			const response = await this.eventsService.getEventDeliveries({
+				eventId,
+				startDate: range.startDate,
+				endDate: range.endDate
+			});
+			if (fetchId !== this.sidebarFetchId) return;
+			this.sidebarEventDeliveries = response.data?.content || [];
 			this.isLoadingSidebarDeliveries = false;
-
+			this.sidebarLoadedForEventId = eventId;
 			return;
 		} catch (error) {
+			if (fetchId !== this.sidebarFetchId) return;
+			this.sidebarEventDeliveries = [];
 			this.isLoadingSidebarDeliveries = false;
 			return error;
 		}


### PR DESCRIPTION
## Summary
- Event Logs search keeps the current rows and shows a spinner on the search field while the request is in flight.
- Deliveries overview loads for the auto-selected event instead of staying on the initial shimmer until a row is clicked.
- Sidebar delivery fetches use the same date window as the event list, and stale in-flight responses are ignored.

## Test plan
- [ ] Open Event Logs and confirm Deliveries overview fills for the first event without clicking a row.
- [ ] Type in search and confirm the field icon spins, existing rows stay visible, and pagination/tail refresh do not spin.
- [ ] Incomplete JSON such as `{` does not start a search spinner.
- [ ] Clicking another event still loads that event's deliveries.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only fetch/UI state changes; no auth, API contract, or data-write changes.
> 
> **Overview**
> Event Logs search now keeps the current table visible and shows a spinner on the search field while a query is in flight, instead of a full-page loader. Pagination and tail refresh stay unchanged.
> 
> The details sidebar loads deliveries for the auto-selected first event without requiring a row click. Sidebar fetches use the same date window as the event list, skip duplicate loads for the same event, and ignore stale in-flight responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8872e75ba77d5d9f4d431fa5732a6574d05cb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->