### PR TITLE
fix(dataplane): reconcile stored partition retention with config

### DIFF
--- a/internal/pkg/retention/retention.go
+++ b/internal/pkg/retention/retention.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgtype"
+
 	partman "github.com/jirevwe/gopartman"
 
 	"github.com/frain-dev/convoy/database"
@@ -25,10 +27,11 @@ import (
 var RetentionTables = []string{"events", "events_search", "event_deliveries", "delivery_attempts"}
 
 const (
-	retentionSchema      = "convoy"
-	retentionTenantCol   = "project_id"
-	retentionPartitionBy = "created_at"
-	retentionPremake     = 10
+	retentionSchema            = "convoy"
+	retentionTenantCol         = "project_id"
+	retentionPartitionBy       = "created_at"
+	retentionPremake           = 10
+	retentionPartitionInterval = "daily"
 )
 
 // UnpartitionedTables returns the retention-managed tables that are not yet
@@ -271,6 +274,9 @@ func (r *PartitionRetentionPolicy) registerParents(ctx context.Context) {
 			r.logger.Error(fmt.Sprintf("failed to register convoy.%s with gopartman", table), "error", err)
 			continue
 		}
+		if err := r.reconcileParent(ctx, table); err != nil {
+			r.logger.Error(fmt.Sprintf("failed to reconcile convoy.%s parent config", table), "error", err)
+		}
 
 		ref := partman.ParentRef{SchemaName: retentionSchema, TableName: table}
 		report, err := r.manager.ImportExisting(ctx, ref)
@@ -280,6 +286,67 @@ func (r *PartitionRetentionPolicy) registerParents(ctx context.Context) {
 		}
 		r.logImportReport(table, report)
 	}
+}
+
+// storedParent reads the partman.parent_tables row Maintain and
+// dropAdoptedPartition both use for the retention window.
+func (r *PartitionRetentionPolicy) storedParent(ctx context.Context, table string) (partman.ParentInfo, error) {
+	parents, err := r.manager.ListParents(ctx)
+	if err != nil {
+		return partman.ParentInfo{}, err
+	}
+	for _, parent := range parents {
+		if parent.SchemaName == retentionSchema && parent.TableName == table {
+			return parent, nil
+		}
+	}
+	return partman.ParentInfo{}, fmt.Errorf("partman has no parent row for convoy.%s", table)
+}
+
+// reconcileParent writes the operator's current parentConfig onto an
+// already-registered partman.parent_tables row. RegisterParent is
+// insert-if-absent (ON CONFLICT DO NOTHING), so a config change plus a
+// restart otherwise leaves retention_period, premake, and
+// partition_interval on the first write. Maintain and dropAdoptedPartition
+// both read that stored window. Config wins on write.
+func (r *PartitionRetentionPolicy) reconcileParent(ctx context.Context, table string) error {
+	stored, err := r.storedParent(ctx, table)
+	if err != nil {
+		return err
+	}
+
+	desired := r.parentConfig(table)
+	if stored.RetentionPeriod == desired.RetentionPeriod &&
+		stored.Premake == desired.Premake &&
+		stored.PartitionInterval == retentionPartitionInterval {
+		return nil
+	}
+
+	_, err = r.db.GetConn().Exec(ctx, `
+        UPDATE partman.parent_tables
+        SET retention_period = $1,
+            premake = $2,
+            partition_interval = $3,
+            updated_at = CURRENT_TIMESTAMP
+        WHERE schema_name = $4 AND table_name = $5`,
+		pgtype.Interval{Microseconds: desired.RetentionPeriod.Microseconds(), Valid: true},
+		desired.Premake,
+		retentionPartitionInterval,
+		retentionSchema,
+		table,
+	)
+	if err != nil {
+		return err
+	}
+
+	r.logger.Info(fmt.Sprintf(
+		"corrected convoy.%s parent config: retention_period %s -> %s, premake %d -> %d, partition_interval %s -> %s",
+		table,
+		stored.RetentionPeriod, desired.RetentionPeriod,
+		stored.Premake, desired.Premake,
+		stored.PartitionInterval, retentionPartitionInterval,
+	))
+	return nil
 }
 
 // logImportReport surfaces the outcome of ImportExisting. gopartman reports
