### PR TITLE
fix(dashboard): keep discarded deliveries on a neutral chip

### DIFF
--- a/web/ui/dashboard/src/app/pipes/status-color/status-color.pipe.spec.ts
+++ b/web/ui/dashboard/src/app/pipes/status-color/status-color.pipe.spec.ts
@@ -1,8 +1,18 @@
 import { StatusColorPipe } from '../status-color/status-color.pipe';
 
 describe('StatusColorPipe', () => {
+	const pipe = new StatusColorPipe();
+
 	it('create an instance', () => {
-		const pipe = new StatusColorPipe();
 		expect(pipe).toBeTruthy();
+	});
+
+	it('maps delivery outcomes without treating Discarded as a failure', () => {
+		expect(pipe.transform('Success')).toBe('success');
+		expect(pipe.transform('Failure')).toBe('error');
+		expect(pipe.transform('Discarded')).toBe('neutral');
+		expect(pipe.transform('Scheduled')).toBe('neutral');
+		expect(pipe.transform('Processing')).toBe('neutral');
+		expect(pipe.transform('Retry')).toBe('neutral');
 	});
 });

--- a/web/ui/dashboard/src/app/pipes/status-color/status-color.pipe.ts
+++ b/web/ui/dashboard/src/app/pipes/status-color/status-color.pipe.ts
@@ -36,6 +36,13 @@ export class StatusColorPipe implements PipeTransform {
 			case 'overdue':
 				type = 'error';
 				break;
+			case 'Discarded':
+			case 'discarded':
+			case 'Scheduled':
+			case 'Processing':
+			case 'Retry':
+				type = 'neutral';
+				break;
 
 			default:
 				break;

--- a/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.html
@@ -281,7 +281,7 @@
 
               <!-- Route -->
               <div class="flex items-center px-12px h-40px">
-                <span class="inline-flex items-center h-20px px-6px rounded-4px font-body font-medium text-[12px] leading-[14px]" [class]="hasMatchedSubscription(event) ? 'bg-[#C6F5CE] text-new.text-primary' : 'bg-new.surface-muted text-new.text-secondary'">{{ getRouteStatus(event) }}</span>
+                <span class="inline-flex items-center h-20px px-6px rounded-4px font-body font-medium text-[12px] leading-[14px]" [class]="routeChipClass(event)">{{ getRouteStatus(event) }}</span>
               </div>
 
               <!-- Time -->

--- a/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.spec.ts
@@ -22,3 +22,17 @@ describe('EventLogsComponent', () => {
     expect(component).toBeTruthy();
   });
 });
+
+describe('EventLogsComponent route chips', () => {
+	const logs = Object.create(EventLogsComponent.prototype) as EventLogsComponent;
+
+	it('labels a subscription match as Matched, not Delivered', () => {
+		const matched = { endpoints: [{ uid: 'ep_1' }] } as any;
+		const unmatched = { endpoints: [] } as any;
+
+		expect(logs.getRouteStatus(matched)).toBe('Matched');
+		expect(logs.getRouteStatus(unmatched)).toBe('Unmatched');
+		expect(logs.routeChipClass(matched)).toBe('bg-success-a3 text-success-11');
+		expect(logs.routeChipClass(unmatched)).toBe('bg-new.surface-muted text-new.text-secondary');
+	});
+});

--- a/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/event-logs/event-logs.component.ts
@@ -664,7 +664,12 @@ export class EventLogsComponent implements OnInit, OnDestroy {
 	}
 
 	getRouteStatus(event: EVENT): string {
-		return this.hasMatchedSubscription(event) ? 'Delivered' : 'Unmatched';
+		return this.hasMatchedSubscription(event) ? 'Matched' : 'Unmatched';
+	}
+
+	routeChipClass(event?: EVENT): string {
+		if (this.hasMatchedSubscription(event)) return 'bg-success-a3 text-success-11';
+		return 'bg-new.surface-muted text-new.text-secondary';
 	}
 
 	// Prefer the server's reason. Without it we can only guess, and the guess is

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-deliveries/event-deliveries.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-deliveries/event-deliveries.component.spec.ts
@@ -1,26 +1,12 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { EventDeliveriesComponent } from './event-deliveries.component';
-import { RouterTestingModule } from '@angular/router/testing';
 
-describe('EventDeliveriesComponent', () => {
-  let component: EventDeliveriesComponent;
-  let fixture: ComponentFixture<EventDeliveriesComponent>;
+describe('EventDeliveriesComponent status pills', () => {
+	const pills = Object.create(EventDeliveriesComponent.prototype) as EventDeliveriesComponent;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [ RouterTestingModule, EventDeliveriesComponent ]
-    })
-    .compileComponents();
-  });
-
-  beforeEach(() => {
-    fixture = TestBed.createComponent(EventDeliveriesComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
-
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+	it('keeps Failure red and Discarded muted', () => {
+		expect(pills.statusPillClass('Success')).toBe('bg-success-a3 text-success-11');
+		expect(pills.statusPillClass('Failure')).toBe('bg-error-a3 text-error-11');
+		expect(pills.statusPillClass('Discarded')).toBe('bg-new.surface-muted text-new.text-secondary');
+		expect(pills.statusPillClass('Scheduled')).toBe('bg-new.surface-muted text-new.text-secondary');
+	});
 });

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-deliveries/event-deliveries.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-deliveries/event-deliveries.component.ts
@@ -361,7 +361,7 @@ export class EventDeliveriesComponent implements OnInit, OnDestroy {
 
 	statusPillClass(status?: string): string {
 		if (status === 'Success') return 'bg-success-a3 text-success-11';
-		if (status === 'Failure' || status === 'Discarded') return 'bg-error-a3 text-error-11';
+		if (status === 'Failure') return 'bg-error-a3 text-error-11';
 		return 'bg-new.surface-muted text-new.text-secondary';
 	}
 


### PR DESCRIPTION
## Summary
- Discarded deliveries use the muted chip, not the error red used for Failure.
- Event log Route now says Matched when a subscription hit, instead of Delivered.
- Status color pipe maps Discarded, Scheduled, Processing, and Retry to neutral so sidebar and details chips stay consistent.

## Test plan
- [ ] Event Deliveries: Discarded is muted; Failure stays red; Success stays green
- [ ] Event log Route: events with endpoints show Matched (green); unmatched stay muted Unmatched
- [ ] Event log sidebar and delivery details: Discarded chip is neutral, not red
- [ ] Retry still available on Discarded rows