### PR TITLE
fix(controlplane): give the concurrent index build its own lock budget

### DIFF
--- a/internal/pkg/indexes/adopt.go
+++ b/internal/pkg/indexes/adopt.go
@@ -2,10 +2,8 @@ package indexes
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -66,8 +64,7 @@ func adoptOne(ctx context.Context, db *pgxpool.Pool, name string) (bool, error) 
 		// A lock we could not take says the table is busy, which is the same
 		// answer as Busy above: leave the index for the next boot rather than
 		// abandoning the indexes after it in the list.
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "55P03" {
+		if isLockTimeout(err) {
 			return false, nil
 		}
 		return false, err

--- a/internal/pkg/indexes/indexes.go
+++ b/internal/pkg/indexes/indexes.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -34,14 +35,38 @@ import (
 // truncated by the server, silently, which would make two derived names collide.
 const maxIdentifier = 63
 
-// lockTimeout bounds the statements that take a lock on the table: creating the
-// parent index and attaching to it. A rebuild is elective, so it gives way to
-// traffic rather than queueing ahead of it.
-const lockTimeout = "3s"
+// tableLockTimeout bounds the statements that take a lock on the table: creating
+// the parent index, attaching to it, and clearing an invalid leftover. A rebuild
+// is elective, so it gives way to traffic rather than queueing ahead of it.
+const tableLockTimeout = "3s"
 
-// resetTimeout bounds undoing lockTimeout when the connection goes back to the
-// pool. It is short because the alternative to waiting is closing the connection,
-// which is cheap next to leaving a session-wide timeout on a pooled connection.
+// buildLockTimeout bounds a concurrent build, which needs a budget of a
+// different order to the one above.
+//
+// CREATE INDEX CONCURRENTLY waits twice for every transaction that was already
+// open to finish, and it takes that wait as a lock on each transaction's virtual
+// id, so lock_timeout cancels it exactly as it cancels a wait for the table.
+// Those are not the same risk. Waiting for the table means queueing ahead of
+// traffic; waiting for transactions to drain costs nothing but time, since the
+// build holds ShareUpdateExclusive throughout, which blocks other DDL and
+// autovacuum on that table but not reads or writes.
+//
+// Sharing one budget made the drain wait fail against Convoy's own daily counts
+// rollup, whose transaction runs for tens of seconds every minute, so a build
+// only succeeded if it happened to start in a gap between rollup runs. Postgres
+// 17 prunes transactions that cannot see the table from that wait; 15, which is
+// what the observed instance runs, waits for all of them.
+//
+// Ten minutes, not longer: the wait is for transactions to end, and a
+// transaction still open after ten minutes is stuck rather than slow. There is
+// one rebuild slot for the instance, so waiting past that point costs every
+// index behind this one. The failure names what it waited for.
+const buildLockTimeout = "10min"
+
+// resetTimeout bounds undoing whichever of the budgets above is still set when
+// the connection goes back to the pool. It is short because the alternative to
+// waiting is closing the connection, which is cheap next to leaving a
+// session-wide timeout on a pooled connection.
 const resetTimeout = 5 * time.Second
 
 // PayloadGIN is the events payload search index. sql/1787200001.sql inserts this
@@ -261,7 +286,7 @@ func Rebuild(ctx context.Context, db *pgxpool.Pool, d Dropped) error {
 	// SET, not SET LOCAL: a concurrent index build cannot run in a transaction,
 	// so there is no transaction for the setting to be local to. That makes it
 	// session state on a pooled connection, which release has to undo.
-	if _, err = conn.Exec(ctx, `SET lock_timeout = '`+lockTimeout+`'`); err != nil {
+	if err := setLockTimeout(ctx, conn, tableLockTimeout); err != nil {
 		return err
 	}
 
@@ -290,8 +315,9 @@ func Rebuild(ctx context.Context, db *pgxpool.Pool, d Dropped) error {
 
 // release hands the connection back with the lock_timeout undone.
 //
-// The pool this came from serves ordinary traffic, where a 3s lock_timeout is
-// wrong: a row-lock wait that is supposed to queue would abort instead. The
+// The pool this came from serves ordinary traffic, where either of the rebuild's
+// budgets is wrong: a row-lock wait that is supposed to queue would abort after
+// three seconds, or hold a request open for ten minutes. The
 // reset gets a context of its own because it also has to run when the rebuild's
 // context is already cancelled, which is exactly when the setting would
 // otherwise be left behind. If the reset cannot be confirmed, the connection
@@ -320,8 +346,9 @@ func rebuildHeap(ctx context.Context, conn *pgxpool.Conn, d Dropped) error {
 	if err != nil {
 		return err
 	}
-	if _, err = conn.Exec(ctx, stmt); err != nil {
-		return fmt.Errorf("building %s on convoy.%s: %w", d.Name, d.Table, err)
+	if err := buildConcurrently(ctx, conn, d.Table, stmt,
+		fmt.Sprintf("building %s on convoy.%s", d.Name, d.Table)); err != nil {
+		return err
 	}
 
 	return assertValid(ctx, conn, d.Name,
@@ -361,8 +388,9 @@ func rebuildPartitioned(ctx context.Context, conn *pgxpool.Conn, d Dropped) erro
 			return err
 		}
 
-		if _, err = conn.Exec(ctx, create); err != nil {
-			return fmt.Errorf("building %s on partition convoy.%s: %w", child, partition, err)
+		if err := buildConcurrently(ctx, conn, partition, create,
+			fmt.Sprintf("building %s on partition convoy.%s", child, partition)); err != nil {
+			return err
 		}
 
 		if _, err = conn.Exec(ctx, attach); err != nil {
@@ -375,6 +403,159 @@ func rebuildPartitioned(ctx context.Context, conn *pgxpool.Conn, d Dropped) erro
 	// record a rebuild that did not finish.
 	return assertValid(ctx, conn, d.Name,
 		fmt.Sprintf("%d partitions were covered, run the rebuild again to pick up the rest", len(partitions)))
+}
+
+// buildConcurrently runs one concurrent build under the longer budget, and only
+// that statement, so the statements around it still give way to traffic.
+//
+// The table lock is probed first because the longer budget would otherwise hide
+// real contention: a table someone holds a conflicting lock on would occupy the
+// one rebuild slot for half an hour instead of being left for the next pass. The
+// probe also separates the two failures for the operator reading the message,
+// since lock_timeout alone cannot say which wait expired.
+//
+// A lock taken and released proves the table was free a moment ago, not that it
+// still is. That is enough to stop the common case from wasting the slot.
+func buildConcurrently(ctx context.Context, conn *pgxpool.Conn, relation, stmt, what string) error {
+	if err := probeTableLock(ctx, conn, relation); err != nil {
+		return fmt.Errorf("%s: %w", what, err)
+	}
+
+	if err := setLockTimeout(ctx, conn, buildLockTimeout); err != nil {
+		return err
+	}
+	_, err := conn.Exec(ctx, stmt)
+
+	// Restore the short budget whether or not the build worked: the attach that
+	// follows a partition build, and the row the rebuild records, both take
+	// ordinary locks and must not inherit half an hour of patience.
+	if resetErr := setLockTimeout(ctx, conn, tableLockTimeout); resetErr != nil && err == nil {
+		return resetErr
+	}
+
+	if err == nil {
+		return nil
+	}
+	if isLockTimeout(err) {
+		if waiting := openTransactions(ctx, conn); waiting != "" {
+			return fmt.Errorf("%s: %w, after waiting %s for transactions to finish. Still open: %s",
+				what, err, buildLockTimeout, waiting)
+		}
+	}
+	return fmt.Errorf("%s: %w", what, err)
+}
+
+// probeTableLock reports whether the relation can be locked the way a concurrent
+// build locks it, without waiting longer than an elective rebuild should.
+//
+// The lock is taken in its own transaction and rolled back, so it is held for
+// the round trip and nothing else.
+func probeTableLock(ctx context.Context, conn *pgxpool.Conn, relation string) error {
+	err := func() error {
+		tx, err := conn.Begin(ctx)
+		if err != nil {
+			return err
+		}
+		// Rolled back before this returns, so the caller can query the
+		// connection: a statement that failed leaves the transaction aborted and
+		// refusing everything until it ends.
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		if _, err = tx.Exec(ctx, `SET LOCAL lock_timeout = '`+tableLockTimeout+`'`); err != nil {
+			return fmt.Errorf("bounding the table lock wait: %w", err)
+		}
+		_, err = tx.Exec(ctx, `LOCK TABLE convoy.`+pgx.Identifier{relation}.Sanitize()+
+			` IN SHARE UPDATE EXCLUSIVE MODE`)
+		return err
+	}()
+
+	if err != nil && isLockTimeout(err) {
+		return fmt.Errorf("convoy.%s could not be locked within %s%s", relation, tableLockTimeout,
+			held(ctx, conn, relation))
+	}
+	return err
+}
+
+// held names the sessions holding a lock on the relation, for a message that
+// would otherwise say only that a lock could not be taken.
+func held(ctx context.Context, conn *pgxpool.Conn, relation string) string {
+	rows, err := conn.Query(ctx, `
+        SELECT l.pid, l.mode, COALESCE(NULLIF(LEFT(REGEXP_REPLACE(a.query, '\s+', ' ', 'g'), 80), ''), '(not visible)')
+          FROM pg_locks l
+          LEFT JOIN pg_stat_activity a ON a.pid = l.pid
+         WHERE l.relation = ('convoy.' || QUOTE_IDENT($1))::regclass
+           AND l.granted
+           AND l.pid <> pg_backend_pid()
+           AND l.mode IN ('ShareUpdateExclusiveLock', 'ShareLock', 'ShareRowExclusiveLock',
+                          'ExclusiveLock', 'AccessExclusiveLock')
+         ORDER BY l.pid
+         LIMIT 3`, relation)
+	if err != nil {
+		return ""
+	}
+	defer rows.Close()
+
+	var holders []string
+	for rows.Next() {
+		var pid int
+		var mode, query string
+		if err = rows.Scan(&pid, &mode, &query); err != nil {
+			return ""
+		}
+		holders = append(holders, fmt.Sprintf("pid %d holds %s running %s", pid, mode, query))
+	}
+	if rows.Err() != nil || len(holders) == 0 {
+		return ""
+	}
+	return ". Held by " + strings.Join(holders, "; ")
+}
+
+// openTransactions names the transactions a concurrent build was still waiting
+// for. A build waits for transactions that were open before it started, whatever
+// they touch, so the one holding it up is usually nowhere near this table.
+func openTransactions(ctx context.Context, conn *pgxpool.Conn) string {
+	rows, err := conn.Query(ctx, `
+        SELECT pid,
+               DATE_TRUNC('second', CLOCK_TIMESTAMP() - xact_start)::TEXT,
+               COALESCE(NULLIF(LEFT(REGEXP_REPLACE(query, '\s+', ' ', 'g'), 80), ''), '(not visible)')
+          FROM pg_stat_activity
+         WHERE pid <> pg_backend_pid()
+           AND xact_start IS NOT NULL
+           AND CLOCK_TIMESTAMP() - xact_start > INTERVAL '3 seconds'
+         ORDER BY xact_start
+         LIMIT 3`)
+	if err != nil {
+		return ""
+	}
+	defer rows.Close()
+
+	var open []string
+	for rows.Next() {
+		var pid int
+		var age, query string
+		if err = rows.Scan(&pid, &age, &query); err != nil {
+			return ""
+		}
+		open = append(open, fmt.Sprintf("pid %d open %s running %s", pid, age, query))
+	}
+	if rows.Err() != nil || len(open) == 0 {
+		return ""
+	}
+	return strings.Join(open, "; ")
+}
+
+func setLockTimeout(ctx context.Context, conn *pgxpool.Conn, value string) error {
+	if _, err := conn.Exec(ctx, `SET lock_timeout = '`+value+`'`); err != nil {
+		return fmt.Errorf("setting the lock timeout to %s: %w", value, err)
+	}
+	return nil
+}
+
+// isLockTimeout reports a statement Postgres cancelled because a lock it wanted
+// was held by someone else. It says nothing about which lock.
+func isLockTimeout(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "55P03"
 }
 
 // assertValid is what stands between a build that did not happen and a

--- a/internal/pkg/indexes/repair_test.go
+++ b/internal/pkg/indexes/repair_test.go
@@ -539,6 +539,136 @@ func TestRebuildLeavesNoLockTimeoutOnThePool(t *testing.T) {
 	}
 }
 
+// A concurrent build waits for transactions that were already open before it can
+// finish, and it takes that wait as a lock, so one budget covering both the table
+// lock and this wait let an ordinary transaction cancel the build. In production
+// the transaction was Convoy's own daily counts rollup, which runs every minute
+// for tens of seconds, and it cancelled the same rebuild on every attempt.
+//
+// The blocker here writes to the table being indexed, which every supported
+// Postgres waits for. The production case was a transaction elsewhere in the
+// database, and that one reproduces on the 15 that instance runs but not on the
+// 17 this test uses, because 17 prunes transactions that cannot see the table.
+// Same wait, same cancellation, narrower trigger.
+func TestRebuildWaitsForAnOpenTransactionInsteadOfBeingCancelled(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+
+	_, err := db.Exec(ctx, `CREATE TABLE convoy.idx_test_drain (k TEXT)`)
+	require.NoError(t, err)
+
+	owed := Dropped{
+		Table:      "idx_test_drain",
+		Name:       "idx_test_drain_k",
+		Definition: `CREATE INDEX idx_test_drain_k ON convoy.idx_test_drain USING btree (k)`,
+	}
+	_, err = db.Exec(ctx, `
+        INSERT INTO convoy.dropped_indexes (index_name, table_name, definition)
+        VALUES ($1, $2, $3)`, owed.Name, owed.Table, owed.Definition)
+	require.NoError(t, err)
+
+	// A writer's ROW EXCLUSIVE does not conflict with the SHARE UPDATE EXCLUSIVE
+	// a build takes, so this is a transaction to wait for and not a table that
+	// cannot be locked. The two have to stay distinguishable: the first is worth
+	// waiting out, the second is worth giving the rebuild slot back for.
+	blocker, err := db.Begin(ctx)
+	require.NoError(t, err)
+	_, err = blocker.Exec(ctx, `INSERT INTO convoy.idx_test_drain (k) VALUES ('held')`)
+	require.NoError(t, err)
+
+	const held = 5 * time.Second
+	released := make(chan error, 1)
+	go func() {
+		time.Sleep(held)
+		released <- blocker.Rollback(context.Background())
+	}()
+
+	start := time.Now()
+	err = Rebuild(ctx, db, owed)
+	elapsed := time.Since(start)
+	require.NoError(t, <-released)
+	require.NoError(t, err, "an unrelated transaction is something to wait for, not a failed rebuild")
+
+	require.Greater(t, elapsed, 3*time.Second,
+		"the build returned before the blocking transaction ended, so it cannot have waited for it")
+
+	var valid bool
+	require.NoError(t, db.QueryRow(ctx, `
+        SELECT i.indisvalid FROM pg_index i
+          JOIN pg_class c ON c.oid = i.indexrelid
+         WHERE c.relname = $1`, owed.Name).Scan(&valid))
+	require.True(t, valid)
+
+	var rebuiltAt pgtype.Timestamptz
+	require.NoError(t, db.QueryRow(ctx, `
+        SELECT rebuilt_at FROM convoy.dropped_indexes WHERE index_name = $1`, owed.Name).Scan(&rebuiltAt))
+	require.True(t, rebuiltAt.Valid, "a finished build has to leave the debt paid")
+}
+
+// The longer budget is only for waiting on transactions. A table someone holds a
+// conflicting lock on must still be given up quickly, because there is one
+// rebuild slot for the whole instance and the indexes behind this one are
+// waiting for it.
+func TestRebuildGivesUpQuicklyOnALockedTable(t *testing.T) {
+	db := setupDB(t)
+	ctx := context.Background()
+
+	_, err := db.Exec(ctx, `CREATE TABLE convoy.idx_test_locked_build (k TEXT)`)
+	require.NoError(t, err)
+
+	owed := Dropped{
+		Table:      "idx_test_locked_build",
+		Name:       "idx_test_locked_build_k",
+		Definition: `CREATE INDEX idx_test_locked_build_k ON convoy.idx_test_locked_build USING btree (k)`,
+	}
+	_, err = db.Exec(ctx, `
+        INSERT INTO convoy.dropped_indexes (index_name, table_name, definition)
+        VALUES ($1, $2, $3)`, owed.Name, owed.Table, owed.Definition)
+	require.NoError(t, err)
+
+	blocker, err := db.Begin(ctx)
+	require.NoError(t, err)
+	_, err = blocker.Exec(ctx, `LOCK TABLE convoy.idx_test_locked_build IN ACCESS EXCLUSIVE MODE`)
+	require.NoError(t, err)
+
+	start := time.Now()
+	err = Rebuild(ctx, db, owed)
+	elapsed := time.Since(start)
+	require.NoError(t, blocker.Rollback(ctx))
+
+	require.Error(t, err, "a table that cannot be locked is not a rebuild that happened")
+	require.Less(t, elapsed, 30*time.Second, "the rebuild waited past the table lock budget")
+	require.Contains(t, err.Error(), "could not be locked within "+tableLockTimeout)
+	require.Contains(t, err.Error(), "Held by pid",
+		"the message has to name the holder, or the operator learns only that a lock timed out")
+
+	var rebuiltAt pgtype.Timestamptz
+	require.NoError(t, db.QueryRow(ctx, `
+        SELECT rebuilt_at FROM convoy.dropped_indexes WHERE index_name = $1`, owed.Name).Scan(&rebuiltAt))
+	require.False(t, rebuiltAt.Valid, "a build that never ran must stay owed")
+
+	// The failure path hands the connection back too, and the build budget is
+	// session state the next caller must not inherit.
+	idle := int(db.Stat().IdleConns())
+	require.Positive(t, idle)
+
+	conns := make([]*pgxpool.Conn, 0, idle)
+	defer func() {
+		for _, c := range conns {
+			c.Release()
+		}
+	}()
+	for i := 0; i < idle; i++ {
+		conn, err := db.Acquire(ctx)
+		require.NoError(t, err)
+		conns = append(conns, conn)
+
+		var timeout string
+		require.NoError(t, conn.QueryRow(ctx, `SHOW lock_timeout`).Scan(&timeout))
+		require.Equal(t, "0", timeout, "a failed rebuild left its lock_timeout on a pooled connection")
+	}
+}
+
 // Boot calls Adopt before the listener starts, so the ACCESS EXCLUSIVE the drop
 // needs must not wait forever behind a lock someone else holds. The rest of the
 // list still has to be adopted: a busy table is a reason to skip one index, not

--- a/web/ui/dashboard/src/app/portal/event-deliveries/event-deliveries.component.html
+++ b/web/ui/dashboard/src/app/portal/event-deliveries/event-deliveries.component.html
@@ -68,7 +68,7 @@
       @if (isLoadingDeliveryCounts) {
         <convoy-skeleton-loader className="w-100px h-32px mb-4px"></convoy-skeleton-loader>
       } @else {
-        <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ deliveryCounts.success === null ? '—' : (deliveryCounts.success | number) }}</span>
+        <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ deliveryCounts.success === null ? '–' : (deliveryCounts.success | number) }}</span>
       }
       <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Successful deliveries</span>
     </div>
@@ -76,7 +76,7 @@
       @if (isLoadingDeliveryCounts) {
         <convoy-skeleton-loader className="w-100px h-32px mb-4px"></convoy-skeleton-loader>
       } @else {
-        <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ deliveryCounts.failure === null ? '—' : (deliveryCounts.failure | number) }}</span>
+        <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ deliveryCounts.failure === null ? '–' : (deliveryCounts.failure | number) }}</span>
       }
       <span class="font-body font-normal text-[14px] leading-normal" [class]="(deliveryCounts.failure ?? 0) > 0 ? 'text-[#df3520]' : 'text-new.text-secondary'">Failed deliveries</span>
     </div>

