### PR TITLE
fix(controlplane): bump postgres cache epoch before dropping a local entry

### DIFF
--- a/cache/postgres/client.go
+++ b/cache/postgres/client.go
@@ -79,10 +79,13 @@ func NewWithLocalReads(db *sqlx.DB, ttl time.Duration, size int) *PostgresCache 
 // stored row so a writer cannot read back what it just replaced.
 func (c *PostgresCache) forget(key string) {
 	if c.local != nil {
-		c.local.Remove(key)
-		// Bump after the remove: a reader that samples the stripe before this
-		// point and stores after it must see the change and skip its store.
+		// Bump first: a Get that sampled the stripe before this Add and stores
+		// after it will skip, whether or not Remove has run yet. The reverse
+		// order leaves a window between Remove and Add where that Get sees an
+		// unchanged stripe, stores the row it already read, and resurrects a
+		// deleted value for the rest of the entry's lifetime.
 		c.stripeFor(key).Add(1)
+		c.local.Remove(key)
 	}
 }
 

--- a/cache/postgres/client_test.go
+++ b/cache/postgres/client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 
@@ -374,6 +375,35 @@ func TestLocalReadsDisabled(t *testing.T) {
 	got = ""
 	require.NoError(t, c.Get(ctx, key, &got))
 	require.Empty(t, got, "without local reads every Get must hit the table")
+}
+
+// TestForgetAdvancesStripeBeforeDroppingLocal is the contract Get's
+// store-after-read guard relies on, asserted at the moment the local entry
+// disappears rather than after forget returns. The LRU onEvict callback runs
+// inside Remove, so if forget still dropped first and bumped second the
+// callback would see the old stripe and this would fail. That is the window
+// an in-flight Get stores into, resurrecting a deleted value for the rest of
+// the entry's lifetime.
+func TestForgetAdvancesStripeBeforeDroppingLocal(t *testing.T) {
+	const key = "k"
+
+	c := &PostgresCache{}
+	var stripeAtEvict uint64
+	var evicted bool
+	c.local = expirable.NewLRU[string, []byte](8, func(k string, _ []byte) {
+		if k == key {
+			evicted = true
+			stripeAtEvict = c.stripeFor(key).Load()
+		}
+	}, time.Minute)
+
+	c.local.Add(key, []byte("v1"))
+	before := c.stripeFor(key).Load()
+	c.forget(key)
+
+	require.True(t, evicted, "forget must drop the local copy")
+	require.Greater(t, stripeAtEvict, before,
+		"the epoch must have moved before the local entry disappeared")
 }
 
 // TestLocalReadsNotResurrectedByConcurrentGet covers the interleaving the


### PR DESCRIPTION
## Summary

`PostgresCache.forget` dropped the local LRU entry and then incremented the invalidation stripe. A `Get` that had already read the old row from the table, and then stored after the drop but before the increment, saw an unchanged stripe and wrote the deleted value back into memory. That value then answered every later `Get` on this replica for the rest of the entry's lifetime, including the writer's own next read.

The unit shard that covers `cache/postgres` failed on an unrelated PR with `TestLocalReadsNotResurrectedByConcurrentGet` at loop iteration 21: "a deleted key must not be resurrected by an in-flight Get". That test is timing-dependent and can miss the window; the resurrection itself is real.

`forget` now increments the stripe first, then drops the local entry. A `Get` that sampled the stripe before the increment skips its store whether or not `Remove` has run yet. The reverse window, a few nanoseconds of stale local hit between the increment and the drop, is the duration of two in-memory operations and matches ordinary invalidation.

`TestForgetAdvancesStripeBeforeDroppingLocal` asserts the order at the moment the local entry disappears, using the LRU `onEvict` callback which runs inside `Remove`. Against the old order it fails with `"0" is not greater than "0"`.

## Test plan

- [x] `TestForgetAdvancesStripeBeforeDroppingLocal` fails on the unfixed `forget` and passes after the swap
- [x] `go test -race -count=1 ./cache/postgres/` (20 tests) green
- [x] `golangci-lint run --config=.golangci.yml --new-from-rev=origin/main ./cache/postgres/...` clean