### PR TITLE
fix(dataplane): rebuild every owed index at boot

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -205,12 +205,10 @@ func StartConvoyServer(a *cli.App) error {
 
 	a.Logger.Infof("Started convoy server in %s", time.Since(start))
 
-	// Fail open: dashboard list and JSON search seq-scan until those indexes
-	// are valid. Do not block listen. Start the deliveries index first so it
-	// takes the single-active slot ahead of the hours-long payload GIN.
+	// Fail open: queries seq-scan until owed indexes are valid. Do not block
+	// listen. Unique indexes take the single-active slot first.
 	p := partitions.New(a.DB, a.Logger)
-	p.StartQueuedEventDeliveriesProjectCreated(context.Background())
-	p.StartQueuedPayloadGIN(context.Background())
+	p.StartQueuedDroppedIndexes(context.Background())
 
 	httpConfig := cfg.Server.HTTP
 	if httpConfig.SSL {

--- a/cmd/utils/indexes.go
+++ b/cmd/utils/indexes.go
@@ -25,12 +25,13 @@ An index build that is interrupted, by a pod restart during an upgrade for
 example, leaves the index behind marked invalid. The planner ignores it from
 then on, so the table performs as if the index had never been created, and no
 query fails to say so. Migrations drop what they find, which is instant, and
-record the definition so the build can happen here instead of stalling a boot.
+record the definition. Server and agent rebuild those in the background after
+boot, unique indexes first, one at a time.
 
---rebuild builds those indexes again, concurrently, one at a time. On a large
-table this takes hours per index and can be interrupted and run again: it
-resumes rather than starting over. It is cheapest after retention has dropped
-the largest partition of a converted table.`,
+--rebuild does the same work from a shell. On a large table this takes hours
+per index and can be interrupted and run again: it resumes rather than
+starting over. It is cheapest after retention has dropped the largest
+partition of a converted table.`,
 		Annotations: map[string]string{
 			"CheckMigration":  "true",
 			"ShouldBootstrap": "false",

--- a/internal/dataplane/runtime.go
+++ b/internal/dataplane/runtime.go
@@ -54,12 +54,10 @@ func (r *Runtime) Run(ctx context.Context) error {
 		return fmt.Errorf("worker failed to become ready within 30 seconds")
 	}
 
-	// Fail open: dashboard list and JSON search seq-scan until those indexes
-	// are valid. Do not block ingest. Start the deliveries index first so it
-	// takes the single-active slot ahead of the hours-long payload GIN.
+	// Fail open: queries seq-scan until owed indexes are valid. Do not block
+	// ingest. Unique indexes take the single-active slot first.
 	p := partitions.New(r.opts.DB, r.opts.Logger)
-	p.StartQueuedEventDeliveriesProjectCreated(ctx)
-	p.StartQueuedPayloadGIN(ctx)
+	p.StartQueuedDroppedIndexes(ctx)
 
 	if err := StartIngest(ctx, r.opts, r.cfg); err != nil {
 		return fmt.Errorf("error starting data plane ingest component: %w", err)

--- a/internal/pkg/indexes/indexes.go
+++ b/internal/pkg/indexes/indexes.go
@@ -10,11 +10,10 @@
 // applied.
 //
 // Migrations drop what they find instead, which is instant, and record the
-// definition in convoy.dropped_indexes so the build can happen here, when an
-// operator chooses. Rebuilding is the expensive half: hours on a large table, and
-// it must not run at boot — except the names migrate queues on purpose
-// (PayloadGIN, EventDeliveriesProjectCreated) so server and agent can start
-// those rebuilds in the background.
+// definition in convoy.dropped_indexes. Rebuilding is the expensive half: hours
+// on a large table. Server and agent start every owed rebuild in the background
+// after boot, unique indexes first, one at a time. The dashboard and CLI are
+// progress and retry, not the only way a rebuild starts.
 package indexes
 
 import (
@@ -60,14 +59,12 @@ const EventDeliveriesProjectCreated = "idx_event_deliveries_project_created_id_d
 // It has to match the row sql/1787251200.sql inserts.
 const EventDeliveriesProjectCreatedDefinition = `CREATE INDEX idx_event_deliveries_project_created_id_deleted ON convoy.event_deliveries USING btree (project_id, created_at DESC, id DESC) WHERE (deleted_at IS NULL)`
 
-// BootQueuedNames is the boot rebuild order: dashboard list first, then the
-// hours-long payload GIN. StartQueued* walks this at process start; a finished
-// boot rebuild walks it again so a name that hit the single-active slot still
-// starts when the slot frees, without waiting for the next process start.
+// BootQueuedNames are the indexes migrate always inserts into dropped_indexes
+// instead of CREATE INDEX, so every upgraded instance owes them a rebuild.
 var BootQueuedNames = []string{EventDeliveriesProjectCreated, PayloadGIN}
 
-// BootQueued reports whether migrate queued this name for a boot rebuild rather
-// than leaving it for the operator --rebuild path.
+// BootQueued reports whether migrate always queues this name. Repair tests use
+// it to look past those rows when counting operator-dropped indexes.
 func BootQueued(name string) bool {
 	for _, n := range BootQueuedNames {
 		if n == name {
@@ -165,7 +162,10 @@ func ListInvalid(ctx context.Context, db *pgxpool.Pool) ([]Invalid, error) {
 // to start anything else until it is back, so a rebuild that took another index
 // first would fail on every one of them. Unique indexes follow, because a missing
 // unique index is not just slower, it is not enforcing its key, and hours spent
-// on a large non-unique index first leaves that gap open for those hours.
+// on a large non-unique index first leaves that gap open for those hours. Among
+// non-unique indexes the Event Deliveries list index is next: that query times
+// out until it is valid, and dropped_at alone would put the hours-long payload
+// GIN first because migrate queued GIN earlier.
 //
 // This is the only place the order is decided, so the list an operator reads and
 // the list --rebuild works through cannot disagree.
@@ -176,6 +176,7 @@ func ListDropped(ctx context.Context, db *pgxpool.Pool) ([]Dropped, error) {
          WHERE rebuilt_at IS NULL
          ORDER BY (index_name = 'idx_partition_runs_single_active') DESC,
                   (definition LIKE 'CREATE UNIQUE %') DESC,
+                  (index_name = '`+EventDeliveriesProjectCreated+`') DESC,
                   dropped_at`)
 	if err != nil {
 		return nil, fmt.Errorf("reading dropped indexes: %w", err)

--- a/internal/pkg/indexes/repair_test.go
+++ b/internal/pkg/indexes/repair_test.go
@@ -389,6 +389,30 @@ func TestTheRunGuardIsOfferedAheadOfOtherUniqueIndexes(t *testing.T) {
 		"the guard blocks every other rebuild, so it cannot be second")
 }
 
+// The Event Deliveries list times out until this index is valid. Migrate queued
+// the payload GIN first, so dropped_at alone would spend those hours on search
+// while the dashboard list is still sequential.
+func TestDroppedIndexesOfferTheDeliveriesListIndexAheadOfOlderNonUniqueIndexes(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+
+	owed, err := ListDropped(ctx, db)
+	require.NoError(t, err)
+
+	listPos, ginPos := -1, -1
+	for i, d := range owed {
+		switch d.Name {
+		case EventDeliveriesProjectCreated:
+			listPos = i
+		case PayloadGIN:
+			ginPos = i
+		}
+	}
+	require.GreaterOrEqual(t, listPos, 0, "migrate queues the deliveries list index")
+	require.GreaterOrEqual(t, ginPos, 0, "migrate queues the payload GIN")
+	require.Less(t, listPos, ginPos)
+}
+
 // A concurrent build cannot run in a transaction, so the rebuild's lock_timeout
 // is session state on a pooled connection. Left behind, it would abort row-lock
 // waits in ordinary traffic that are supposed to queue.
@@ -452,8 +476,8 @@ func names(invalid []Invalid) []string {
 	return out
 }
 
-// sql/1787200001.sql and sql/1787251200.sql queue boot-rebuild indexes on
-// every migrated test DB. Repair assertions that count operator-dropped
+// sql/1787200001.sql and sql/1787251200.sql always queue these names on
+// every migrated test DB. Repair assertions that count other dropped
 // indexes have to look past those rows.
 func exceptPayloadGIN(owed []Dropped) []Dropped {
 	out := make([]Dropped, 0, len(owed))

--- a/internal/pkg/partitions/partitions.go
+++ b/internal/pkg/partitions/partitions.go
@@ -112,7 +112,8 @@ var (
 // failedIndexRebuilds are names whose rebuild already failed in this process.
 // Handlers call New() per request, so this cannot live on Service or a
 // conversion finishing on a fresh runner would retry a boot failure.
-// StartIndexRebuild still tries a caller-supplied name (dashboard retry).
+// StartIndexRebuild still tries a caller-supplied name (dashboard retry) and
+// deletes the skip when that rebuild succeeds.
 var failedIndexRebuilds sync.Map
 
 // Tables lists what can be converted, in the order the CLI converts them when
@@ -294,6 +295,8 @@ func (s *Service) StartIndexRebuild(ctx context.Context, indexName, triggeredBy 
 		detached := context.WithoutCancel(ctx)
 		if err := s.rebuild(detached, run, d); err != nil {
 			failedIndexRebuilds.Store(d.Name, struct{}{})
+		} else {
+			failedIndexRebuilds.Delete(d.Name)
 		}
 		s.startQueuedDroppedIndexes(detached, d.Name)
 	}()
@@ -317,10 +320,11 @@ func (s *Service) RunIndexRebuild(ctx context.Context, indexName, triggeredBy st
 const bootTriggeredBy = "boot"
 
 // StartQueuedDroppedIndexes starts the concurrent rebuild of every index still
-// owed, in ListDropped order (guard, unique, deliveries list, then the rest). Failure policy: fail open. Queries seq-scan until
-// an index is valid; ingest and HTTP must not wait on the build. A replica that
-// finds the slot taken, or a name that is already rebuilt, is success. Any
-// other error is logged and ignored so the process still listens.
+// owed, in ListDropped order (guard, unique, deliveries list, then the rest).
+// Failure policy: fail open. Queries seq-scan until an index is valid; ingest
+// and HTTP must not wait on the build. A replica that finds the slot taken, or
+// a name that is already rebuilt, is success. Any other error is logged and
+// ignored so the process still listens.
 func (s *Service) StartQueuedDroppedIndexes(ctx context.Context) {
 	s.startQueuedDroppedIndexes(ctx, "")
 }

--- a/internal/pkg/partitions/partitions.go
+++ b/internal/pkg/partitions/partitions.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
@@ -107,6 +108,12 @@ var (
 	ErrAlreadyPartitioned = errors.New("table is already partitioned")
 	ErrNotPartitioned     = errors.New("table is not partitioned")
 )
+
+// failedIndexRebuilds are names whose rebuild already failed in this process.
+// Handlers call New() per request, so this cannot live on Service or a
+// conversion finishing on a fresh runner would retry a boot failure.
+// StartIndexRebuild still tries a caller-supplied name (dashboard retry).
+var failedIndexRebuilds sync.Map
 
 // Tables lists what can be converted, in the order the CLI converts them when
 // given no argument.
@@ -285,7 +292,9 @@ func (s *Service) StartIndexRebuild(ctx context.Context, indexName, triggeredBy 
 
 	go func() {
 		detached := context.WithoutCancel(ctx)
-		_ = s.rebuild(detached, run, d)
+		if err := s.rebuild(detached, run, d); err != nil {
+			failedIndexRebuilds.Store(d.Name, struct{}{})
+		}
 		s.startQueuedDroppedIndexes(detached, d.Name)
 	}()
 
@@ -327,6 +336,9 @@ func (s *Service) startQueuedDroppedIndexes(ctx context.Context, skip string) {
 	}
 	for _, d := range owed {
 		if d.Name == skip {
+			continue
+		}
+		if _, failed := failedIndexRebuilds.Load(d.Name); failed {
 			continue
 		}
 		s.startQueuedBootIndex(ctx, d.Name, bootIndexLogName(d.Name))

--- a/internal/pkg/partitions/partitions.go
+++ b/internal/pkg/partitions/partitions.go
@@ -212,6 +212,9 @@ type rebuilder interface {
 	// dropped resolves the name to the index awaiting a rebuild, and reports
 	// which table it is on so the run row names that table.
 	dropped(ctx context.Context, name string) (indexes.Dropped, error)
+	// listDropped is the owed rebuilds in ListDropped order: guard, unique,
+	// deliveries list index, then the rest by when they were dropped.
+	listDropped(ctx context.Context) ([]indexes.Dropped, error)
 	rebuild(ctx context.Context, d indexes.Dropped) error
 }
 
@@ -246,8 +249,13 @@ func (s *Service) Start(ctx context.Context, table Table, op Operation, triggere
 
 	// The conversion is detached from the request that started it, so it keeps
 	// running after the response is written. Cancelling it midway would leave a
-	// half-converted table, which is worse than letting it finish.
-	go s.convert(context.WithoutCancel(ctx), run)
+	// half-converted table, which is worse than letting it finish. When it
+	// frees the slot, start any owed index rebuilds that lost the race at boot.
+	go func() {
+		detached := context.WithoutCancel(ctx)
+		_ = s.convert(detached, run)
+		s.StartQueuedDroppedIndexes(detached)
+	}()
 
 	return run, nil
 }
@@ -275,7 +283,11 @@ func (s *Service) StartIndexRebuild(ctx context.Context, indexName, triggeredBy 
 		return nil, err
 	}
 
-	go s.rebuild(context.WithoutCancel(ctx), run, d)
+	go func() {
+		detached := context.WithoutCancel(ctx)
+		_ = s.rebuild(detached, run, d)
+		s.startQueuedDroppedIndexes(detached, d.Name)
+	}()
 
 	return run, nil
 }
@@ -295,23 +307,30 @@ func (s *Service) RunIndexRebuild(ctx context.Context, indexName, triggeredBy st
 
 const bootTriggeredBy = "boot"
 
-// StartQueuedPayloadGIN starts the concurrent rebuild of indexes.PayloadGIN if
-// migrate queued it. Failure policy: fail open. Search seq-scans until the
-// index is valid; ingest and HTTP must not wait on the build. A replica that
+// StartQueuedDroppedIndexes starts the concurrent rebuild of every index still
+// owed, in ListDropped order (guard, unique, deliveries list, then the rest). Failure policy: fail open. Queries seq-scan until
+// an index is valid; ingest and HTTP must not wait on the build. A replica that
 // finds the slot taken, or a name that is already rebuilt, is success. Any
 // other error is logged and ignored so the process still listens.
-func (s *Service) StartQueuedPayloadGIN(ctx context.Context) {
-	s.startQueuedBootIndex(ctx, indexes.PayloadGIN, bootIndexLogName(indexes.PayloadGIN))
+func (s *Service) StartQueuedDroppedIndexes(ctx context.Context) {
+	s.startQueuedDroppedIndexes(ctx, "")
 }
 
-// StartQueuedEventDeliveriesProjectCreated starts the concurrent rebuild of
-// indexes.EventDeliveriesProjectCreated if migrate queued it. Failure policy:
-// fail open. The 30-day Event Deliveries list times out until the index is
-// valid; ingest and HTTP must not wait on the build. Call this before
-// StartQueuedPayloadGIN at boot so the dashboard index takes the single-active
-// slot ahead of the hours-long payload GIN.
-func (s *Service) StartQueuedEventDeliveriesProjectCreated(ctx context.Context) {
-	s.startQueuedBootIndex(ctx, indexes.EventDeliveriesProjectCreated, bootIndexLogName(indexes.EventDeliveriesProjectCreated))
+func (s *Service) startQueuedDroppedIndexes(ctx context.Context, skip string) {
+	if s.rebuilder == nil {
+		return
+	}
+	owed, err := s.rebuilder.listDropped(ctx)
+	if err != nil {
+		s.logger.Error("dropped index list did not load", "error", err.Error())
+		return
+	}
+	for _, d := range owed {
+		if d.Name == skip {
+			continue
+		}
+		s.startQueuedBootIndex(ctx, d.Name, bootIndexLogName(d.Name))
+	}
 }
 
 func (s *Service) startQueuedBootIndex(ctx context.Context, name, logName string) {
@@ -624,25 +643,9 @@ func (s *Service) convert(ctx context.Context, run *Run) error {
 // clearing a leftover from an earlier attempt, so the phase stream is as useful
 // here as it is for a conversion.
 func (s *Service) rebuild(ctx context.Context, run *Run, d indexes.Dropped) error {
-	err := s.execute(ctx, run, func(ctx context.Context) error {
+	return s.execute(ctx, run, func(ctx context.Context) error {
 		return s.rebuilder.rebuild(ctx, d)
 	})
-	// The slot is free again. A sibling BootQueued name that lost the race at
-	// process start (ErrRunInProgress) would otherwise stay unbuilt until the
-	// next boot. Failure policy: fail open; startQueuedBootIndex already logs.
-	if run.TriggeredBy == bootTriggeredBy {
-		s.startNextQueuedBootIndex(ctx, d.Name)
-	}
-	return err
-}
-
-func (s *Service) startNextQueuedBootIndex(ctx context.Context, justFinished string) {
-	for _, name := range indexes.BootQueuedNames {
-		if name == justFinished {
-			continue
-		}
-		s.startQueuedBootIndex(ctx, name, bootIndexLogName(name))
-	}
 }
 
 func bootIndexLogName(name string) string {
@@ -791,6 +794,10 @@ type indexRebuilder struct {
 
 func (r *indexRebuilder) dropped(ctx context.Context, name string) (indexes.Dropped, error) {
 	return indexes.GetDropped(ctx, r.db.GetConn(), name)
+}
+
+func (r *indexRebuilder) listDropped(ctx context.Context) ([]indexes.Dropped, error) {
+	return indexes.ListDropped(ctx, r.db.GetConn())
 }
 
 func (r *indexRebuilder) rebuild(ctx context.Context, d indexes.Dropped) error {

--- a/internal/pkg/partitions/partitions_test.go
+++ b/internal/pkg/partitions/partitions_test.go
@@ -424,6 +424,8 @@ func TestDashboardRebuildRetriesANameThatFailedOnAnotherRunner(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, runs, 1)
 	waitForStatus(t, boot, ctx, runs[0].UID, StatusFailed)
+	_, skipped := failedIndexRebuilds.Load("idx_event_deliveries_usage")
+	require.True(t, skipped)
 
 	retry := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
 	close(retry.release)
@@ -432,6 +434,8 @@ func TestDashboardRebuildRetriesANameThatFailedOnAnotherRunner(t *testing.T) {
 	require.NoError(t, err)
 	<-retry.started
 	waitForStatus(t, dashboard, ctx, run.UID, StatusCompleted)
+	_, skipped = failedIndexRebuilds.Load("idx_event_deliveries_usage")
+	require.False(t, skipped, "a successful retry must not keep skipping the name")
 }
 
 func TestConversionFinishStartsOwedIndexRebuilds(t *testing.T) {

--- a/internal/pkg/partitions/partitions_test.go
+++ b/internal/pkg/partitions/partitions_test.go
@@ -50,6 +50,11 @@ func setupTestDB(t *testing.T) (database.Database, context.Context) {
 
 	require.NoError(t, config.LoadConfig(""))
 
+	failedIndexRebuilds.Range(func(k, _ any) bool {
+		failedIndexRebuilds.Delete(k)
+		return true
+	})
+
 	conn, err := testEnv.CloneTestDatabase(t, "convoy")
 	require.NoError(t, err)
 
@@ -303,6 +308,130 @@ func TestUserRebuildStartsTheNextOwedIndexWhenTheSlotFrees(t *testing.T) {
 		require.NotNil(t, listed.IndexName)
 		waitForStatus(t, s, ctx, listed.UID, StatusCompleted)
 	}
+}
+
+func TestFailedRebuildStartsTheNextOwedIndexOnce(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	usage := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
+	usage.rebuildErr = errors.New("lock_timeout")
+	gin := newBlockingRebuilder("events", indexes.PayloadGIN)
+	s := newRebuildService(t, db, &multiRebuilder{
+		order: []string{"idx_event_deliveries_usage", indexes.PayloadGIN},
+		byName: map[string]*blockingRebuilder{
+			"idx_event_deliveries_usage": usage,
+			indexes.PayloadGIN:           gin,
+		},
+	})
+
+	s.StartQueuedDroppedIndexes(ctx)
+	<-usage.started
+	close(usage.release)
+	<-gin.started
+	close(gin.release)
+
+	runs, err := s.List(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, runs, 2)
+	for _, listed := range runs {
+		require.NotNil(t, listed.IndexName)
+		if *listed.IndexName == "idx_event_deliveries_usage" {
+			waitForStatus(t, s, ctx, listed.UID, StatusFailed)
+			continue
+		}
+		waitForStatus(t, s, ctx, listed.UID, StatusCompleted)
+	}
+
+	select {
+	case <-usage.started:
+		t.Fatal("failed usage rebuild started again after the next index finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestTwoFailedRebuildsDoNotAlternate(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	usage := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
+	usage.rebuildErr = errors.New("lock_timeout")
+	gin := newBlockingRebuilder("events", indexes.PayloadGIN)
+	gin.rebuildErr = errors.New("lock_timeout")
+	s := newRebuildService(t, db, &multiRebuilder{
+		order: []string{"idx_event_deliveries_usage", indexes.PayloadGIN},
+		byName: map[string]*blockingRebuilder{
+			"idx_event_deliveries_usage": usage,
+			indexes.PayloadGIN:           gin,
+		},
+	})
+
+	s.StartQueuedDroppedIndexes(ctx)
+	<-usage.started
+	close(usage.release)
+	<-gin.started
+	close(gin.release)
+
+	runs, err := s.List(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, runs, 2)
+	for _, listed := range runs {
+		waitForStatus(t, s, ctx, listed.UID, StatusFailed)
+	}
+
+	select {
+	case <-usage.started:
+		t.Fatal("failed usage rebuild started again after the other failed rebuild finished")
+	case <-gin.started:
+		t.Fatal("failed payload GIN started again after the other failed rebuild finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestConversionOnANewRunnerDoesNotRetryAFailedIndex(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	usage := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
+	usage.rebuildErr = errors.New("lock_timeout")
+	boot := newRebuildService(t, db, usage)
+
+	boot.StartQueuedDroppedIndexes(ctx)
+	<-usage.started
+	close(usage.release)
+	runs, err := boot.List(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	waitForStatus(t, boot, ctx, runs[0].UID, StatusFailed)
+
+	c := newBlockingConverter()
+	s := &Service{db: db, logger: log.New("partitions-test", log.LevelError), converter: c, rebuilder: usage}
+	run, err := s.Start(ctx, TableEvents, OperationPartition, "user-1")
+	require.NoError(t, err)
+	<-c.started
+	close(c.release)
+	waitForStatus(t, s, ctx, run.UID, StatusCompleted)
+
+	select {
+	case <-usage.started:
+		t.Fatal("conversion on a new runner retried an index that already failed this process")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestDashboardRebuildRetriesANameThatFailedOnAnotherRunner(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	first := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
+	first.rebuildErr = errors.New("lock_timeout")
+	close(first.release)
+	boot := newRebuildService(t, db, first)
+	boot.StartQueuedDroppedIndexes(ctx)
+	runs, err := boot.List(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	waitForStatus(t, boot, ctx, runs[0].UID, StatusFailed)
+
+	retry := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
+	close(retry.release)
+	dashboard := newRebuildService(t, db, retry)
+	run, err := dashboard.StartIndexRebuild(ctx, "idx_event_deliveries_usage", "user-1")
+	require.NoError(t, err)
+	<-retry.started
+	waitForStatus(t, dashboard, ctx, run.UID, StatusCompleted)
 }
 
 func TestConversionFinishStartsOwedIndexRebuilds(t *testing.T) {

--- a/internal/pkg/partitions/partitions_test.go
+++ b/internal/pkg/partitions/partitions_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -87,6 +88,7 @@ type blockingRebuilder struct {
 	rebuildErr error
 	release    chan struct{}
 	started    chan struct{}
+	done       atomic.Bool
 }
 
 func newBlockingRebuilder(table, index string) *blockingRebuilder {
@@ -107,13 +109,34 @@ func (r *blockingRebuilder) dropped(_ context.Context, name string) (indexes.Dro
 	return r.index, nil
 }
 
+func (r *blockingRebuilder) listDropped(ctx context.Context) ([]indexes.Dropped, error) {
+	if r.done.Load() {
+		return nil, nil
+	}
+	if r.lookupErr != nil {
+		if errors.Is(r.lookupErr, indexes.ErrNotDropped) {
+			return nil, nil
+		}
+		return nil, r.lookupErr
+	}
+	d, err := r.dropped(ctx, r.index.Name)
+	if err != nil {
+		return nil, err
+	}
+	return []indexes.Dropped{d}, nil
+}
+
 func (r *blockingRebuilder) rebuild(context.Context, indexes.Dropped) error {
 	r.started <- struct{}{}
 	<-r.release
+	if r.rebuildErr == nil {
+		r.done.Store(true)
+	}
 	return r.rebuildErr
 }
 
 type multiRebuilder struct {
+	order  []string
 	byName map[string]*blockingRebuilder
 }
 
@@ -123,6 +146,22 @@ func (m *multiRebuilder) dropped(ctx context.Context, name string) (indexes.Drop
 		return indexes.Dropped{}, indexes.ErrNotDropped
 	}
 	return r.dropped(ctx, name)
+}
+
+func (m *multiRebuilder) listDropped(ctx context.Context) ([]indexes.Dropped, error) {
+	out := make([]indexes.Dropped, 0, len(m.order))
+	for _, name := range m.order {
+		r, ok := m.byName[name]
+		if !ok || r.done.Load() {
+			continue
+		}
+		d, err := m.dropped(ctx, name)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, nil
 }
 
 func (m *multiRebuilder) rebuild(ctx context.Context, d indexes.Dropped) error {
@@ -161,12 +200,12 @@ func TestStartIndexRebuildRecordsTheIndexAndItsTable(t *testing.T) {
 	require.Equal(t, "idx_event_deliveries_usage", *done.IndexName)
 }
 
-func TestStartQueuedPayloadGINStartsTheNamedIndex(t *testing.T) {
+func TestStartQueuedDroppedIndexesStartsTheFirstOwed(t *testing.T) {
 	db, ctx := setupTestDB(t)
-	r := newBlockingRebuilder("events", indexes.PayloadGIN)
+	r := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
 	s := newRebuildService(t, db, r)
 
-	s.StartQueuedPayloadGIN(ctx)
+	s.StartQueuedDroppedIndexes(ctx)
 	<-r.started
 
 	runs, err := s.List(ctx, 10)
@@ -174,48 +213,42 @@ func TestStartQueuedPayloadGINStartsTheNamedIndex(t *testing.T) {
 	require.NotEmpty(t, runs)
 	require.Equal(t, OperationRebuildIndex, runs[0].Operation)
 	require.NotNil(t, runs[0].IndexName)
-	require.Equal(t, indexes.PayloadGIN, *runs[0].IndexName)
+	require.Equal(t, "idx_event_deliveries_usage", *runs[0].IndexName)
 	require.Equal(t, bootTriggeredBy, runs[0].TriggeredBy)
 
 	close(r.release)
 	waitForStatus(t, s, ctx, runs[0].UID, StatusCompleted)
 }
 
-func TestStartQueuedEventDeliveriesProjectCreatedStartsTheNamedIndex(t *testing.T) {
+func TestBootRebuildStartsEveryOwedIndexWhenTheSlotFrees(t *testing.T) {
 	db, ctx := setupTestDB(t)
-	r := newBlockingRebuilder("event_deliveries", indexes.EventDeliveriesProjectCreated)
-	s := newRebuildService(t, db, r)
-
-	s.StartQueuedEventDeliveriesProjectCreated(ctx)
-	<-r.started
-
-	runs, err := s.List(ctx, 10)
-	require.NoError(t, err)
-	require.NotEmpty(t, runs)
-	require.Equal(t, OperationRebuildIndex, runs[0].Operation)
-	require.NotNil(t, runs[0].IndexName)
-	require.Equal(t, indexes.EventDeliveriesProjectCreated, *runs[0].IndexName)
-	require.Equal(t, bootTriggeredBy, runs[0].TriggeredBy)
-
-	close(r.release)
-	waitForStatus(t, s, ctx, runs[0].UID, StatusCompleted)
-}
-
-func TestBootRebuildStartsTheNextQueuedIndexWhenTheSlotFrees(t *testing.T) {
-	db, ctx := setupTestDB(t)
+	usage := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
 	deliveries := newBlockingRebuilder("event_deliveries", indexes.EventDeliveriesProjectCreated)
 	gin := newBlockingRebuilder("events", indexes.PayloadGIN)
-	s := newRebuildService(t, db, &multiRebuilder{byName: map[string]*blockingRebuilder{
-		indexes.EventDeliveriesProjectCreated: deliveries,
-		indexes.PayloadGIN:                    gin,
-	}})
+	s := newRebuildService(t, db, &multiRebuilder{
+		order: []string{"idx_event_deliveries_usage", indexes.EventDeliveriesProjectCreated, indexes.PayloadGIN},
+		byName: map[string]*blockingRebuilder{
+			"idx_event_deliveries_usage":          usage,
+			indexes.EventDeliveriesProjectCreated: deliveries,
+			indexes.PayloadGIN:                    gin,
+		},
+	})
 
-	s.StartQueuedEventDeliveriesProjectCreated(ctx)
-	s.StartQueuedPayloadGIN(ctx)
+	s.StartQueuedDroppedIndexes(ctx)
+	<-usage.started
+	select {
+	case <-deliveries.started:
+		t.Fatal("list index started while the usage rebuild held the slot")
+	case <-gin.started:
+		t.Fatal("payload GIN started while the usage rebuild held the slot")
+	default:
+	}
+
+	close(usage.release)
 	<-deliveries.started
 	select {
 	case <-gin.started:
-		t.Fatal("payload GIN started while the deliveries rebuild held the slot")
+		t.Fatal("payload GIN started while the list index rebuild held the slot")
 	default:
 	}
 
@@ -225,24 +258,91 @@ func TestBootRebuildStartsTheNextQueuedIndexWhenTheSlotFrees(t *testing.T) {
 
 	runs, err := s.List(ctx, 10)
 	require.NoError(t, err)
-	require.Len(t, runs, 2)
-	names := make(map[string]string, 2)
+	require.Len(t, runs, 3)
+	names := make(map[string]string, 3)
 	for _, run := range runs {
 		require.NotNil(t, run.IndexName)
 		waitForStatus(t, s, ctx, run.UID, StatusCompleted)
 		names[*run.IndexName] = run.TriggeredBy
 	}
+	require.Equal(t, bootTriggeredBy, names["idx_event_deliveries_usage"])
 	require.Equal(t, bootTriggeredBy, names[indexes.EventDeliveriesProjectCreated])
 	require.Equal(t, bootTriggeredBy, names[indexes.PayloadGIN])
 }
 
-func TestStartQueuedEventDeliveriesProjectCreatedNoopsWhenNotQueued(t *testing.T) {
+func TestUserRebuildStartsTheNextOwedIndexWhenTheSlotFrees(t *testing.T) {
 	db, ctx := setupTestDB(t)
-	r := newBlockingRebuilder("event_deliveries", indexes.EventDeliveriesProjectCreated)
+	usage := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
+	gin := newBlockingRebuilder("events", indexes.PayloadGIN)
+	s := newRebuildService(t, db, &multiRebuilder{
+		order: []string{"idx_event_deliveries_usage", indexes.PayloadGIN},
+		byName: map[string]*blockingRebuilder{
+			"idx_event_deliveries_usage": usage,
+			indexes.PayloadGIN:           gin,
+		},
+	})
+
+	run, err := s.StartIndexRebuild(ctx, "idx_event_deliveries_usage", "user-1")
+	require.NoError(t, err)
+	<-usage.started
+	select {
+	case <-gin.started:
+		t.Fatal("payload GIN started while the usage rebuild held the slot")
+	default:
+	}
+
+	close(usage.release)
+	<-gin.started
+	close(gin.release)
+
+	waitForStatus(t, s, ctx, run.UID, StatusCompleted)
+	runs, err := s.List(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, runs, 2)
+	for _, listed := range runs {
+		require.NotNil(t, listed.IndexName)
+		waitForStatus(t, s, ctx, listed.UID, StatusCompleted)
+	}
+}
+
+func TestConversionFinishStartsOwedIndexRebuilds(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	c := newBlockingConverter()
+	r := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
+	s := &Service{db: db, logger: log.New("partitions-test", log.LevelError), converter: c, rebuilder: r}
+
+	run, err := s.Start(ctx, TableEvents, OperationPartition, "user-1")
+	require.NoError(t, err)
+	<-c.started
+
+	s.StartQueuedDroppedIndexes(ctx)
+	select {
+	case <-r.started:
+		t.Fatal("index rebuild started while a conversion held the slot")
+	default:
+	}
+
+	close(c.release)
+	waitForStatus(t, s, ctx, run.UID, StatusCompleted)
+	<-r.started
+	close(r.release)
+	runs, err := s.List(ctx, 10)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(runs), 2)
+	for _, listed := range runs {
+		if listed.Operation == OperationRebuildIndex {
+			waitForStatus(t, s, ctx, listed.UID, StatusCompleted)
+		}
+	}
+}
+
+func TestStartQueuedDroppedIndexesNoopsWhenNothingOwed(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	r := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
 	r.lookupErr = indexes.ErrNotDropped
 	s := newRebuildService(t, db, r)
 
-	s.StartQueuedEventDeliveriesProjectCreated(ctx)
+	s.StartQueuedDroppedIndexes(ctx)
 
 	select {
 	case <-r.started:
@@ -255,26 +355,7 @@ func TestStartQueuedEventDeliveriesProjectCreatedNoopsWhenNotQueued(t *testing.T
 	require.Empty(t, runs)
 }
 
-func TestStartQueuedPayloadGINNoopsWhenNotQueued(t *testing.T) {
-	db, ctx := setupTestDB(t)
-	r := newBlockingRebuilder("events", indexes.PayloadGIN)
-	r.lookupErr = indexes.ErrNotDropped
-	s := newRebuildService(t, db, r)
-
-	s.StartQueuedPayloadGIN(ctx)
-
-	select {
-	case <-r.started:
-		t.Fatal("rebuild started for an index that was not queued")
-	default:
-	}
-
-	runs, err := s.List(ctx, 10)
-	require.NoError(t, err)
-	require.Empty(t, runs)
-}
-
-func TestStartQueuedPayloadGINNoopsWhenTheSlotIsTaken(t *testing.T) {
+func TestStartQueuedDroppedIndexesNoopsWhenTheSlotIsTaken(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	c := newBlockingConverter()
 	running := newService(t, db, c)
@@ -282,12 +363,12 @@ func TestStartQueuedPayloadGINNoopsWhenTheSlotIsTaken(t *testing.T) {
 	require.NoError(t, err)
 	<-c.started
 
-	r := newBlockingRebuilder("events", indexes.PayloadGIN)
-	newRebuildService(t, db, r).StartQueuedPayloadGIN(ctx)
+	r := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
+	newRebuildService(t, db, r).StartQueuedDroppedIndexes(ctx)
 
 	select {
 	case <-r.started:
-		t.Fatal("payload GIN rebuild started while a conversion held the slot")
+		t.Fatal("index rebuild started while a conversion held the slot")
 	default:
 	}
 
@@ -295,13 +376,13 @@ func TestStartQueuedPayloadGINNoopsWhenTheSlotIsTaken(t *testing.T) {
 	waitForStatus(t, running, ctx, run.UID, StatusCompleted)
 }
 
-func TestStartQueuedPayloadGINFailsOpenOnLookupError(t *testing.T) {
+func TestStartQueuedDroppedIndexesFailsOpenOnLookupError(t *testing.T) {
 	db, ctx := setupTestDB(t)
-	r := newBlockingRebuilder("events", indexes.PayloadGIN)
+	r := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
 	r.lookupErr = errors.New("database unreachable")
 	s := newRebuildService(t, db, r)
 
-	s.StartQueuedPayloadGIN(ctx)
+	s.StartQueuedDroppedIndexes(ctx)
 
 	select {
 	case <-r.started:

--- a/web/ui/dashboard/src/app/private/pages/admin/table-indexes/table-indexes.component.html
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-indexes/table-indexes.component.html
@@ -1,6 +1,6 @@
 <div class="flex flex-col gap-4px mb-16px">
   <h3 class="font-heading font-medium text-[18px] leading-[26px] text-new.text-primary">Table indexes</h3>
-  <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">An index build that is interrupted leaves the index behind marked invalid, and the planner ignores it from then on, so the table performs as if the index had never been created without any query failing to say so. Upgrades drop what they find, which is instant, and record the definition so the rebuild can happen here on your schedule.</p>
+  <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">An index build that is interrupted leaves the index behind marked invalid, and the planner ignores it from then on, so the table performs as if the index had never been created without any query failing to say so. Upgrades drop what they find, which is instant, and record the definition. Server and agent rebuild those in the background after boot, unique indexes first. Use Rebuild to retry one that failed.</p>
 </div>
 
 <div class="h-[1px] w-full bg-new.border mb-20px"></div>
@@ -36,7 +36,7 @@
     <div class="bg-warning-500/5 border border-warning-500/20 rounded-12px p-16px mb-16px">
       <p class="font-body font-semibold text-[14px] leading-normal text-new.text-primary mb-4px">A unique index is missing</p>
       <p class="font-body font-normal text-[13px] leading-[20px] text-new.text-secondary">
-        Nothing stops a duplicate row on {{ uniqueDroppedCount === 1 ? 'one of these' : uniqueDroppedCount + ' of these' }} until it is rebuilt. Rebuild those first.
+        Nothing stops a duplicate row on {{ uniqueDroppedCount === 1 ? 'one of these' : uniqueDroppedCount + ' of these' }} until it is rebuilt. Unique indexes are rebuilt first.
       </p>
     </div>
   }


### PR DESCRIPTION
## Summary
- Server and agent start every owed `dropped_indexes` rebuild at boot, one at a time, instead of only the two migrate-queued names.
- Unique indexes still go first, then the Event Deliveries list index, then the rest by drop time.
- A conversion or dashboard Rebuild that holds the slot starts the next owed index when it finishes. Admin → Table indexes is progress and retry.

## Test plan
- [ ] `go test ./internal/pkg/partitions/ ./internal/pkg/indexes/`
- [ ] Fresh boot with several owed rows: unique starts first, list index before payload GIN, remaining names chain when the slot frees
- [ ] Dashboard Rebuild of one index starts the next owed name after it completes
- [ ] Failed rebuild is skipped for that boot and retried on the next process start

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches boot-time background index rebuilds and the single-active partition/rebuild slot. Fail-open and skip-on-failure reduce hang risk, but a bad queue order or skip logic could delay unique indexes or retry loops.
> 
> **Overview**
> Server and agent now start **every** owed `dropped_indexes` rebuild after boot, not just the two migrate-queued names. Rebuilds still run one at a time and fail open so listen/ingest is not blocked.
> 
> `ListDropped` order is now: single-active guard, unique indexes, Event Deliveries list index, then the rest by drop time (so the hours-long payload GIN does not starve the dashboard list). When a conversion or dashboard Rebuild frees the slot, the next owed index starts automatically. Failed names are skipped for the rest of the process; dashboard Rebuild can retry and clear that skip.
> 
> Admin copy treats the page as progress and retry rather than the only way a rebuild starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f5cbf2fc23de6213e46290b6d48b5706d237af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->