--- a/web/ui/dashboard/src/app/private/pages/project/events/events.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/events/events.component.html
@@ -160,7 +160,7 @@
           @if (isLoadingDeliveryCounts) {
             <convoy-skeleton-loader className="w-100px h-32px mb-4px"></convoy-skeleton-loader>
           } @else {
-            <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ deliveryCounts.success === null ? '—' : (deliveryCounts.success | number) }}</span>
+            <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ deliveryCounts.success === null ? '–' : (deliveryCounts.success | number) }}</span>
           }
           <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Successful deliveries</span>
         </div>
@@ -168,7 +168,7 @@
           @if (isLoadingDeliveryCounts) {
             <convoy-skeleton-loader className="w-100px h-32px mb-4px"></convoy-skeleton-loader>
           } @else {
-            <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ deliveryCounts.failure === null ? '—' : (deliveryCounts.failure | number) }}</span>
+            <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ deliveryCounts.failure === null ? '–' : (deliveryCounts.failure | number) }}</span>
           }
           <span class="font-body font-normal text-[14px] leading-normal" [class]="(deliveryCounts.failure ?? 0) > 0 ? 'text-[#df3520]' : 'text-new.text-secondary'">Failed deliveries</span>
         </div>


### PR DESCRIPTION
## Summary

Background index rebuilds ran every statement under one `lock_timeout` of 3s. That budget is right for statements that take a lock on the table, because a rebuild is elective and should give way to traffic. It is wrong for the build itself.

