### PR TITLE
fix(dashboard): warn on unsaved admin configuration changes

### DIFF
--- a/web/ui/dashboard/src/app/private/pages/admin/admin.component.html
+++ b/web/ui/dashboard/src/app/private/pages/admin/admin.component.html
@@ -3,7 +3,7 @@
 <div class="mt-24px mx-auto w-full max-w-[1000px] pb-60px desktop:px-24px">
   <!-- Page header -->
   <div class="flex items-center gap-12px">
-    <a routerLink="/projects" (click)="leaveAdmin($event)" class="w-28px h-28px flex items-center justify-center rounded-[6px] border border-new.border bg-white-100 transition-colors hover:bg-new.surface-muted">
+    <a href="/projects" (click)="leaveAdmin($event)" class="w-28px h-28px flex items-center justify-center rounded-[6px] border border-new.border bg-white-100 transition-colors hover:bg-new.surface-muted">
       <svg width="20" height="20" class="fill-new.text-secondary scale-75">
         <use xlink:href="#arrow-left-icon"></use>
       </svg>

--- a/web/ui/dashboard/src/app/private/pages/admin/admin.component.html
+++ b/web/ui/dashboard/src/app/private/pages/admin/admin.component.html
@@ -3,7 +3,7 @@
 <div class="mt-24px mx-auto w-full max-w-[1000px] pb-60px desktop:px-24px">
   <!-- Page header -->
   <div class="flex items-center gap-12px">
-    <a href="/projects" (click)="leaveAdmin($event)" class="w-28px h-28px flex items-center justify-center rounded-[6px] border border-new.border bg-white-100 transition-colors hover:bg-new.surface-muted">
+    <a [attr.href]="projectsHref" (click)="leaveAdmin($event)" class="w-28px h-28px flex items-center justify-center rounded-[6px] border border-new.border bg-white-100 transition-colors hover:bg-new.surface-muted">
       <svg width="20" height="20" class="fill-new.text-secondary scale-75">
         <use xlink:href="#arrow-left-icon"></use>
       </svg>

--- a/web/ui/dashboard/src/app/private/pages/admin/admin.component.html
+++ b/web/ui/dashboard/src/app/private/pages/admin/admin.component.html
@@ -3,7 +3,7 @@
 <div class="mt-24px mx-auto w-full max-w-[1000px] pb-60px desktop:px-24px">
   <!-- Page header -->
   <div class="flex items-center gap-12px">
-    <a routerLink="/projects" class="w-28px h-28px flex items-center justify-center rounded-[6px] border border-new.border bg-white-100 transition-colors hover:bg-new.surface-muted">
+    <a routerLink="/projects" (click)="leaveAdmin($event)" class="w-28px h-28px flex items-center justify-center rounded-[6px] border border-new.border bg-white-100 transition-colors hover:bg-new.surface-muted">
       <svg width="20" height="20" class="fill-new.text-secondary scale-75">
         <use xlink:href="#arrow-left-icon"></use>
       </svg>

--- a/web/ui/dashboard/src/app/private/pages/admin/admin.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/admin.component.ts
@@ -68,15 +68,16 @@ export class AdminComponent implements OnInit {
 	}
 
 	leaveAdmin(event: MouseEvent) {
-		if (!this.confirmLeaveConfigurations(null)) {
-			event.preventDefault();
-			event.stopPropagation();
-			return;
-		}
+		// Modifier / middle-click only opens another tab; this form stays dirty.
+		// Confirming first would block native navigation for a leave that never happens.
 		const modified =
 			event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0;
 		if (modified) {
-			// Allow the browser to follow projectsHref (includes RootPath / base href).
+			return;
+		}
+		if (!this.confirmLeaveConfigurations(null)) {
+			event.preventDefault();
+			event.stopPropagation();
 			return;
 		}
 		// Primary click: SPA navigate. Do not rely on href alone so Cancel can block.

--- a/web/ui/dashboard/src/app/private/pages/admin/admin.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/admin.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ConfigurationsComponent } from '../settings/configurations/configurations.component';
 
 export type ADMIN_PAGE = 'configurations' | 'feature flags' | 'circuit breaker config' | 'resend events' | 'queue monitoring' | 'table partitions' | 'table indexes';
 
@@ -20,6 +21,8 @@ export class AdminComponent implements OnInit {
 		{ name: 'table partitions', icon: 'table-grid', svg: 'fill' },
 		{ name: 'table indexes', icon: 'key', svg: 'fill' }
 	];
