### PR TITLE
fix(dashboard): serve delivery table count from the daily rollup

### DIFF
--- a/web/ui/dashboard/src/app/private/pages/project/events/event-deliveries/event-deliveries.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-deliveries/event-deliveries.component.spec.ts
@@ -1,4 +1,4 @@
-import { EventDeliveriesComponent } from './event-deliveries.component';
+import { EventDeliveriesComponent, rollupCanServeDisplayCount, sumRollupDisplayCount } from './event-deliveries.component';
 
 describe('EventDeliveriesComponent status pills', () => {
 	const pills = Object.create(EventDeliveriesComponent.prototype) as EventDeliveriesComponent;
@@ -8,5 +8,30 @@ describe('EventDeliveriesComponent status pills', () => {
 		expect(pills.statusPillClass('Failure')).toBe('bg-error-a3 text-error-11');
 		expect(pills.statusPillClass('Discarded')).toBe('bg-new.surface-muted text-new.text-secondary');
 		expect(pills.statusPillClass('Scheduled')).toBe('bg-new.surface-muted text-new.text-secondary');
+	});
+});
+
+describe('rollup display count', () => {
+	it('sums every status when none are selected', () => {
+		expect(sumRollupDisplayCount({ Success: 753161, Processing: 22, Scheduled: 6 }, [])).toBe(753189);
+	});
+
+	it('sums only the selected statuses', () => {
+		expect(sumRollupDisplayCount({ Success: 753161, Processing: 22, Scheduled: 6 }, ['Scheduled', 'Processing', 'Discarded'])).toBe(28);
+	});
+
+	it('treats a missing selected status as zero', () => {
+		expect(sumRollupDisplayCount({ Success: 10 }, ['Failure'])).toBe(0);
+	});
+
+	it('serves the rollup for date and endpoint filters', () => {
+		expect(rollupCanServeDisplayCount({})).toBe(true);
+		expect(rollupCanServeDisplayCount({ query: '', eventId: '  ', eventType: undefined })).toBe(true);
+	});
+
+	it('omits N when the filter is live-only', () => {
+		expect(rollupCanServeDisplayCount({ query: 'invoice.paid' })).toBe(false);
+		expect(rollupCanServeDisplayCount({ eventId: '01M0A9MCES4EG2W1JGR41VFXJQ' })).toBe(false);
+		expect(rollupCanServeDisplayCount({ eventType: 'invoice.paid' })).toBe(false);
 	});
 });

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-deliveries/event-deliveries.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-deliveries/event-deliveries.component.ts
@@ -55,6 +55,7 @@ export class EventDeliveriesComponent implements OnInit, OnDestroy {
 	// cursor-based so the absolute position is derived from prev/next navigation.
 	currentPage = 1;
 	totalCount?: number;
+	private totalCountFetchId = 0;
 	selectedDeliveries = new Set<string>();
 	batchRetryParams?: FILTER_QUERY_PARAM;
 	batchRetryDate = '';
@@ -286,13 +287,21 @@ export class EventDeliveriesComponent implements OnInit, OnDestroy {
 
 	async refreshTotalCount() {
 		const countParams = this.queryParamsForCount(this.queryParams);
+		const fetchId = ++this.totalCountFetchId;
 
-		try {
-			const response = await this.eventsService.getRetryCount(countParams);
-			this.totalCount = response.data.num;
-		} catch (error) {
-			this.totalCount = undefined;
+		if (!rollupCanServeDisplayCount(countParams)) {
+			if (fetchId === this.totalCountFetchId) this.totalCount = undefined;
+			return;
 		}
+
+		const totals = await this.eventsService.getStatusTotals({
+			startDate: countParams.startDate,
+			endDate: countParams.endDate,
+			endpointId: countParams.endpointId
+		});
+
+		if (fetchId !== this.totalCountFetchId) return;
+		this.totalCount = totals ? sumRollupDisplayCount(totals, this.statusFilter) : undefined;
 	}
 
 	async getEventTypesForFilter() {
@@ -452,4 +461,16 @@ export class EventDeliveriesComponent implements OnInit, OnDestroy {
 		const { next_page_cursor: _next, prev_page_cursor: _prev, direction: _direction, sort: _sort, showLoader: _showLoader, ...filters } = params || {};
 		return filters;
 	}
+}
+
+// Rollup is date + optional endpoint. Search, event id, and event type are
+// live-only filters, so the table omits N rather than showing a wrong total.
+export function rollupCanServeDisplayCount(params: { query?: string; eventId?: string; eventType?: string }): boolean {
+	const present = (value?: string) => typeof value === 'string' && value.trim().length > 0;
+	return !present(params.query) && !present(params.eventId) && !present(params.eventType);
+}
+
+export function sumRollupDisplayCount(totals: Record<string, number>, statuses: string[]): number {
+	const keys = statuses.length > 0 ? statuses : Object.keys(totals);
+	return keys.reduce((n, key) => n + (Number(totals[key]) || 0), 0);
 }

--- a/web/ui/dashboard/src/app/private/pages/project/events/events.service.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/events.service.ts
@@ -118,6 +118,7 @@ export class EventsService {
 		});
 	}
 
+	// Exact live count for Retry All. Do not use this for the table label.
 	getRetryCount(requestDetails: { endpointId?: string; eventId?: string; startDate?: string; endDate?: string; status?: any }): Promise<HTTP_RESPONSE> {
 		return new Promise(async (resolve, reject) => {
 			try {
@@ -135,27 +136,33 @@ export class EventsService {
 		});
 	}
 
-	// Success/failure totals for the summary cards, served from the daily rollup
-	// rather than the batch retry count endpoint's live scan of event_deliveries.
+	// Per-status totals from /eventdeliveries/statustotals (daily rollup once
+	// backfill has completed). Display-only: hideNotification, and null on
+	// transport/timeout so a failed read cannot render as zero.
 	//
-	// null means the total could not be determined. A status missing from a
-	// successful response had no deliveries in the window and is a real 0, but a
-	// failed request must not render as "no successful deliveries", so the caller
-	// shows a dash. Shared by the project and portal delivery screens, which
-	// display the same cards.
-	async getSummaryDeliveryCounts(requestDetails: { startDate?: string; endDate?: string; endpointId?: string }): Promise<{ success: number | null; failure: number | null }> {
+	// Do not use this for Retry All. That path must stay on getRetryCount.
+	async getStatusTotals(requestDetails: { startDate?: string; endDate?: string; endpointId?: string }): Promise<Record<string, number> | null> {
 		try {
 			const response = await this.http.request({
 				url: `/eventdeliveries/statustotals`,
 				method: 'get',
 				level: 'org_project',
-				query: requestDetails
+				query: requestDetails,
+				hideNotification: true
 			});
 
-			const totals = response?.data?.totals || {};
-			return { success: totals['Success'] ?? 0, failure: totals['Failure'] ?? 0 };
+			return response?.data?.totals || {};
 		} catch (error) {
-			return { success: null, failure: null };
+			return null;
 		}
+	}
+
+	// Success/failure totals for the summary cards. Shared by the project and
+	// portal delivery screens. A missing status on a successful response is 0;
+	// a failed request is null so the caller shows a dash.
+	async getSummaryDeliveryCounts(requestDetails: { startDate?: string; endDate?: string; endpointId?: string }): Promise<{ success: number | null; failure: number | null }> {
+		const totals = await this.getStatusTotals(requestDetails);
+		if (!totals) return { success: null, failure: null };
+		return { success: totals['Success'] ?? 0, failure: totals['Failure'] ?? 0 };
 	}
 }


### PR DESCRIPTION
## Summary
- Delivery Table "N events" / "21–40 of N" now sums `/eventdeliveries/statustotals` (daily rollup) for date, endpoint, and status filters.
- Omits N when the filter is search, event id, or event type, which the rollup cannot honor.
- Retry All still uses the live `countbatchretryevents` count. The batch-retry worker is unchanged.

## Test plan
- [ ] Default 30-day Event Deliveries load: label appears, no timeout toast, page 2 still lists rows
- [ ] Status filter: label matches the selected statuses
- [ ] Endpoint filter: label scopes to that endpoint
- [ ] Search / event type: label omitted
- [ ] Retry All on a date group: confirmation count is live and exact
- [ ] Summary Success/Failure cards still load (shared `getStatusTotals`)