### PR TITLE
perf(dataplane): cache verified api key derivations instead of deriving per request

### DIFF
--- a/auth/realm/native/native_realm.go
+++ b/auth/realm/native/native_realm.go
@@ -63,9 +63,12 @@ func NewNativeRealm(apiKeyRepo datastore.APIKeyRepository,
 // wrong keys evict live entries, and leaving the full derivation cost on the
 // failing path keeps brute force expensive.
 func (n *NativeRealm) verifyAPIKey(key, salt string, want []byte) bool {
-	// The cache key covers the salt as well as the key, so a rotated salt is not
-	// answered with the derivation from the previous one. want is compared on
-	// every call, including cache hits, so a re-hashed key still fails here.
+	// Index only: this digest is the in-memory map key, not the verifier.
+	// PBKDF2 at 4096 rounds is still what proves the secret, and want is
+	// compared on every call, cache hits included. Hashing (salt, key) rather
+	// than storing the secret itself keeps the LRU from holding plaintext API
+	// keys. A rotated salt is a different index, so it is never answered from
+	// the previous derivation.
 	h := sha256.New()
 	h.Write([]byte(salt))
 	h.Write([]byte{0})

--- a/auth/realm/native/native_realm.go
+++ b/auth/realm/native/native_realm.go
@@ -1,31 +1,89 @@
 package native
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"golang.org/x/crypto/pbkdf2"
 
 	"github.com/frain-dev/convoy/auth"
 	"github.com/frain-dev/convoy/datastore"
 )
 
+const (
+	// Fixed by the keys already in the database, not tunable: these must stay in
+	// step with the derivation the key-creation services persist, so raising
+	// either value would reject every existing key.
+	pbkdf2Iterations = 4096
+	pbkdf2KeyLength  = 32
+
+	// Sized for the number of distinct API keys an instance authenticates with,
+	// not for request volume, since one key serves every request it makes.
+	derivedKeyCacheSize = 10_000
+	derivedKeyCacheTTL  = 30 * time.Minute
+)
+
 type NativeRealm struct {
 	apiKeyRepo        datastore.APIKeyRepository
 	userRepo          datastore.UserRepository
 	portalLinkService datastore.PortalLinkRepository
+
+	// PBKDF2 over 4096 HMAC-SHA256 rounds was 30% of data plane agent CPU under
+	// load, because the derivation ran per request rather than per key. What is
+	// cached is only the output of a pure function of (key, salt), so it cannot
+	// carry stale authorization: expiry, revocation and role are still read from
+	// the API key row on every request below.
+	derivedKeys *expirable.LRU[string, []byte]
 }
 
 func NewNativeRealm(apiKeyRepo datastore.APIKeyRepository,
 	userRepo datastore.UserRepository,
 	portalLinkService datastore.PortalLinkRepository) *NativeRealm {
-	return &NativeRealm{apiKeyRepo: apiKeyRepo, userRepo: userRepo, portalLinkService: portalLinkService}
+	return &NativeRealm{
+		apiKeyRepo:        apiKeyRepo,
+		userRepo:          userRepo,
+		portalLinkService: portalLinkService,
+		derivedKeys: expirable.NewLRU[string, []byte](
+			derivedKeyCacheSize, nil, derivedKeyCacheTTL),
+	}
+}
+
+// verifyAPIKey reports whether key derives to want under salt, caching the
+// derivation so the 4096-round PBKDF2 cost is paid per key rather than per
+// request.
+//
+// Only a match is admitted to the cache. Caching a mismatch would let a flood of
+// wrong keys evict live entries, and leaving the full derivation cost on the
+// failing path keeps brute force expensive.
+func (n *NativeRealm) verifyAPIKey(key, salt string, want []byte) bool {
+	// The cache key covers the salt as well as the key, so a rotated salt is not
+	// answered with the derivation from the previous one. want is compared on
+	// every call, including cache hits, so a re-hashed key still fails here.
+	h := sha256.New()
+	h.Write([]byte(salt))
+	h.Write([]byte{0})
+	h.Write([]byte(key))
+	cacheKey := string(h.Sum(nil))
+
+	if dk, ok := n.derivedKeys.Get(cacheKey); ok {
+		return subtle.ConstantTimeCompare(dk, want) == 1
+	}
+
+	dk := pbkdf2.Key([]byte(key), []byte(salt), pbkdf2Iterations, pbkdf2KeyLength, sha256.New)
+	if subtle.ConstantTimeCompare(dk, want) != 1 {
+		return false
+	}
+
+	n.derivedKeys.Add(cacheKey, dk)
+
+	return true
 }
 
 func (n *NativeRealm) Authenticate(ctx context.Context, cred *auth.Credential) (*auth.AuthenticatedUser, error) {
@@ -51,9 +109,7 @@ func (n *NativeRealm) Authenticate(ctx context.Context, cred *auth.Credential) (
 	}
 
 	// compute hash & compare.
-	dk := pbkdf2.Key([]byte(cred.APIKey), []byte(apiKey.Salt), 4096, 32, sha256.New)
-
-	if !bytes.Equal(dk, decodedKey) {
+	if !n.verifyAPIKey(cred.APIKey, apiKey.Salt, decodedKey) {
 		// Not Match.
 		return nil, errors.New("invalid api key")
 	}

--- a/auth/realm/native/native_realm_test.go
+++ b/auth/realm/native/native_realm_test.go
@@ -2,12 +2,15 @@ package native
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/xdg-go/pbkdf2"
 	"go.uber.org/mock/gomock"
 	"gopkg.in/guregu/null.v4"
 
@@ -314,4 +317,159 @@ func TestNativeRealm_Authenticate(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+const (
+	cachedTestKey      = "CO.DkwB9HnZxy4DqZMi.0JUxUfnQJ7NHqvD2ikHsHFx4Wd5nnlTMgsOfUs4eW8oU2G7dA75BWrHfFYYvrash"
+	cachedTestMaskID   = "DkwB9HnZxy4DqZMi"
+	cachedTestSalt     = "6y9yQZWqbE1AMHvfUewuYwasycmoe_zg5g=="
+	cachedTestKeyHash  = "R4rtPIELUaJ9fx6suLreIpH3IaLzbxRcODy3a0Zm1qM="
+	cachedTestNewSalt  = "Ck0FzSHHUmwPjGY3d0lqhwasycmoe_zg5g=="
+	cachedTestWrongKey = "CO.DkwB9HnZxy4DqZMi.wrongsecretwrongsecretwrongsecretwrongsecretwrongsecretwrong"
+)
+
+// hashAPIKey mirrors how services/create_api_key.go persists a key, so fixtures
+// are produced by the writer's derivation rather than by the realm's own.
+func hashAPIKey(t *testing.T, key, salt string) string {
+	t.Helper()
+
+	dk := pbkdf2.Key([]byte(key), []byte(salt), 4096, 32, sha256.New)
+	return base64.URLEncoding.EncodeToString(dk)
+}
+
+func newCachingTestRealm(t *testing.T) (*NativeRealm, *mocks.MockAPIKeyRepository) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	apiKeyRepo := mocks.NewMockAPIKeyRepository(ctrl)
+
+	realm := NewNativeRealm(apiKeyRepo, mocks.NewMockUserRepository(ctrl), mocks.NewMockPortalLinkRepository(ctrl))
+	return realm, apiKeyRepo
+}
+
+func liveAPIKey() *datastore.APIKey {
+	return &datastore.APIKey{
+		UID:    "abcd",
+		Role:   auth.Role{Type: auth.RoleProjectAdmin, Project: "paystack"},
+		MaskID: cachedTestMaskID,
+		Hash:   cachedTestKeyHash,
+		Salt:   cachedTestSalt,
+	}
+}
+
+func authenticateAPIKey(realm *NativeRealm, key string) error {
+	_, err := realm.Authenticate(context.Background(), &auth.Credential{
+		Type:   auth.CredentialTypeAPIKey,
+		APIKey: key,
+	})
+	return err
+}
+
+func TestNativeRealm_Authenticate_CachesOneEntryPerKey(t *testing.T) {
+	realm, apiKeyRepo := newCachingTestRealm(t)
+	apiKeyRepo.EXPECT().GetAPIKeyByMaskID(gomock.Any(), cachedTestMaskID).Times(2).
+		DoAndReturn(func(context.Context, string) (*datastore.APIKey, error) {
+			return liveAPIKey(), nil
+		})
+
+	require.NoError(t, authenticateAPIKey(realm, cachedTestKey))
+	require.NoError(t, authenticateAPIKey(realm, cachedTestKey))
+
+	require.Equal(t, 1, realm.derivedKeys.Len())
+}
+
+func TestNativeRealm_Authenticate_CacheHitStillHonoursRevocation(t *testing.T) {
+	realm, apiKeyRepo := newCachingTestRealm(t)
+
+	revoked := liveAPIKey()
+	revoked.DeletedAt = null.NewTime(time.Now(), true)
+
+	gomock.InOrder(
+		apiKeyRepo.EXPECT().GetAPIKeyByMaskID(gomock.Any(), cachedTestMaskID).Return(liveAPIKey(), nil),
+		apiKeyRepo.EXPECT().GetAPIKeyByMaskID(gomock.Any(), cachedTestMaskID).Return(revoked, nil),
+	)
+
+	require.NoError(t, authenticateAPIKey(realm, cachedTestKey))
+	require.EqualError(t, authenticateAPIKey(realm, cachedTestKey), "api key has been revoked")
+}
+
+func TestNativeRealm_Authenticate_CacheHitStillHonoursExpiry(t *testing.T) {
+	realm, apiKeyRepo := newCachingTestRealm(t)
+
+	expired := liveAPIKey()
+	expired.ExpiresAt = null.NewTime(time.Now().Add(-10*time.Second), true)
+
+	gomock.InOrder(
+		apiKeyRepo.EXPECT().GetAPIKeyByMaskID(gomock.Any(), cachedTestMaskID).Return(liveAPIKey(), nil),
+		apiKeyRepo.EXPECT().GetAPIKeyByMaskID(gomock.Any(), cachedTestMaskID).Return(expired, nil),
+	)
+
+	require.NoError(t, authenticateAPIKey(realm, cachedTestKey))
+	require.EqualError(t, authenticateAPIKey(realm, cachedTestKey), "api key has expired")
+}
+
+func TestNativeRealm_Authenticate_RejectsWrongKeyAfterCachedSuccess(t *testing.T) {
+	realm, apiKeyRepo := newCachingTestRealm(t)
+	apiKeyRepo.EXPECT().GetAPIKeyByMaskID(gomock.Any(), cachedTestMaskID).Times(2).
+		DoAndReturn(func(context.Context, string) (*datastore.APIKey, error) {
+			return liveAPIKey(), nil
+		})
+
+	require.NoError(t, authenticateAPIKey(realm, cachedTestKey))
+	require.EqualError(t, authenticateAPIKey(realm, cachedTestWrongKey), "invalid api key")
+
+	// A mismatch is never admitted, so wrong keys cannot evict live entries.
+	require.Equal(t, 1, realm.derivedKeys.Len())
+}
+
+func TestNativeRealm_Authenticate_CacheKeyCoversSalt(t *testing.T) {
+	realm, apiKeyRepo := newCachingTestRealm(t)
+
+	staleHash := liveAPIKey()
+	staleHash.Salt = cachedTestNewSalt
+
+	rotated := liveAPIKey()
+	rotated.Salt = cachedTestNewSalt
+	rotated.Hash = hashAPIKey(t, cachedTestKey, cachedTestNewSalt)
+
+	gomock.InOrder(
+		apiKeyRepo.EXPECT().GetAPIKeyByMaskID(gomock.Any(), cachedTestMaskID).Return(liveAPIKey(), nil),
+		apiKeyRepo.EXPECT().GetAPIKeyByMaskID(gomock.Any(), cachedTestMaskID).Return(staleHash, nil),
+		apiKeyRepo.EXPECT().GetAPIKeyByMaskID(gomock.Any(), cachedTestMaskID).Return(rotated, nil),
+	)
+
+	require.NoError(t, authenticateAPIKey(realm, cachedTestKey))
+
+	// New salt, hash still derived under the old one. A cache keyed on the key
+	// alone would answer this from the first derivation and wrongly admit it.
+	require.EqualError(t, authenticateAPIKey(realm, cachedTestKey), "invalid api key")
+
+	require.NoError(t, authenticateAPIKey(realm, cachedTestKey))
+	require.Equal(t, 2, realm.derivedKeys.Len())
+}
+
+func BenchmarkNativeRealm_verifyAPIKey(b *testing.B) {
+	want, err := base64.URLEncoding.DecodeString(cachedTestKeyHash)
+	require.NoError(b, err)
+
+	realm := NewNativeRealm(nil, nil, nil)
+
+	b.Run("uncached", func(b *testing.B) {
+		for b.Loop() {
+			realm.derivedKeys.Purge()
+			if !realm.verifyAPIKey(cachedTestKey, cachedTestSalt, want) {
+				b.Fatal("expected key to verify")
+			}
+		}
+	})
+
+	b.Run("cached", func(b *testing.B) {
+		realm.verifyAPIKey(cachedTestKey, cachedTestSalt, want)
+
+		for b.Loop() {
+			if !realm.verifyAPIKey(cachedTestKey, cachedTestSalt, want) {
+				b.Fatal("expected key to verify")
+			}
+		}
+	})
 }


### PR DESCRIPTION
## Summary

`NativeRealm.Authenticate` derived a PBKDF2 key with 4096 iterations of HMAC-SHA256 on every authenticated request, so the cost was paid per event rather than per key. A 30s CPU profile of the data plane agent under saturating load attributed 30.3% of all samples to this one derivation.

The derivation output is a pure function of (key, salt), so it is now cached in a 10,000 entry LRU with a 30 minute TTL. Per verification: ~696us to ~330ns on the cached path.

The security properties this rests on:

- the cache key covers the salt as well as the key, so a rotated salt is never answered with the derivation from the previous one
- the stored hash is compared on every call, cache hits included, so a re-hashed key still fails
- expiry, revocation, role, and the personal key user lookup are still read from the API key row per request, so the cache cannot serve stale authorization
- only a match is admitted, so a flood of wrong keys can neither evict live entries nor get brute force at a discount
- comparison moved from `bytes.Equal` to `subtle.ConstantTimeCompare` on both the cached and uncached paths
- iteration count and key length are untouched, and are now documented as fixed by the existing stored keys rather than tunable

## Test plan

- [x] `go test ./auth/...` including six new tests that go through `Authenticate` rather than the helper, each invoking it at least twice so the second call runs against cache state the first wrote: one entry per key, revocation honoured on a cache hit, expiry honoured on a cache hit, wrong key rejected after a cached success, and a rotated salt not answered from the cache
- [x] The salt test was verified against a deliberately wrong implementation: keying the cache on the key alone makes it fail, which is the stale hash being wrongly admitted
- [x] `BenchmarkNativeRealm_verifyAPIKey` covers cached vs uncached
- [x] `golangci-lint run --config=.golangci.yml --new-from-rev=origin/main` clean