### PR TITLE
fix(dashboard): use singular metric labels when the count is one

### DIFF
--- a/web/ui/dashboard/src/app/pipes/count-label/count-label.pipe.spec.ts
+++ b/web/ui/dashboard/src/app/pipes/count-label/count-label.pipe.spec.ts
@@ -1,0 +1,22 @@
+import { CountLabelPipe } from './count-label.pipe';
+
+describe('CountLabelPipe', () => {
+	const pipe = new CountLabelPipe();
+
+	it('uses the singular label when the count is 1', () => {
+		expect(pipe.transform(1, 'Event sent', 'Events sent')).toBe('Event sent');
+	});
+
+	it('uses the plural label when the count is 0', () => {
+		expect(pipe.transform(0, 'Failed delivery', 'Failed deliveries')).toBe('Failed deliveries');
+	});
+
+	it('uses the plural label when the count is greater than 1', () => {
+		expect(pipe.transform(2, 'Active endpoint', 'Active endpoints')).toBe('Active endpoints');
+	});
+
+	it('uses the plural label when the count is unknown', () => {
+		expect(pipe.transform(null, 'Successful delivery', 'Successful deliveries')).toBe('Successful deliveries');
+		expect(pipe.transform(undefined, 'Successful delivery', 'Successful deliveries')).toBe('Successful deliveries');
+	});
+});

--- a/web/ui/dashboard/src/app/pipes/count-label/count-label.pipe.ts
+++ b/web/ui/dashboard/src/app/pipes/count-label/count-label.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+	name: 'countLabel',
+	standalone: true
+})
+export class CountLabelPipe implements PipeTransform {
+	transform(count: number | null | undefined, singular: string, plural: string): string {
+		return count === 1 ? singular : plural;
+	}
+}

--- a/web/ui/dashboard/src/app/portal/event-deliveries/event-deliveries.component.html
+++ b/web/ui/dashboard/src/app/portal/event-deliveries/event-deliveries.component.html
@@ -62,7 +62,7 @@
       } @else {
         <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ dashboardData.events_sent | number }}</span>
       }
-      <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Events sent</span>
+      <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">{{ dashboardData.events_sent | countLabel:'Event sent':'Events sent' }}</span>
     </div>
     <div class="bg-white-100 border border-new.border rounded-8px p-12px flex flex-col gap-4px min-h-[84px]">
       @if (isLoadingDeliveryCounts) {
@@ -70,7 +70,7 @@
       } @else {
         <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ deliveryCounts.success === null ? '–' : (deliveryCounts.success | number) }}</span>
       }
-      <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Successful deliveries</span>
+      <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">{{ deliveryCounts.success | countLabel:'Successful delivery':'Successful deliveries' }}</span>
     </div>
     <div class="bg-white-100 border border-new.border rounded-8px p-12px flex flex-col gap-4px min-h-[84px]">
       @if (isLoadingDeliveryCounts) {
@@ -78,7 +78,7 @@
       } @else {
         <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ deliveryCounts.failure === null ? '–' : (deliveryCounts.failure | number) }}</span>
       }
-      <span class="font-body font-normal text-[14px] leading-normal" [class]="(deliveryCounts.failure ?? 0) > 0 ? 'text-[#df3520]' : 'text-new.text-secondary'">Failed deliveries</span>
+      <span class="font-body font-normal text-[14px] leading-normal" [class]="(deliveryCounts.failure ?? 0) > 0 ? 'text-[#df3520]' : 'text-new.text-secondary'">{{ deliveryCounts.failure | countLabel:'Failed delivery':'Failed deliveries' }}</span>
     </div>
     <div class="bg-white-100 border border-new.border rounded-8px p-12px flex flex-col gap-4px min-h-[84px]">
       @if (isLoadingSummaryEndpoints) {
@@ -86,7 +86,7 @@
       } @else {
         <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ activeEndpointCount | number }}</span>
       }
-      <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Active endpoints</span>
+      <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">{{ activeEndpointCount | countLabel:'Active endpoint':'Active endpoints' }}</span>
     </div>
   </div>
 

--- a/web/ui/dashboard/src/app/portal/event-deliveries/event-deliveries.component.ts
+++ b/web/ui/dashboard/src/app/portal/event-deliveries/event-deliveries.component.ts
@@ -14,10 +14,11 @@ import {EventsService} from '../../private/pages/project/events/events.service';
 import {PrivateService} from '../../private/private.service';
 import {Router} from '@angular/router';
 import {LicensesService} from "../../services/licenses/licenses.service";