`CREATE INDEX CONCURRENTLY` waits for transactions that were already open before it can finish, and it takes that wait as a lock on each transaction's virtual id, so `lock_timeout` cancels it exactly as it cancels a wait for the table. The two waits are not the same risk. Waiting for the table means queueing ahead of traffic. Waiting for a drain costs only time: the build holds `ShareUpdateExclusive` throughout, which blocks other DDL and autovacuum on that table but not reads or writes.

Sharing one budget made the drain wait fail against the daily counts rollup, which runs every minute and holds a single transaction for tens of seconds. A rebuild only succeeded if it happened to start in a gap between runs. On one instance the same index failed on every attempt, sampled waiting on `Lock/virtualxid` behind that rollup's `INSERT`.

Changes in `internal/pkg/indexes`:

- `tableLockTimeout` (3s, the old value) still bounds every statement that takes a lock on the table: the parent index create, the attach, and clearing an invalid leftover.
- `buildLockTimeout` (10min) bounds the concurrent build alone, and the short value is restored afterwards whether or not the build worked, so the attach and the row the rebuild records do not inherit it. Ten minutes because a transaction still open after that is stuck rather than slow, and there is one rebuild slot for the instance.
- The table lock is probed first, in its own rolled-back transaction under the short budget. Without it the longer budget would hide real contention: a table someone holds would occupy the rebuild slot for ten minutes instead of being left for the next pass. It also separates the two failures for the reader, which `lock_timeout` alone cannot express.
- Failures name the blocker. A locked table reports holders with their lock modes; a drain timeout reports pids with transaction ages and truncated query text. Both are best-effort and degrade to the plain error.
- `isLockTimeout` replaces the inline `55P03` check that `adopt.go` already had.

