### PR TITLE
fix(dataplane): skip-scan observed delivery types

### DIFF
--- a/internal/event_deliveries/filter_event_types.go
+++ b/internal/event_deliveries/filter_event_types.go
@@ -85,28 +85,35 @@ func eventMetadataTypeExistsSQL(arg string) string {
 	return `EXISTS (SELECT 1 FROM convoy.events ev WHERE ev.id = ed.event_id AND ev.project_id = ed.project_id AND ev.event_type ` + arg + `)`
 }
 
-func observedEventTypesSQL(projectID string, start, end time.Time, endpointIDs []string) (string, []any) {
+func observedEventTypeSeekSQL(endpointIDs []string) (string, []any) {
 	var b strings.Builder
-	args := make([]any, 0, 5)
-	b.WriteString(`SELECT DISTINCT ev.event_type FROM convoy.event_deliveries ed INNER JOIN convoy.events ev ON ev.id = ed.event_id AND ev.project_id = ed.project_id WHERE ed.deleted_at IS NULL`)
-	args = append(args, projectID)
-	fmt.Fprintf(&b, ` AND ed.project_id = $%d`, len(args))
-	args = append(args, start)
-	fmt.Fprintf(&b, ` AND ed.created_at >= $%d`, len(args))
-	args = append(args, end)
-	fmt.Fprintf(&b, ` AND ed.created_at <= $%d`, len(args))
-	b.WriteString(` AND ev.event_type <> '' AND ev.event_type <> '*'`)
+	b.WriteString(`ed.deleted_at IS NULL AND ed.project_id = $1 AND ed.created_at >= $2 AND ed.created_at <= $3 AND ed.event_type <> '' AND ed.event_type <> '*'`)
+	var extra []any
 	if len(endpointIDs) > 0 {
-		args = append(args, endpointIDs)
-		fmt.Fprintf(&b, ` AND ed.endpoint_id = ANY($%d::TEXT[])`, len(args))
+		extra = append(extra, endpointIDs)
+		b.WriteString(` AND ed.endpoint_id = ANY($4::TEXT[])`)
 	}
-	fmt.Fprintf(&b, ` ORDER BY ev.event_type LIMIT %d`, FilterEventTypeLimit)
-	return b.String(), args
+	return b.String(), extra
 }
 
-// ObservedEventTypes returns distinct live event types in the date window,
-// using the same COALESCE as the list table. Empty and "*" are excluded.
-// When endpointIDs is set the predicate is a real ANY, not a CASE flag.
+func observedEventTypesSQL(projectID string, start, end time.Time, endpointIDs []string) (string, []any) {
+	where, extra := observedEventTypeSeekSQL(endpointIDs)
+	args := append([]any{projectID, start, end}, extra...)
+	query := `WITH RECURSIVE types AS (` +
+		`(SELECT ed.event_type FROM convoy.event_deliveries ed WHERE ` + where + ` ORDER BY ed.event_type LIMIT 1)` +
+		` UNION ALL ` +
+		`SELECT nxt.event_type FROM types CROSS JOIN LATERAL (` +
+		`SELECT ed.event_type FROM convoy.event_deliveries ed WHERE ` + where + ` AND ed.event_type > types.event_type ORDER BY ed.event_type LIMIT 1` +
+		`) nxt WHERE types.event_type IS NOT NULL` +
+		`) SELECT event_type FROM types WHERE event_type IS NOT NULL LIMIT ` + fmt.Sprint(FilterEventTypeLimit)
+	return query, args
+}
+
+// ObservedEventTypes returns distinct live delivery event types in the date
+// window. Empty and "*" are excluded. Types are walked one name at a time so
+// the scan follows distinct types, not every row in the window. Blank
+// event_deliveries.event_type rows are omitted. When endpointIDs is set the
+// predicate is a real ANY, not a CASE flag.
 func (s *Service) ObservedEventTypes(ctx context.Context, projectID string, params datastore.SearchParams, endpointIDs []string) ([]string, error) {
 	start, end := getCreatedDateFilter(params.CreatedAtStart, params.CreatedAtEnd)
 	query, args := observedEventTypesSQL(projectID, start, end, endpointIDs)

--- a/internal/event_deliveries/filter_event_types_test.go
+++ b/internal/event_deliveries/filter_event_types_test.go
@@ -1,6 +1,7 @@
 package event_deliveries
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -61,8 +62,10 @@ func TestObservedEventTypesSQLOmitsEndpointPredicateWhenUnscoped(t *testing.T) {
 	sql, args := observedEventTypesSQL("proj_1", time.Unix(1, 0), time.Unix(2, 0), nil)
 	require.NotContains(t, sql, "CASE")
 	require.NotContains(t, sql, "endpoint_id")
-	require.Contains(t, sql, "INNER JOIN convoy.events ev")
-	require.Contains(t, sql, "SELECT DISTINCT ev.event_type")
+	require.NotContains(t, sql, "INNER JOIN convoy.events")
+	require.NotContains(t, sql, "SELECT DISTINCT")
+	require.Contains(t, sql, "WITH RECURSIVE types AS")
+	require.Contains(t, sql, "ed.event_type > types.event_type")
 	require.Contains(t, sql, "LIMIT 200")
 	require.Equal(t, []any{"proj_1", time.Unix(1, 0), time.Unix(2, 0)}, args)
 }
@@ -72,4 +75,5 @@ func TestObservedEventTypesSQLUsesRealEndpointAny(t *testing.T) {
 	require.NotContains(t, sql, "CASE")
 	require.Contains(t, sql, "ed.endpoint_id = ANY($4::TEXT[])")
 	require.Equal(t, []string{"ep_1"}, args[3])
+	require.Equal(t, 2, strings.Count(sql, "ed.endpoint_id = ANY($4::TEXT[])"))
 }

--- a/internal/event_deliveries/impl_test.go
+++ b/internal/event_deliveries/impl_test.go
@@ -2415,20 +2415,20 @@ func TestObservedEventTypes(t *testing.T) {
 	eventOld := seedEventNamed(t, db, project.UID, ep1.UID, src.UID, "old.event")
 	otherEvent := seedEventNamed(t, db, other.UID, otherEp.UID, otherSrc.UID, "webhook.received")
 
-	createFor := func(projectID, eventID, endpointID, subID string) *datastore.EventDelivery {
+	createFor := func(projectID, eventID, endpointID, subID string, eventType datastore.EventType) *datastore.EventDelivery {
 		t.Helper()
 		d := createTestEventDelivery(t, projectID, eventID, endpointID, subID)
-		d.EventType = ""
+		d.EventType = eventType
 		require.NoError(t, service.CreateEventDelivery(ctx, d))
 		return d
 	}
 
-	createFor(project.UID, eventPaid.UID, ep1.UID, sub1.UID)
-	createFor(project.UID, eventPaid.UID, ep1.UID, sub1.UID)
-	createFor(project.UID, eventStar.UID, ep1.UID, sub1.UID)
-	createFor(project.UID, eventOrder.UID, ep2.UID, sub2.UID)
-	old := createFor(project.UID, eventOld.UID, ep1.UID, sub1.UID)
-	createFor(other.UID, otherEvent.UID, otherEp.UID, otherSub.UID)
+	createFor(project.UID, eventPaid.UID, ep1.UID, sub1.UID, eventPaid.EventType)
+	createFor(project.UID, eventPaid.UID, ep1.UID, sub1.UID, eventPaid.EventType)
+	createFor(project.UID, eventStar.UID, ep1.UID, sub1.UID, eventStar.EventType)
+	createFor(project.UID, eventOrder.UID, ep2.UID, sub2.UID, eventOrder.EventType)
+	old := createFor(project.UID, eventOld.UID, ep1.UID, sub1.UID, eventOld.EventType)
+	createFor(other.UID, otherEvent.UID, otherEp.UID, otherSub.UID, otherEvent.EventType)
 
 	_, err := db.GetConn().Exec(ctx,
 		"UPDATE convoy.event_deliveries SET created_at=$1, updated_at=$1 WHERE id=$2",
@@ -2451,7 +2451,49 @@ func TestObservedEventTypes(t *testing.T) {
 	require.Equal(t, []string{"order.created"}, observed)
 }
 
-func TestObservedEventTypesReadsEventMetadataWhenDeliveryTypeBlank(t *testing.T) {
+func TestObservedEventTypesReadsDeliveryEventType(t *testing.T) {
+	service, db := setupTestDB(t)
+	ctx := context.Background()
+
+	project := seedTestProject(t, db)
+	ep := seedTestEndpoint(t, db, project.UID)
+	src := seedTestSource(t, db, project.UID)
+	sub := seedSubscription(t, db, project.UID, ep.UID, src.UID)
+	event := seedEventNamed(t, db, project.UID, ep.UID, src.UID, "bench.event")
+
+	d := createTestEventDelivery(t, project.UID, event.UID, ep.UID, sub.UID)
+	d.EventType = event.EventType
+	require.NoError(t, service.CreateEventDelivery(ctx, d))
+
+	pageable := datastore.Pageable{PerPage: 10, Direction: datastore.Next, Sort: "DESC"}
+	listed, _, err := service.LoadEventDeliveriesPaged(
+		ctx, project.UID, nil, "", "", nil, defaultSearchParams(), pageable, "", "", "",
+	)
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	require.Equal(t, "bench.event", string(listed[0].EventType))
+
+	observed, err := service.ObservedEventTypes(ctx, project.UID, defaultSearchParams(), nil)
+	require.NoError(t, err)
+	require.Equal(t, []string{"bench.event"}, observed)
+
+	observedAgain, err := service.ObservedEventTypes(ctx, project.UID, defaultSearchParams(), nil)
+	require.NoError(t, err)
+	require.Equal(t, observed, observedAgain)
+
+	filtered, _, err := service.LoadEventDeliveriesPaged(
+		ctx, project.UID, nil, "", "", nil, defaultSearchParams(), pageable, "", "bench.event", "",
+	)
+	require.NoError(t, err)
+	require.Len(t, filtered, 1)
+	require.Equal(t, d.UID, filtered[0].UID)
+
+	catalog, grouped := GroupFilterEventTypes(nil, observed)
+	require.Empty(t, catalog)
+	require.Equal(t, []string{"bench.event"}, grouped)
+}
+
+func TestObservedEventTypesSkipsBlankDeliveryType(t *testing.T) {
 	service, db := setupTestDB(t)
 	ctx := context.Background()
 
@@ -2477,11 +2519,7 @@ func TestObservedEventTypesReadsEventMetadataWhenDeliveryTypeBlank(t *testing.T)
 
 	observed, err := service.ObservedEventTypes(ctx, project.UID, defaultSearchParams(), nil)
 	require.NoError(t, err)
-	require.Equal(t, []string{"bench.event"}, observed)
-
-	observedAgain, err := service.ObservedEventTypes(ctx, project.UID, defaultSearchParams(), nil)
-	require.NoError(t, err)
-	require.Equal(t, observed, observedAgain)
+	require.Empty(t, observed)
 
 	filtered, _, err := service.LoadEventDeliveriesPaged(
 		ctx, project.UID, nil, "", "", nil, defaultSearchParams(), pageable, "", "bench.event", "",
@@ -2489,8 +2527,4 @@ func TestObservedEventTypesReadsEventMetadataWhenDeliveryTypeBlank(t *testing.T)
 	require.NoError(t, err)
 	require.Len(t, filtered, 1)
 	require.Equal(t, d.UID, filtered[0].UID)
-
-	catalog, grouped := GroupFilterEventTypes(nil, observed)
-	require.Empty(t, catalog)
-	require.Equal(t, []string{"bench.event"}, grouped)
 }

--- a/internal/pkg/indexes/indexes.go
+++ b/internal/pkg/indexes/indexes.go
@@ -85,9 +85,17 @@ const EventDeliveriesProjectCreated = "idx_event_deliveries_project_created_id_d
 // It has to match the row sql/1787251200.sql inserts.
 const EventDeliveriesProjectCreatedDefinition = `CREATE INDEX idx_event_deliveries_project_created_id_deleted ON convoy.event_deliveries USING btree (project_id, created_at DESC, id DESC) WHERE (deleted_at IS NULL)`
 
+// EventDeliveriesProjectEventTypeCreated is the Observed event-type dropdown index.
+// sql/1787702400.sql inserts this name into dropped_indexes instead of CREATE INDEX at migrate.
+const EventDeliveriesProjectEventTypeCreated = "idx_event_deliveries_project_event_type_created"
+
+// EventDeliveriesProjectEventTypeCreatedDefinition is the statement the rebuild must execute.
+// It has to match the row sql/1787702400.sql inserts.
+const EventDeliveriesProjectEventTypeCreatedDefinition = `CREATE INDEX idx_event_deliveries_project_event_type_created ON convoy.event_deliveries USING btree (project_id, event_type, created_at) WHERE (deleted_at IS NULL)`
+
 // BootQueuedNames are the indexes migrate always inserts into dropped_indexes
 // instead of CREATE INDEX, so every upgraded instance owes them a rebuild.
-var BootQueuedNames = []string{EventDeliveriesProjectCreated, PayloadGIN}
+var BootQueuedNames = []string{EventDeliveriesProjectCreated, EventDeliveriesProjectEventTypeCreated, PayloadGIN}
 
 // BootQueued reports whether migrate always queues this name. Repair tests use
 // it to look past those rows when counting operator-dropped indexes.
@@ -196,8 +204,9 @@ func ListInvalid(ctx context.Context, db *pgxpool.Pool) ([]Invalid, error) {
 // unique index is not just slower, it is not enforcing its key, and hours spent
 // on a large non-unique index first leaves that gap open for those hours. Among
 // non-unique indexes the Event Deliveries list index is next: that query times
-// out until it is valid, and dropped_at alone would put the hours-long payload
-// GIN first because migrate queued GIN earlier.
+// out until it is valid. The Observed-types index follows it: the same page
+// 504s the type dropdown until that btree is valid. dropped_at alone would put
+// the hours-long payload GIN first because migrate queued GIN earlier.
 //
 // This is the only place the order is decided, so the list an operator reads and
 // the list --rebuild works through cannot disagree.
@@ -209,6 +218,7 @@ func ListDropped(ctx context.Context, db *pgxpool.Pool) ([]Dropped, error) {
          ORDER BY (index_name = 'idx_partition_runs_single_active') DESC,
                   (definition LIKE 'CREATE UNIQUE %') DESC,
                   (index_name = '`+EventDeliveriesProjectCreated+`') DESC,
+                  (index_name = '`+EventDeliveriesProjectEventTypeCreated+`') DESC,
                   dropped_at`)
 	if err != nil {
 		return nil, fmt.Errorf("reading dropped indexes: %w", err)

--- a/internal/pkg/indexes/indexes_test.go
+++ b/internal/pkg/indexes/indexes_test.go
@@ -159,6 +159,26 @@ func TestEventDeliveriesProjectCreatedDefinitionMatchesMigration(t *testing.T) {
 	require.NotRegexp(t, `(?m)^CREATE INDEX`, string(body))
 }
 
+func TestEventDeliveriesProjectEventTypeCreatedDefinitionIsRebuildable(t *testing.T) {
+	stmt, err := concurrently(EventDeliveriesProjectEventTypeCreatedDefinition)
+	require.NoError(t, err)
+	require.Equal(t, `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_event_deliveries_project_event_type_created `+
+		`ON convoy.event_deliveries USING btree (project_id, event_type, created_at) `+
+		`WHERE (deleted_at IS NULL)`, stmt)
+
+	parent, err := parentStatement(EventDeliveriesProjectEventTypeCreated, "event_deliveries", EventDeliveriesProjectEventTypeCreatedDefinition)
+	require.NoError(t, err)
+	require.Contains(t, parent, " ON ONLY ")
+	require.NotContains(t, parent, "CONCURRENTLY")
+}
+
+func TestEventDeliveriesProjectEventTypeCreatedDefinitionMatchesMigration(t *testing.T) {
+	body, err := os.ReadFile("../../../sql/1787702400.sql")
+	require.NoError(t, err)
+	require.Contains(t, string(body), EventDeliveriesProjectEventTypeCreatedDefinition)
+	require.NotRegexp(t, `(?m)^CREATE INDEX`, string(body))
+}
+
 func TestEventPayloadJsonbIsParallelUnsafe(t *testing.T) {
 	for _, name := range []string{"../../../sql/1787200000.sql", "../../../sql/1787200002.sql"} {
 		body, err := os.ReadFile(name)

--- a/internal/pkg/indexes/repair_test.go
+++ b/internal/pkg/indexes/repair_test.go
@@ -481,18 +481,22 @@ func TestDroppedIndexesOfferTheDeliveriesListIndexAheadOfOlderNonUniqueIndexes(t
 	owed, err := ListDropped(ctx, db)
 	require.NoError(t, err)
 
-	listPos, ginPos := -1, -1
+	listPos, observedPos, ginPos := -1, -1, -1
 	for i, d := range owed {
 		switch d.Name {
 		case EventDeliveriesProjectCreated:
 			listPos = i
+		case EventDeliveriesProjectEventTypeCreated:
+			observedPos = i
 		case PayloadGIN:
 			ginPos = i
 		}
 	}
 	require.GreaterOrEqual(t, listPos, 0, "migrate queues the deliveries list index")
+	require.GreaterOrEqual(t, observedPos, 0, "migrate queues the observed-types index")
 	require.GreaterOrEqual(t, ginPos, 0, "migrate queues the payload GIN")
-	require.Less(t, listPos, ginPos)
+	require.Less(t, listPos, observedPos)
+	require.Less(t, observedPos, ginPos)
 }
 
 // A concurrent build cannot run in a transaction, so the rebuild's lock_timeout
@@ -782,9 +786,9 @@ func names(invalid []Invalid) []string {
 	return out
 }
 
-// sql/1787200001.sql and sql/1787251200.sql always queue these names on
-// every migrated test DB. Repair assertions that count other dropped
-// indexes have to look past those rows.
+// sql/1787200001.sql, sql/1787251200.sql, and sql/1787702400.sql always
+// queue these names on every migrated test DB. Repair assertions that
+// count other dropped indexes have to look past those rows.
 func exceptPayloadGIN(owed []Dropped) []Dropped {
 	out := make([]Dropped, 0, len(owed))
 	for _, d := range owed {

--- a/internal/pkg/partitions/partitions.go
+++ b/internal/pkg/partitions/partitions.go
@@ -221,7 +221,8 @@ type rebuilder interface {
 	// which table it is on so the run row names that table.
 	dropped(ctx context.Context, name string) (indexes.Dropped, error)
 	// listDropped is the owed rebuilds in ListDropped order: guard, unique,
-	// deliveries list index, then the rest by when they were dropped.
+	// deliveries list index, observed-types index, then the rest by when they
+	// were dropped.
 	listDropped(ctx context.Context) ([]indexes.Dropped, error)
 	rebuild(ctx context.Context, d indexes.Dropped) error
 }
@@ -319,7 +320,8 @@ func (s *Service) RunIndexRebuild(ctx context.Context, indexName, triggeredBy st
 const bootTriggeredBy = "boot"
 
 // StartQueuedDroppedIndexes starts the concurrent rebuild of every index still
-// owed, in ListDropped order (guard, unique, deliveries list, then the rest).
+// owed, in ListDropped order (guard, unique, deliveries list, observed types,
+// then the rest).
 // Failure policy: fail open. Queries seq-scan until an index is valid; ingest
 // and HTTP must not wait on the build. A replica that finds the slot taken, or
 // a name that is already rebuilt, is success. Any other error is logged and
@@ -699,6 +701,8 @@ func bootIndexLogName(name string) string {
 		return "payload search index rebuild"
 	case indexes.EventDeliveriesProjectCreated:
 		return "event deliveries list index rebuild"
+	case indexes.EventDeliveriesProjectEventTypeCreated:
+		return "event deliveries observed-types index rebuild"
 	default:
 		return "index rebuild"
 	}

--- a/internal/pkg/partitions/partitions_test.go
+++ b/internal/pkg/partitions/partitions_test.go
@@ -430,13 +430,15 @@ func TestBootRebuildStartsEveryOwedIndexWhenTheSlotFrees(t *testing.T) {
 	db, ctx := setupTestDB(t)
 	usage := newBlockingRebuilder("event_deliveries", "idx_event_deliveries_usage")
 	deliveries := newBlockingRebuilder("event_deliveries", indexes.EventDeliveriesProjectCreated)
+	observed := newBlockingRebuilder("event_deliveries", indexes.EventDeliveriesProjectEventTypeCreated)
 	gin := newBlockingRebuilder("events", indexes.PayloadGIN)
 	s := newRebuildService(t, db, &multiRebuilder{
-		order: []string{"idx_event_deliveries_usage", indexes.EventDeliveriesProjectCreated, indexes.PayloadGIN},
+		order: []string{"idx_event_deliveries_usage", indexes.EventDeliveriesProjectCreated, indexes.EventDeliveriesProjectEventTypeCreated, indexes.PayloadGIN},
 		byName: map[string]*blockingRebuilder{
-			"idx_event_deliveries_usage":          usage,
-			indexes.EventDeliveriesProjectCreated: deliveries,
-			indexes.PayloadGIN:                    gin,
+			"idx_event_deliveries_usage":                   usage,
+			indexes.EventDeliveriesProjectCreated:          deliveries,
+			indexes.EventDeliveriesProjectEventTypeCreated: observed,
+			indexes.PayloadGIN:                             gin,
 		},
 	})
 
@@ -445,6 +447,8 @@ func TestBootRebuildStartsEveryOwedIndexWhenTheSlotFrees(t *testing.T) {
 	select {
 	case <-deliveries.started:
 		t.Fatal("list index started while the usage rebuild held the slot")
+	case <-observed.started:
+		t.Fatal("observed-types index started while the usage rebuild held the slot")
 	case <-gin.started:
 		t.Fatal("payload GIN started while the usage rebuild held the slot")
 	default:
@@ -453,19 +457,29 @@ func TestBootRebuildStartsEveryOwedIndexWhenTheSlotFrees(t *testing.T) {
 	close(usage.release)
 	<-deliveries.started
 	select {
+	case <-observed.started:
+		t.Fatal("observed-types index started while the list index rebuild held the slot")
 	case <-gin.started:
 		t.Fatal("payload GIN started while the list index rebuild held the slot")
 	default:
 	}
 
 	close(deliveries.release)
+	<-observed.started
+	select {
+	case <-gin.started:
+		t.Fatal("payload GIN started while the observed-types rebuild held the slot")
+	default:
+	}
+
+	close(observed.release)
 	<-gin.started
 	close(gin.release)
 
 	runs, err := s.List(ctx, 10)
 	require.NoError(t, err)
-	require.Len(t, runs, 3)
-	names := make(map[string]string, 3)
+	require.Len(t, runs, 4)
+	names := make(map[string]string, 4)
 	for _, run := range runs {
 		require.NotNil(t, run.IndexName)
 		waitForStatus(t, s, ctx, run.UID, StatusCompleted)
@@ -473,6 +487,7 @@ func TestBootRebuildStartsEveryOwedIndexWhenTheSlotFrees(t *testing.T) {
 	}
 	require.Equal(t, bootTriggeredBy, names["idx_event_deliveries_usage"])
 	require.Equal(t, bootTriggeredBy, names[indexes.EventDeliveriesProjectCreated])
+	require.Equal(t, bootTriggeredBy, names[indexes.EventDeliveriesProjectEventTypeCreated])
 	require.Equal(t, bootTriggeredBy, names[indexes.PayloadGIN])
 }
 

--- a/sql/1787702400.sql
+++ b/sql/1787702400.sql
@@ -1,0 +1,31 @@
+-- +migrate Up
+SET lock_timeout = '2s';
+SET statement_timeout = '30s';
+
+-- Queue the Event Deliveries Observed-types index instead of CREATE INDEX.
+-- DISTINCT over the date window scans every live delivery in range and 504s
+-- the 5s list budget on large projects. A (project_id, event_type, created_at)
+-- btree lets Observed walk one type at a time. CONCURRENTLY is illegal on a
+-- partitioned parent, and a blocking build takes a write lock for the full
+-- scan. After migrate, convoy server and convoy agent start this rebuild at
+-- boot, after the list/chart index.
+INSERT INTO convoy.dropped_indexes (index_name, table_name, definition)
+VALUES (
+    'idx_event_deliveries_project_event_type_created',
+    'event_deliveries',
+    'CREATE INDEX idx_event_deliveries_project_event_type_created ON convoy.event_deliveries USING btree (project_id, event_type, created_at) WHERE (deleted_at IS NULL)'
+)
+ON CONFLICT (index_name) DO NOTHING;
+
+RESET lock_timeout;
+RESET statement_timeout;
+
+-- +migrate Down
+SET lock_timeout = '2s';
+SET statement_timeout = '30s';
+
+DELETE FROM convoy.dropped_indexes WHERE index_name = 'idx_event_deliveries_project_event_type_created';
+DROP INDEX IF EXISTS convoy.idx_event_deliveries_project_event_type_created;
+
+RESET lock_timeout;
+RESET statement_timeout;


### PR DESCRIPTION
## Summary
- Observed type dropdown walks distinct `event_deliveries.event_type` values one name at a time instead of `DISTINCT` over the date window.
- Queue `idx_event_deliveries_project_event_type_created` `(project_id, event_type, created_at)` via `dropped_indexes`. Migrate does not `CREATE INDEX`.
- Exact type list filter still joins `events`. Blank delivery types stay out of Observed until a later backfill.

Until the index rebuilds after deploy, large windows can still 504 inside the existing 5s search timeout.

## Test plan
- [ ] `go test ./internal/event_deliveries -count=1 -run 'TestObservedEventTypes|TestListFilterEventType|TestGroupFilter'`
- [ ] `go test ./internal/pkg/indexes -count=1`
- [ ] `go test ./internal/pkg/partitions -count=1 -run 'TestBootRebuildStartsEveryOwedIndexWhenTheSlotFrees'`
- [ ] `go test ./api -count=1 -run 'TestEventIntegrationTestSuite/Test_EventDeliveryFilterEventTypes_ObservedFromEventMetadata'`
- [ ] After deploy, wait for the observed-types index rebuild, then confirm the Event Deliveries type dropdown on a large project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches a hot dashboard query and queues a new btree rebuild on partitioned `event_deliveries`. Until the index is valid, large projects can still time out; Observed also no longer falls back to event metadata for blank delivery types.
> 
> **Overview**
> Stops the Event Deliveries type dropdown from `DISTINCT`-scanning every live row in the date window. `ObservedEventTypes` now skip-scans `event_deliveries.event_type` one name at a time (recursive seek, no join to `events`). Blank and `"*"` delivery types stay out of Observed; exact list filtering still uses event metadata.
> 
> Queues `idx_event_deliveries_project_event_type_created` `(project_id, event_type, created_at)` via `dropped_indexes` instead of `CREATE INDEX` at migrate. Boot rebuilds it after the list/chart index and before the payload GIN. Until that rebuild finishes, large windows can still 504 inside the existing 5s timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9db01b72519aa5bd8f63d2d25bfec01c5e7df7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->