+import {CountLabelPipe} from 'src/app/pipes/count-label/count-label.pipe';
 
 @Component({
     selector: 'convoy-event-deliveries',
-    imports: [CommonModule, EventDeliveriesModule, DatePickerComponent, DropdownComponent, DropdownOptionDirective, SkeletonLoaderComponent],
+    imports: [CommonModule, EventDeliveriesModule, DatePickerComponent, DropdownComponent, DropdownOptionDirective, SkeletonLoaderComponent, CountLabelPipe],
     templateUrl: './event-deliveries.component.html',
     styleUrls: ['./event-deliveries.component.scss']
 })

--- a/web/ui/dashboard/src/app/private/pages/project/events/events.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/events/events.component.html
@@ -154,7 +154,7 @@
           } @else {
             <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ dashboardData.events_sent | number }}</span>
           }
-          <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Events sent</span>
+          <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">{{ dashboardData.events_sent | countLabel:'Event sent':'Events sent' }}</span>
         </div>
         <div class="bg-white-100 border border-new.border rounded-8px p-12px flex flex-col gap-4px min-h-[84px]">
           @if (isLoadingDeliveryCounts) {
@@ -162,7 +162,7 @@
           } @else {
             <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ deliveryCounts.success === null ? '–' : (deliveryCounts.success | number) }}</span>
           }
-          <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Successful deliveries</span>
+          <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">{{ deliveryCounts.success | countLabel:'Successful delivery':'Successful deliveries' }}</span>
         </div>
         <div class="bg-white-100 border border-new.border rounded-8px p-12px flex flex-col gap-4px min-h-[84px]">
           @if (isLoadingDeliveryCounts) {
@@ -170,7 +170,7 @@
           } @else {
             <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ deliveryCounts.failure === null ? '–' : (deliveryCounts.failure | number) }}</span>
           }
-          <span class="font-body font-normal text-[14px] leading-normal" [class]="(deliveryCounts.failure ?? 0) > 0 ? 'text-[#df3520]' : 'text-new.text-secondary'">Failed deliveries</span>
+          <span class="font-body font-normal text-[14px] leading-normal" [class]="(deliveryCounts.failure ?? 0) > 0 ? 'text-[#df3520]' : 'text-new.text-secondary'">{{ deliveryCounts.failure | countLabel:'Failed delivery':'Failed deliveries' }}</span>
         </div>
         <div class="bg-white-100 border border-new.border rounded-8px p-12px flex flex-col gap-4px min-h-[84px]">
           @if (isloadingDashboardData) {
@@ -178,7 +178,7 @@
           } @else {
             <span class="font-body font-medium text-[32px] leading-[40px] text-new.text-primary">{{ dashboardData.apps | number }}</span>
           }
-          <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Active endpoints</span>
+          <span class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">{{ dashboardData.apps | countLabel:'Active endpoint':'Active endpoints' }}</span>
         </div>
       </div>
 

--- a/web/ui/dashboard/src/app/private/pages/project/events/events.module.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/events.module.ts
@@ -15,6 +15,7 @@ import {CopyButtonComponent} from 'src/app/components/copy-button/copy-button.co
 import {TagComponent} from 'src/app/components/tag/tag.component';
 import {StatusColorModule} from 'src/app/pipes/status-color/status-color.module';
 import {PermissionDirective} from "../../../components/permission/permission.directive";
+import {CountLabelPipe} from 'src/app/pipes/count-label/count-label.pipe';
 
 const routes: Routes = [{ path: '', component: EventsComponent }];
 
@@ -36,7 +37,8 @@ const routes: Routes = [{ path: '', component: EventsComponent }];
         CopyButtonComponent,
         TagComponent,
         StatusColorModule,
-        PermissionDirective
+        PermissionDirective,
+        CountLabelPipe
     ],
 	providers: [DatePipe]
 })


### PR DESCRIPTION
## Summary
- Event and delivery list headers now use a shared count-label pipe.
- A count of one renders the singular noun (1 Event, 1 Event Delivery).

## Test plan
- [ ] Events page with one row shows "1 Event".
- [ ] Events page with zero or many rows stays plural.
- [ ] Portal event deliveries list follows the same rule.