+
+	@ViewChild(ConfigurationsComponent) configurations?: ConfigurationsComponent;
 
 	constructor(private route: ActivatedRoute, private router: Router) {}
 
@@ -46,8 +49,37 @@ export class AdminComponent implements OnInit {
 	// page added above cannot be one an ?activePage link silently falls back from.
 	toggleActivePage(page: string) {
 		const known = this.adminMenu.some(menu => menu.name === page);
-		this.activePage = known ? (page as ADMIN_PAGE) : 'configurations';
+		const next = known ? (page as ADMIN_PAGE) : 'configurations';
+		if (next === this.activePage) {
+			this.addPageToUrl();
+			return;
+		}
+		if (!this.confirmLeaveConfigurations(next)) {
+			return;
+		}
+		this.activePage = next;
 		this.addPageToUrl();
+	}
+
+	leaveAdmin(event: Event) {
+		if (!this.confirmLeaveConfigurations(null)) {
+			event.preventDefault();
+			event.stopPropagation();
+		}
+	}
+
+	// next null means leaving Admin entirely (back to projects).
+	private confirmLeaveConfigurations(next: ADMIN_PAGE | null): boolean {
+		if (this.activePage !== 'configurations') {
+			return true;
+		}
+		if (next === 'configurations') {
+			return true;
+		}
+		if (!this.configurations?.hasUnsavedChanges) {
+			return true;
+		}
+		return window.confirm('You have unsaved configuration changes. Leave without saving?');
 	}
 
 	// The tab is written back to the URL so a reload lands where the operator

--- a/web/ui/dashboard/src/app/private/pages/admin/admin.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/admin.component.ts
@@ -62,10 +62,14 @@ export class AdminComponent implements OnInit {
 	}
 
 	leaveAdmin(event: Event) {
+		// Always take navigation: routerLink on the same anchor still fires after
+		// preventDefault alone, so Cancel would discard unsaved Configurations.
+		event.preventDefault();
+		event.stopPropagation();
 		if (!this.confirmLeaveConfigurations(null)) {
-			event.preventDefault();
-			event.stopPropagation();
+			return;
 		}
+		void this.router.navigate(['/projects']);
 	}
 
 	// next null means leaving Admin entirely (back to projects).

--- a/web/ui/dashboard/src/app/private/pages/admin/admin.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/admin.component.ts
@@ -69,21 +69,21 @@ export class AdminComponent implements OnInit {
 
 	leaveAdmin(event: MouseEvent) {
 		// Modifier / middle-click only opens another tab; this form stays dirty.
-		// Confirming first would block native navigation for a leave that never happens.
 		const modified =
 			event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0;
 		if (modified) {
 			return;
 		}
-		if (!this.confirmLeaveConfigurations(null)) {
-			event.preventDefault();
-			event.stopPropagation();
-			return;
-		}
-		// Primary click: SPA navigate. Do not rely on href alone so Cancel can block.
+		// Primary click: SPA navigate. canDeactivate owns the unsaved confirm so
+		// logo / browser-back / other router exits share one path (no double prompt).
 		event.preventDefault();
 		event.stopPropagation();
 		void this.router.navigate(['/projects']);
+	}
+
+	// Router leaving Admin entirely (back control, shell links, browser history).
+	canDeactivate(): boolean {
+		return this.confirmLeaveConfigurations(null);
 	}
 
 	// next null means leaving Admin entirely (back to projects).

--- a/web/ui/dashboard/src/app/private/pages/admin/admin.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/admin.component.ts
@@ -1,3 +1,4 @@
+import { Location } from '@angular/common';
 import { Component, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { ConfigurationsComponent } from '../settings/configurations/configurations.component';
@@ -21,10 +22,12 @@ export class AdminComponent implements OnInit {
 		{ name: 'table partitions', icon: 'table-grid', svg: 'fill' },
 		{ name: 'table indexes', icon: 'key', svg: 'fill' }
 	];
+	// External href for the back control so middle-click / open-in-new-tab keep RootPath.
+	projectsHref = '/projects';
 
 	@ViewChild(ConfigurationsComponent) configurations?: ConfigurationsComponent;
 
-	constructor(private route: ActivatedRoute, private router: Router) {}
+	constructor(private route: ActivatedRoute, private router: Router, private location: Location) {}
 
 	// Every class is written out in full because Tailwind reads these files as text:
 	// a name assembled from parts at runtime is never generated, and the missing
@@ -40,6 +43,9 @@ export class AdminComponent implements OnInit {
 	}
 
 	ngOnInit() {
+		this.projectsHref = this.location.prepareExternalUrl(
+			this.router.serializeUrl(this.router.createUrlTree(['/projects']))
+		);
 		// Set active page from URL query parameter
 		const requestedPage = this.route.snapshot.queryParams?.activePage ?? 'configurations';
 		this.toggleActivePage(requestedPage);
@@ -61,14 +67,21 @@ export class AdminComponent implements OnInit {
 		this.addPageToUrl();
 	}
 
-	leaveAdmin(event: Event) {
-		// Always take navigation: routerLink on the same anchor still fires after
-		// preventDefault alone, so Cancel would discard unsaved Configurations.
-		event.preventDefault();
-		event.stopPropagation();
+	leaveAdmin(event: MouseEvent) {
 		if (!this.confirmLeaveConfigurations(null)) {
+			event.preventDefault();
+			event.stopPropagation();
 			return;
 		}
+		const modified =
+			event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || event.button !== 0;
+		if (modified) {
+			// Allow the browser to follow projectsHref (includes RootPath / base href).
+			return;
+		}
+		// Primary click: SPA navigate. Do not rely on href alone so Cancel can block.
+		event.preventDefault();
+		event.stopPropagation();
 		void this.router.navigate(['/projects']);
 	}
 

--- a/web/ui/dashboard/src/app/private/pages/admin/admin.module.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/admin.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule, Routes } from '@angular/router';
+import { CanDeactivateFn, RouterModule, Routes } from '@angular/router';
 import { ReactiveFormsModule } from '@angular/forms';
 import { AdminComponent } from './admin.component';
 import { FeatureFlagsComponent } from './feature-flags/feature-flags.component';
@@ -24,7 +24,9 @@ import { RadioComponent } from 'src/app/components/radio/radio.component';
 import { ConfigButtonComponent } from '../../components/config-button/config-button.component';
 import { TooltipComponent } from 'src/app/components/tooltip/tooltip.component';
 
-const routes: Routes = [{ path: '', component: AdminComponent }];
+const adminUnsavedGuard: CanDeactivateFn<AdminComponent> = component => component.canDeactivate();
+
+const routes: Routes = [{ path: '', component: AdminComponent, canDeactivate: [adminUnsavedGuard] }];
 
 @NgModule({
 	declarations: [

--- a/web/ui/dashboard/src/app/private/pages/admin/runs/run.model.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/runs/run.model.ts
@@ -1,7 +1,8 @@
 // One run row covers both kinds of long maintenance work the admin pages drive:
 // converting a table, and rebuilding an index a migration dropped. They share the
-// row because they share the instance-wide single-active slot on the server, so
-// the two pages read the same history and cannot disagree about what is running.
+// row because they share the instance-wide single-active slot on the server. Each
+// page loads that history and shows only its own operation; the unfiltered list
+// still answers whether the slot is free.
 export type MaintenanceOperation = 'partition' | 'unpartition' | 'rebuild_index';
 
 export interface RunStep {

--- a/web/ui/dashboard/src/app/private/pages/admin/table-indexes/table-indexes.component.html
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-indexes/table-indexes.component.html
@@ -80,7 +80,11 @@
 
   @if (activeRun) {
     <p class="font-body font-normal text-[12px] leading-normal text-new.text-secondary mb-24px">
-      A conversion or rebuild is already running. One runs at a time for the whole instance.
+      @if (activeRun.operation === 'rebuild_index') {
+        A rebuild is already running. One runs at a time for the whole instance.
+      } @else {
+        A conversion is already running. One runs at a time for the whole instance.
+      }
     </p>
   }
 }

--- a/web/ui/dashboard/src/app/private/pages/admin/table-indexes/table-indexes.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-indexes/table-indexes.component.ts
@@ -160,8 +160,8 @@ export class TableIndexesComponent implements OnInit, OnDestroy {
 		this.pollInterval = null;
 	}
 
-	// Only the rebuilds are shown here; conversions belong to the partitions page,
-	// and this list is what the buttons above act on.
+	// Only the rebuilds are shown here; conversions belong to the partitions page.
+	// The unfiltered list still drives activeRun / canStart: any run holds the slot.
 	get rebuildRuns(): MaintenanceRun[] {
 		return this.runs.filter(run => run.operation === 'rebuild_index');
 	}

--- a/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.html
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.html
@@ -110,15 +110,19 @@
 
       @if (activeRun) {
         <p class="font-body font-normal text-[12px] leading-normal text-new.text-secondary mt-12px text-right">
-          A conversion is already running. One runs at a time for the whole instance.
+          @if (activeRun.operation === 'rebuild_index') {
+            An index rebuild is already running. One runs at a time for the whole instance.
+          } @else {
+            A conversion is already running. One runs at a time for the whole instance.
+          }
         </p>
       }
     </div>
   </div>
 
-  <!-- Every maintenance run, not only conversions: a rebuild started from the
-       indexes page or a shell holds the same instance-wide slot, so an operator
-       looking for what is blocking a conversion has to see it here. -->
+  <!-- Conversion history only. Index rebuilds belong on the indexes page.
+       The full list is still loaded so a rebuild holding the instance-wide
+       slot keeps canStart false and the one-liner above can name it. -->
   <div class="flex items-center justify-between mb-12px">
     <h4 class="font-heading font-medium text-[15px] leading-[22px] text-new.text-primary">Runs</h4>
     <button
@@ -131,11 +135,11 @@
     </button>
   </div>
 
-  @if (runs.length === 0) {
+  @if (conversionRuns.length === 0) {
     <div class="bg-white-100 border border-new.border rounded-12px p-20px">
       <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">
         @if (runsKnown) {
-          No conversions or index rebuilds have been run on this instance.
+          No conversions have been run on this instance.
         } @else if (runsFailed) {
           The run history could not be loaded. Refresh to try again.
         } @else {
@@ -146,7 +150,7 @@
   }
 
   <div class="flex flex-col gap-12px">
-    @for (run of runs; track run.uid) {
+    @for (run of conversionRuns; track run.uid) {
       <app-admin-run-card [run]="run"></app-admin-run-card>
     }
   </div>

--- a/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.spec.ts
@@ -124,4 +124,64 @@ describe('TablePartitionsComponent', () => {
 		component.runsKnown = false;
 		expect(component.canStart).toBeFalse();
 	});
+
+	// Rebuilds share the slot and the API response, but this page only shows
+	// conversions. A rebuild-only history must not look like a past conversion.
+	it('lists conversion runs and hides rebuilds', () => {
+		component.runs = [
+			{
+				uid: 'run-rebuild',
+				table_name: 'events',
+				operation: 'rebuild_index',
+				index_name: 'idx_events_source_id',
+				status: 'completed',
+				phase: null,
+				steps: null,
+				error: null,
+				triggered_by: 'user-1',
+				started_at: '2026-08-19T09:00:00Z',
+				updated_at: '2026-08-19T09:01:00Z',
+				completed_at: '2026-08-19T09:01:00Z'
+			},
+			{
+				uid: 'run-partition',
+				table_name: 'events',
+				operation: 'partition',
+				index_name: null,
+				status: 'completed',
+				phase: null,
+				steps: null,
+				error: null,
+				triggered_by: 'user-1',
+				started_at: '2026-08-18T09:00:00Z',
+				updated_at: '2026-08-18T09:01:00Z',
+				completed_at: '2026-08-18T09:01:00Z'
+			}
+		];
+		component.runsKnown = true;
+
+		expect(component.conversionRuns.map(run => run.uid)).toEqual(['run-partition']);
+	});
+
+	it('treats a rebuild-only history as no conversions yet', () => {
+		component.runs = [
+			{
+				uid: 'run-rebuild',
+				table_name: 'events',
+				operation: 'rebuild_index',
+				index_name: 'idx_events_source_id',
+				status: 'completed',
+				phase: null,
+				steps: null,
+				error: null,
+				triggered_by: 'user-1',
+				started_at: '2026-08-19T09:00:00Z',
+				updated_at: '2026-08-19T09:01:00Z',
+				completed_at: '2026-08-19T09:01:00Z'
+			}
+		];
+		component.runsKnown = true;
+
+		expect(component.conversionRuns.length).toBe(0);
+	});
 });

--- a/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.ts
@@ -44,9 +44,9 @@ export class TablePartitionsComponent implements OnInit, OnDestroy {
 	// for hours, so it should not be one misplaced click away.
 	partitionForm: FormGroup;
 
-	// Every maintenance run, conversions and index rebuilds alike. They share the
-	// server's single-active slot, so a rebuild in flight has to count as an
-	// active run here or the form would offer a start the server refuses.
+	// Full maintenance history from the server. Display filters to conversions;
+	// rebuilds stay on the indexes page. The unfiltered list still drives
+	// activeRun / canStart because any run holds the instance-wide slot.
 	runs: MaintenanceRun[] = [];
 	tableStates: PartitionTable[] = [];
 	// Distinguishes "fetch failed" from "fetch returned no rows". Clearing
@@ -190,6 +190,11 @@ export class TablePartitionsComponent implements OnInit, OnDestroy {
 
 	get activeRun(): MaintenanceRun | undefined {
 		return this.runs.find(run => run.status === 'running');
+	}
+
+	// Only partition / unpartition rows. Rebuild history is the indexes page's.
+	get conversionRuns(): MaintenanceRun[] {
+		return this.runs.filter(run => run.operation === 'partition' || run.operation === 'unpartition');
 	}
 
 	// runsKnown is part of the gate, not decoration: the slot is instance-wide and a

--- a/web/ui/dashboard/src/app/private/pages/settings/configurations/configurations.component.html
+++ b/web/ui/dashboard/src/app/private/pages/settings/configurations/configurations.component.html
@@ -4,11 +4,17 @@
   <button type="button" class="px-14px py-8px rounded-full bg-new.primary-400 font-body font-medium text-[13px] text-white-100 transition-all hover:opacity-90 disabled:opacity-50" [disabled]="!canSave" (click)="updateConfigSettings()">Save Changes</button>
 </div>
 
+@if (hasUnsavedChanges) {
+  <div class="mb-20px px-14px py-10px rounded-8px border border-new.border bg-new.surface-muted font-body text-[13px] leading-[18px] text-new.text-primary">
+    Unsaved changes. Save before leaving this page or they will be lost.
+  </div>
+}
+
 <form [formGroup]="configForm">
   <div class="flex justify-between items-start">
     <div class="w-3/4">
       <h4 class="font-heading font-medium text-[16px] leading-[24px] text-new.text-primary">Admin Managed</h4>
-      <p class="font-body font-normal text-[13px] leading-normal text-new.text-secondary mt-4px">Use the values on this page after restart. When off, environment values win.</p>
+      <p class="font-body font-normal text-[13px] leading-normal text-new.text-secondary mt-4px">When off, environment values win on boot. When on, Save this page, then restart server (and agent) so boot and circuit-breaker ownership use these values.</p>
     </div>
     <convoy-toggle name="admin_managed" formControlName="admin_managed"></convoy-toggle>
   </div>

--- a/web/ui/dashboard/src/app/private/pages/settings/configurations/configurations.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/settings/configurations/configurations.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, HostListener, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {SettingsService} from '../settings.service';
 import {GeneralService} from 'src/app/services/general/general.service';
@@ -41,6 +41,8 @@ export class ConfigurationsComponent implements OnInit {
 	isFetchingConfig = false;
 	configLoaded = false;
 	loaderIndex: number[] = [0, 1, 2];
+	// Last value returned from GET/Save. Used to toast when ownership flips.
+	private savedAdminManaged = false;
 	// Storage secrets and on-prem path are optional on update: GET redacts them,
 	// and blank on PUT means keep (preserveStoragePolicySecrets).
 	configForm: FormGroup = this.formBuilder.group({
@@ -96,6 +98,20 @@ export class ConfigurationsComponent implements OnInit {
 		return this.configLoaded && this.configForm.dirty && !this.isUpdatingConfig && !this.isFetchingConfig;
 	}
 
+	get hasUnsavedChanges(): boolean {
+		return this.configLoaded && this.configForm.dirty;
+	}
+
+	// Reload / tab close while the form is dirty. Sidebar leave is handled by Admin.
+	@HostListener('window:beforeunload', ['$event'])
+	onBeforeUnload(event: BeforeUnloadEvent) {
+		if (!this.hasUnsavedChanges) {
+			return;
+		}
+		event.preventDefault();
+		event.returnValue = true;
+	}
+
 	async fetchConfigSettings() {
 		this.isFetchingConfig = true;
 		try {
@@ -114,6 +130,7 @@ export class ConfigurationsComponent implements OnInit {
 			}
 			this.syncAdminManaged(!!this.configForm.get('admin_managed')?.value);
 			this.syncRetentionPeriodEnabled(!!this.configForm.get('retention_policy.enabled')?.value);
+			this.savedAdminManaged = !!this.configForm.get('admin_managed')?.value;
 
 			this.configForm.markAsPristine();
 			this.configLoaded = true;
@@ -147,10 +164,18 @@ export class ConfigurationsComponent implements OnInit {
 			payload.retention_policy.period = `${payload.retention_policy.period}h`;
 		}
 
+		const nextAdminManaged = !!payload.admin_managed;
+		const ownershipChanged = this.savedAdminManaged !== nextAdminManaged;
+
 		this.isUpdatingConfig = true;
 		try {
 			const response = await this.settingService.updateConfigSettings(payload);
-			this.generalService.showNotification({ message: response.message, style: 'success' });
+			this.generalService.showNotification({
+				message: ownershipChanged
+					? 'Saved. Restart server (and agent) for boot ownership and circuit-breaker defaults.'
+					: response.message,
+				style: ownershipChanged ? 'info' : 'success'
+			});
 			this.isUpdatingConfig = false;
 			this.fetchConfigSettings();
 		} catch {

--- a/web/ui/dashboard/src/app/private/pages/settings/configurations/configurations.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/settings/configurations/configurations.component.ts
@@ -138,7 +138,9 @@ export class ConfigurationsComponent implements OnInit {
 			this.configLoaded = true;
 			this.isFetchingConfig = false;
 		} catch {
-			this.configLoaded = false;
+			// Leave configLoaded alone. A failed refetch after save must not clear
+			// it: the form still holds editable values, and wiping the flag disables
+			// Save and hides dirty leave warnings for later edits.
 			this.isFetchingConfig = false;
 		}
 	}

--- a/web/ui/dashboard/src/app/private/pages/settings/configurations/configurations.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/settings/configurations/configurations.component.ts
@@ -99,7 +99,9 @@ export class ConfigurationsComponent implements OnInit {
 	}
 
 	get hasUnsavedChanges(): boolean {
-		return this.configLoaded && this.configForm.dirty;
+		// Exclude in-flight save/refetch: after PUT the form is still dirty until
+		// markAsPristine, and a refetch patch briefly dirties it again.
+		return this.configLoaded && this.configForm.dirty && !this.isUpdatingConfig && !this.isFetchingConfig;
 	}
 
 	// Reload / tab close while the form is dirty. Sidebar leave is handled by Admin.
@@ -176,8 +178,12 @@ export class ConfigurationsComponent implements OnInit {
 					: response.message,
 				style: ownershipChanged ? 'info' : 'success'
 			});
+			// Saved bytes are on the server; clear dirty before refetch so leave
+			// confirms and the banner do not treat the post-PUT window as unsaved.
+			this.savedAdminManaged = nextAdminManaged;
+			this.configForm.markAsPristine();
 			this.isUpdatingConfig = false;
-			this.fetchConfigSettings();
+			await this.fetchConfigSettings();
 		} catch {
 			this.isUpdatingConfig = false;
 		}


### PR DESCRIPTION
## Summary
- Show an **Unsaved changes** banner on Admin → Configurations while the form is dirty.
- Confirm before leaving Configurations (Admin sidebar switch or back to projects); block browser reload/close via `beforeunload`.
- Clarify Admin Managed help: Save persists the page; restart applies boot/CB ownership.
- When `admin_managed` flips on Save, toast reminds operators to restart server (and agent).

## Test plan
- [ ] Toggle Admin Managed without Save → banner appears; Save enables
- [ ] Reload with dirty form → browser leave warning
- [ ] Dirty form + click Feature Flags → confirm; Cancel stays; OK discards
- [ ] Dirty form + back to projects → same confirm
- [ ] Save ownership flip → toast mentions restart
- [ ] Save a non-ownership knob → normal success toast only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only UX around admin configuration editing; no API or auth changes, and the change reduces accidental loss of unsaved admin settings.
> 
> **Overview**
> Adds **unsaved-change protection** on Admin → Configurations so operators do not lose in-progress edits when navigating away.
> 
> The configurations form now exposes **`hasUnsavedChanges`**, shows an **unsaved changes** banner while dirty, and uses **`beforeunload`** for reload/tab close. **Admin** intercepts sidebar tab switches and the back-to-projects control with **`window.confirm`** when leaving Configurations with a dirty form; the back link uses a **base-href-aware `projectsHref`** and **`leaveAdmin`** so primary clicks use the router while modified clicks still open `/projects` correctly.
> 
> Copy updates clarify that **Admin Managed** values require **Save** then **server (and agent) restart** for boot and circuit-breaker ownership. On save, toggling **`admin_managed`** triggers an **info toast** reminding operators to restart instead of only the generic success message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c9a2244583c8acf9194e27db2bdf588fec933a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->