@@ -342,7 +409,9 @@ func (r *PartitionRetentionPolicy) registerTenants(ctx context.Context) {
 // Parent registration is re-attempted on each tick so a transient boot-time
 // RegisterParent/ImportExisting failure does not leave Maintain with no
 // managed tables for the life of the process (ErrParentAlreadyExists is
-// treated as success). It does not start gopartman's internal ticker;
+// treated as success). Already-registered rows are then rewritten from
+// parentConfig so a later retention-period change is not stuck on the
+// first insert. It does not start gopartman's internal ticker;
 // Perform (the asynq nightly job) calls Maintain.
 func (r *PartitionRetentionPolicy) Start(ctx context.Context, sampleRate time.Duration) {
 	go func(r *PartitionRetentionPolicy) {
@@ -409,7 +478,11 @@ func (r *PartitionRetentionPolicy) dropExpiredAdoptedPartitions(ctx context.Cont
 }
 
 // dropAdoptedPartition drops <table>_default when every row in it is older than
-// the retention period.
+// the stored retention period.
+//
+// The window is the partman.parent_tables row Maintain already reads, not
+// the in-process config. reconcileParent writes that row from config first.
+// A zero stored period means retention is off, same as Maintain.
 //
 // Two gates, both necessary. The partition must carry the bounds constraint the
 // attach conversion writes, which is what distinguishes an adopted table from
@@ -448,7 +521,15 @@ func (r *PartitionRetentionPolicy) dropAdoptedPartition(ctx context.Context, tab
 	// An empty adopted partition is left alone. It still routes rows below the
 	// conversion's cutoff, and reclaiming nothing is not worth a destructive
 	// statement.
-	if newest == nil || newest.After(time.Now().Add(-r.retentionPeriod)) {
+	if newest == nil {
+		return false, nil
+	}
+
+	parent, err := r.storedParent(ctx, table)
+	if err != nil {
+		return false, err
+	}
+	if parent.RetentionPeriod <= 0 || newest.After(time.Now().Add(-parent.RetentionPeriod)) {
 		return false, nil
 	}
 

--- a/internal/pkg/retention/retention_test.go
+++ b/internal/pkg/retention/retention_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	partman "github.com/jirevwe/gopartman"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 
@@ -250,6 +251,7 @@ func TestKeepsAdoptedHistoryPartitionWhileItHoldsLiveRows(t *testing.T) {
 	partitionDeliveries(t, ctx, db)
 
 	policy := newDropPolicy(t, db, 24*time.Hour)
+	policy.registerParents(ctx)
 
 	dropped, err := policy.dropAdoptedPartition(ctx, "event_deliveries")
 	require.NoError(t, err)
@@ -345,7 +347,9 @@ func TestKeepsAdoptedHistoryPartitionWhenOldestIsExpiredButNewestIsLive(t *testi
 	require.NoError(t, err)
 	partitionDeliveries(t, ctx, db)
 
-	dropped, err := newDropPolicy(t, db, 24*time.Hour).dropAdoptedPartition(ctx, "event_deliveries")
+	policy := newDropPolicy(t, db, 24*time.Hour)
+	policy.registerParents(ctx)
+	dropped, err := policy.dropAdoptedPartition(ctx, "event_deliveries")
 	require.NoError(t, err)
 	require.False(t, dropped, "dropped a history partition because it also held expired rows")
 	require.True(t, relationExists(t, ctx, db, "event_deliveries_default"))
@@ -365,6 +369,7 @@ func TestDropAdoptedPartitionIsIdempotent(t *testing.T) {
 	seedExpiredRow(t, db, "event_deliveries", time.Now().AddDate(0, 0, -90))
 	partitionDeliveries(t, ctx, db)
 	policy := newDropPolicy(t, db, 24*time.Hour)
+	policy.registerParents(ctx)
 
 	dropped, err := policy.dropAdoptedPartition(ctx, "event_deliveries")
 	require.NoError(t, err)
@@ -386,7 +391,9 @@ func TestDropExpiredAdoptedPartitionsDoesNotDropALiveSiblingTable(t *testing.T) 
 	partitionTable(t, ctx, db, "events")
 	partitionDeliveries(t, ctx, db)
 
-	newDropPolicy(t, db, 24*time.Hour).dropExpiredAdoptedPartitions(ctx)
+	policy := newDropPolicy(t, db, 24*time.Hour)
+	policy.registerParents(ctx)
+	policy.dropExpiredAdoptedPartitions(ctx)
 
 	require.False(t, relationExists(t, ctx, db, "events_default"), "expired events history was not dropped")
 	require.True(t, relationExists(t, ctx, db, "event_deliveries_default"), "live deliveries history was dropped because a sibling expired")
@@ -401,7 +408,9 @@ func TestDroppingAdoptedHistoryLeavesDailyPartitions(t *testing.T) {
 	daily := childPartitions(t, ctx, db, "event_deliveries")
 	require.Greater(t, len(daily), 1, "conversion created no daily partitions to leave behind")
 
-	dropped, err := newDropPolicy(t, db, 24*time.Hour).dropAdoptedPartition(ctx, "event_deliveries")
+	policy := newDropPolicy(t, db, 24*time.Hour)
+	policy.registerParents(ctx)
+	dropped, err := policy.dropAdoptedPartition(ctx, "event_deliveries")
 	require.NoError(t, err)
 	require.True(t, dropped)
 
@@ -428,6 +437,52 @@ func TestLicensedRetentionPolicySkipsWhenTablesAreUnpartitioned(t *testing.T) {
 	require.ElementsMatch(t, RetentionTables, missing)
 }
 
+// RegisterParent is insert-if-absent. A later config change plus a full
+// restart used to leave partman.parent_tables.retention_period on the first
+// write, so Maintain kept dropping on the old window while dropAdoptedPartition
+// used the new one.
+func TestRegisterParentsReconcilesStoredRetentionPeriod(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	seedProjectWithEvent(t, db)
+	partitionAll(t, ctx, db)
+
+	first := newDropPolicy(t, db, 720*time.Hour)
+	first.registerParents(ctx)
+	require.Equal(t, 720*time.Hour, storedRetentionPeriod(t, ctx, first, "events"))
+
+	second := newDropPolicy(t, db, 360*time.Hour)
+	second.registerParents(ctx)
+	require.Equal(t, 360*time.Hour, storedRetentionPeriod(t, ctx, second, "events"),
+		"stored retention_period stayed on the first register, so daily drops keep the old window")
+
+	for _, table := range RetentionTables {
+		require.Equal(t, 360*time.Hour, storedRetentionPeriod(t, ctx, second, table), table)
+	}
+
+	second.registerParents(ctx)
+	require.Equal(t, 360*time.Hour, storedRetentionPeriod(t, ctx, second, "events"),
+		"second reconcile rewrote a period that already matched")
+}
+
+func TestRegisterParentsReconcilesStoredPremake(t *testing.T) {
+	db, ctx := setupTestDB(t)
+	seedProjectWithEvent(t, db)
+	partitionAll(t, ctx, db)
+
+	policy := newDropPolicy(t, db, 24*time.Hour)
+	policy.registerParents(ctx)
+
+	_, err := db.GetConn().Exec(ctx, `
+        UPDATE partman.parent_tables
+        SET premake = 1
+        WHERE schema_name = $1 AND table_name = $2`, retentionSchema, "events")
+	require.NoError(t, err)
+
+	policy.registerParents(ctx)
+	require.Equal(t, retentionPremake, storedPremake(t, ctx, policy, "events"),
+		"stored premake stayed on the first register")
+}
+
 func TestLicensedRetentionPolicyRefusesActivationBeforeStart(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	seedProjectWithEvent(t, db)
@@ -436,6 +491,49 @@ func TestLicensedRetentionPolicyRefusesActivationBeforeStart(t *testing.T) {
 	err := NewLicensedRetentionPolicy(db, log.New("convoy", log.LevelInfo), 24*time.Hour).Perform(ctx)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Start has not run")
+}
+
+func storedParent(t *testing.T, ctx context.Context, policy *PartitionRetentionPolicy, table string) partman.ParentInfo {
+	t.Helper()
+
+	parent, err := policy.storedParent(ctx, table)
+	require.NoError(t, err)
+	return parent
+}
+
+// A 10-day-old adopted heap is expired under 24h and live under 720h. The
+// drop must follow the stored window, not the in-process period, or the two
+// drop paths disagree after a config change that has not been reconciled.
+func TestDropAdoptedPartitionUsesStoredRetentionPeriod(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	seedProjectWithDelivery(t, db, time.Now().AddDate(0, 0, -10))
+	partitionDeliveries(t, ctx, db)
+
+	registered := newDropPolicy(t, db, 720*time.Hour)
+	registered.registerParents(ctx)
+
+	inProcess := newDropPolicy(t, db, 24*time.Hour)
+	dropped, err := inProcess.dropAdoptedPartition(ctx, "event_deliveries")
+	require.NoError(t, err)
+	require.False(t, dropped, "dropped on the in-process 24h period instead of the stored 720h window")
+	require.True(t, relationExists(t, ctx, db, "event_deliveries_default"))
+
+	inProcess.registerParents(ctx)
+	dropped, err = inProcess.dropAdoptedPartition(ctx, "event_deliveries")
+	require.NoError(t, err)
+	require.True(t, dropped, "stored 24h window did not drop a 10-day-old history partition")
+	require.False(t, relationExists(t, ctx, db, "event_deliveries_default"))
+}
+
+func storedRetentionPeriod(t *testing.T, ctx context.Context, policy *PartitionRetentionPolicy, table string) time.Duration {
+	t.Helper()
+	return storedParent(t, ctx, policy, table).RetentionPeriod
+}
+
+func storedPremake(t *testing.T, ctx context.Context, policy *PartitionRetentionPolicy, table string) int {
+	t.Helper()
+	return storedParent(t, ctx, policy, table).Premake
 }
 
 func newDropPolicy(t *testing.T, db database.Database, period time.Duration) *PartitionRetentionPolicy {


### PR DESCRIPTION
## Summary
- `RegisterParent` is insert-if-absent, so a later `CONVOY_RETENTION_POLICY` change never updated `partman.parent_tables`.
- `registerParents` now rewrites stored `retention_period`, `premake`, and `partition_interval` from the current config when they differ, and logs the old and new values.
- `dropAdoptedPartition` reads that same stored window, so daily drops and adopted-history drops share one period after reconcile.

## Test plan
- [x] `TestRegisterParentsReconcilesStoredRetentionPeriod` (720h then 360h on all four tables; second reconcile stays 360h)
- [x] `TestRegisterParentsReconcilesStoredPremake`
- [x] `TestDropAdoptedPartitionUsesStoredRetentionPeriod` (in-process 24h does not drop a 10-day-old history partition still stored as 720h; after reconcile it does)
- [x] `go test -count=1 -timeout 8m ./internal/pkg/retention/` (35 passed)
- [ ] Restart a licensed instance whose stored period does not match config and confirm `partman.parent_tables` updates and both drop paths use the new window