### PR TITLE
fix(dataplane): unwrap nat64 and 6to4 in notification ssrf guard

### DIFF
--- a/net/dispatcher.go
+++ b/net/dispatcher.go
@@ -453,8 +453,10 @@ func isMetadataOrLinkLocal(ip netip.Addr) bool {
 }
 
 // embeddedV4 extracts the IPv4 address embedded in a NAT64 (64:ff9b::/96) or
-// 6to4 (2002::/16) IPv6 address.
+// 6to4 (2002::/16) IPv6 address. The zone is stripped first: netip.Prefix.Contains
+// is false for any zoned IPv6 address, which would otherwise skip NAT64 unwrap.
 func embeddedV4(ip netip.Addr) (netip.Addr, bool) {
+	ip = ip.WithZone("")
 	b := ip.As16()
 
 	if nat64WellKnown.Contains(ip) {

--- a/net/dispatcher.go
+++ b/net/dispatcher.go
@@ -365,9 +365,11 @@ func newNotificationTransport(base *http.Transport, detailedTrace bool) http.Rou
 
 // blockPrivateNetworks is a net.Dialer.Control hook that rejects connections to
 // loopback, private, link-local, unspecified, or otherwise non-global-unicast
-// addresses. It runs after DNS resolution with the concrete IP the socket is
-// about to dial, so it closes the DNS-rebinding window a write-time URL check
-// cannot. Fail-closed: an address that cannot be parsed is rejected.
+// addresses, including IPv4-mapped, NAT64 (64:ff9b::/96), and 6to4 (2002::/16)
+// encodings of those IPv4 targets. It runs after DNS resolution with the
+// concrete IP the socket is about to dial, so it closes the DNS-rebinding
+// window a write-time URL check cannot. Fail-closed: an address that cannot
+// be parsed is rejected.
 func blockPrivateNetworks(_, address string, _ syscall.RawConn) error {
 	host, _, err := net.SplitHostPort(address)
 	if err != nil {
@@ -379,6 +381,9 @@ func blockPrivateNetworks(_, address string, _ syscall.RawConn) error {
 		return fmt.Errorf("ssrf guard: cannot parse dial ip %q: %w", host, err)
 	}
 	ip = ip.Unmap()
+	if v4, ok := embeddedV4(ip); ok {
+		ip = v4
+	}
 
 	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() || ip.IsUnspecified() {

--- a/net/dispatcher_test.go
+++ b/net/dispatcher_test.go
@@ -1673,6 +1673,9 @@ func TestBlockPrivateNetworks(t *testing.T) {
 		{name: "6to4-wrapped loopback", address: "[2002:7f00:1::1]:80", blocked: true},
 		{name: "6to4-wrapped private", address: "[2002:a00:1::1]:80", blocked: true},
 		{name: "nat64-wrapped public", address: "[64:ff9b::808:808]:80", blocked: false},
+		{name: "zoned nat64-wrapped loopback", address: "[64:ff9b::7f00:1%eth0]:80", blocked: true},
+		{name: "zoned nat64-wrapped private", address: "[64:ff9b::a00:1%eth0]:80", blocked: true},
+		{name: "zoned nat64-wrapped public", address: "[64:ff9b::808:808%eth0]:80", blocked: false},
 		{name: "unparseable", address: "not-an-ip:80", blocked: true},
 	}
 
@@ -1702,6 +1705,7 @@ func TestBlockMetadataEndpoints(t *testing.T) {
 		{name: "aws imds v6", address: "[fd00:ec2::254]:80", blocked: true},
 		{name: "ipv4-mapped metadata", address: "[::ffff:169.254.169.254]:80", blocked: true},
 		{name: "nat64-wrapped metadata", address: "[64:ff9b::a9fe:a9fe]:80", blocked: true},
+		{name: "zoned nat64-wrapped metadata", address: "[64:ff9b::a9fe:a9fe%eth0]:80", blocked: true},
 		{name: "6to4-wrapped metadata", address: "[2002:a9fe:a9fe::1]:80", blocked: true},
 		{name: "unparseable", address: "not-an-ip:80", blocked: true},
 

--- a/net/dispatcher_test.go
+++ b/net/dispatcher_test.go
@@ -1668,6 +1668,11 @@ func TestBlockPrivateNetworks(t *testing.T) {
 		{name: "unspecified", address: "0.0.0.0:80", blocked: true},
 		{name: "ipv6 ula", address: "[fd00::1]:80", blocked: true},
 		{name: "ipv4-mapped loopback", address: "[::ffff:127.0.0.1]:80", blocked: true},
+		{name: "nat64-wrapped loopback", address: "[64:ff9b::7f00:1]:80", blocked: true},
+		{name: "nat64-wrapped private", address: "[64:ff9b::a00:1]:80", blocked: true},
+		{name: "6to4-wrapped loopback", address: "[2002:7f00:1::1]:80", blocked: true},
+		{name: "6to4-wrapped private", address: "[2002:a00:1::1]:80", blocked: true},
+		{name: "nat64-wrapped public", address: "[64:ff9b::808:808]:80", blocked: false},
 		{name: "unparseable", address: "not-an-ip:80", blocked: true},
 	}
 


### PR DESCRIPTION
## Summary
- Notification egress (`blockPrivateNetworks`) only unmapped IPv4-mapped addresses, so well-known NAT64 and 6to4 encodings of loopback and RFC1918 still dialed.
- Extract the embedded IPv4 the same way the webhook metadata guard already does, and add regression cases for wrapped loopback, private, and public targets.

## Test plan
- [x] `go test ./net -run TestBlockPrivateNetworks`
- [x] `golangci-lint run --config=.golangci.yml --timeout 5m --new-from-rev=origin/main`
- [ ] Confirm Slack/notification URLs to public hosts still succeed
- [ ] Confirm NAT64/6to4 encodings of `127.0.0.1` and RFC1918 are refused at connect time