### PR TITLE
fix(dashboard): put configurations first in admin sidebar

### DIFF
--- a/web/ui/dashboard/src/app/private/pages/admin/admin.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/admin.component.ts
@@ -10,13 +10,13 @@ export type ADMIN_PAGE = 'configurations' | 'feature flags' | 'circuit breaker c
     standalone: false
 })
 export class AdminComponent implements OnInit {
-	activePage: ADMIN_PAGE = 'feature flags';
+	activePage: ADMIN_PAGE = 'configurations';
 	adminMenu: { name: ADMIN_PAGE; icon: string; svg: 'stroke' | 'fill' }[] = [
+		{ name: 'configurations', icon: 'settings', svg: 'fill' },
 		{ name: 'feature flags', icon: 'settings', svg: 'fill' },
 		{ name: 'circuit breaker config', icon: 'shield', svg: 'fill' },
 		{ name: 'resend events', icon: 'retry', svg: 'fill' },
 		{ name: 'queue monitoring', icon: 'logs', svg: 'stroke' },
-		{ name: 'configurations', icon: 'settings', svg: 'fill' },
 		{ name: 'table partitions', icon: 'table-grid', svg: 'fill' },
 		{ name: 'table indexes', icon: 'key', svg: 'fill' }
 	];
@@ -38,7 +38,7 @@ export class AdminComponent implements OnInit {
 
 	ngOnInit() {
 		// Set active page from URL query parameter
-		const requestedPage = this.route.snapshot.queryParams?.activePage ?? 'feature flags';
+		const requestedPage = this.route.snapshot.queryParams?.activePage ?? 'configurations';
 		this.toggleActivePage(requestedPage);
 	}
 
@@ -46,7 +46,7 @@ export class AdminComponent implements OnInit {
 	// page added above cannot be one an ?activePage link silently falls back from.
 	toggleActivePage(page: string) {
 		const known = this.adminMenu.some(menu => menu.name === page);
-		this.activePage = known ? (page as ADMIN_PAGE) : 'feature flags';
+		this.activePage = known ? (page as ADMIN_PAGE) : 'configurations';
 		this.addPageToUrl();
 	}
 


### PR DESCRIPTION
## Summary
- Move **Configurations** to the top of the Admin sidebar.
- Default `/admin` (and unknown `activePage` fallback) to Configurations instead of Feature Flags.

## Test plan
- [ ] Open `/admin` with no query param → Configurations selected first in the sidebar
- [ ] Sidebar order: configurations, feature flags, circuit breaker config, …
- [ ] Deep link `?activePage=feature flags` still opens Feature Flags
- [ ] Invalid `activePage` falls back to Configurations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only default tab and menu ordering in the admin dashboard; no auth, API, or data-path changes.
> 
> **Overview**
> **Admin** now opens on **Configurations** instead of Feature Flags, and the sidebar lists Configurations first.
> 
> The default `activePage`, the `?activePage` default when the query param is missing, and the fallback for unknown tab names all switch from `feature flags` to `configurations`. Valid deep links (e.g. `?activePage=feature flags`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1af324dfc6796e1c836c51653070ef491a5d13ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->