Follow-ups, both pre-existing and out of scope here: the rollup holds one transaction across a range delete and a reinsert, which is what makes it a multi-second blocker; and a table that cannot be locked still lands in the in-process failed set, so it waits for an explicit rebuild rather than the next sweep.

## Test plan

Two regression tests in `repair_test.go`, both run against a real database:

- `TestRebuildWaitsForAnOpenTransactionInsteadOfBeingCancelled` holds a writing transaction open for 5s and asserts the rebuild waits it out, succeeds, and records `rebuilt_at`.
- `TestRebuildGivesUpQuicklyOnALockedTable` holds `ACCESS EXCLUSIVE` and asserts the rebuild fails inside the table budget, names the holder, leaves the debt owed, and leaves no `lock_timeout` on any pooled connection.

Both were run against the pre-fix behaviour (one shared budget, no probe) and fail there with the exact production error, `canceling statement due to lock timeout`.

One caveat worth knowing for anyone extending these tests: the test container is Postgres 17, which prunes transactions that cannot see the table from the drain wait, while the observed instance runs 15. The production trigger, a transaction elsewhere in the database, therefore does not reproduce locally at all. The test uses a writer on the target table, which every supported version waits for, and says so in a comment.

- `go test ./internal/pkg/indexes/`: 34 pass. With `./internal/pkg/partitions/`: 69 pass.
- `gofmt`, `go vet`, `golangci-lint run ./internal/pkg/indexes/...`: clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Postgres lock-timeout behavior for background index rebuilds, including a 10-minute session `lock_timeout` on pooled connections during concurrent builds. A missed reset could abort or stall ordinary traffic; tests cover the reset path.
> 
> **Overview**
> Background index rebuilds no longer share a single 3s `lock_timeout` with table-lock statements. `CREATE INDEX CONCURRENTLY` waits for already-open transactions (as a lock), so the old budget cancelled builds against long-running work such as the daily counts rollup.
> 
> Rebuilds now use **3s** for table locks (parent create, attach, invalid leftover drop) and **10min** only for the concurrent build, then restore the short budget. A short probe of `SHARE UPDATE EXCLUSIVE` runs first so a contended table does not occupy the single rebuild slot. Timeouts name lock holders or still-open transactions.
> 
> Also swaps an oversized em dash for an en dash on the delivery-count cards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f98689eb749f33095fbe87b14b6520b6d85fa12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Also included

`fix(dashboard)`: the Successful and Failed delivery cards show a dash when the count could not be read. It was an em dash, one em wide, so at the cards' 32px font it rendered 32px across and dwarfed the numbers beside it. Now an en dash, half that. The same placeholder elsewhere in the dashboard sits at 13-14px, which is why the width never showed there.
