### PR TITLE
fix(dashboard): import endpoint models as types so the image build emits dist

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -78,6 +78,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist-without-markdown
+          if-no-files-found: error
           path: |
             web/ui/dashboard/dist
             !web/ui/dashboard/dist/**/*.md

--- a/scripts/ui.sh
+++ b/scripts/ui.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+build=""
 
 helpFunc() {
 	echo ""

--- a/web/ui/dashboard/src/app/portal/endpoints/endpoints.component.ts
+++ b/web/ui/dashboard/src/app/portal/endpoints/endpoints.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit, ViewChild} from '@angular/core';
 import { DatePipe, Location } from '@angular/common';
 import {ActivatedRoute, NavigationEnd, Router} from '@angular/router';
 import {DropdownComponent, DropdownOptionDirective} from 'src/app/components/dropdown/dropdown.component';
-import {ENDPOINT, ENDPOINT_PERIOD_FAILURE_RATE, PORTAL_LINK} from 'src/app/models/endpoint.model';
+import type {ENDPOINT, ENDPOINT_PERIOD_FAILURE_RATE, PORTAL_LINK} from 'src/app/models/endpoint.model';
 import {SUBSCRIPTION} from 'src/app/models/subscription';
 import {GeneralService} from 'src/app/services/general/general.service';
 import {EndpointsService} from 'src/app/private/pages/project/endpoints/endpoints.service';

--- a/web/ui/dashboard/src/app/portal/subscriptions/subscriptions.component.ts
+++ b/web/ui/dashboard/src/app/portal/subscriptions/subscriptions.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { Location } from '@angular/common';
-import { PORTAL_LINK } from 'src/app/models/endpoint.model';
+import type { PORTAL_LINK } from 'src/app/models/endpoint.model';
 import { SUBSCRIPTION } from 'src/app/models/subscription';
 import { CURSOR, PAGINATION } from 'src/app/models/global.model';
 import { PrivateService } from 'src/app/private/private.service';

--- a/web/ui/dashboard/src/app/private/components/create-endpoint/create-endpoint.component.ts
+++ b/web/ui/dashboard/src/app/private/components/create-endpoint/create-endpoint.component.ts
@@ -16,7 +16,7 @@ import {PrivateService} from '../../private.service';
 import {FormLoaderComponent} from 'src/app/components/form-loader/form-loader.component';
 import {PermissionDirective} from '../permission/permission.directive';
 import {RbacService} from 'src/app/services/rbac/rbac.service';
-import {ENDPOINT, SECRET} from 'src/app/models/endpoint.model';
+import type {ENDPOINT, SECRET} from 'src/app/models/endpoint.model';
 import {EndpointsService} from '../../pages/project/endpoints/endpoints.service';
 import {DropdownComponent, DropdownOptionDirective} from 'src/app/components/dropdown/dropdown.component';
 import {CopyButtonComponent} from 'src/app/components/copy-button/copy-button.component';

--- a/web/ui/dashboard/src/app/private/components/create-subscription/create-subscription.component.ts
+++ b/web/ui/dashboard/src/app/private/components/create-subscription/create-subscription.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {ActivatedRoute, Router} from '@angular/router';
-import {APP, ENDPOINT} from 'src/app/models/endpoint.model';
+import type {APP, ENDPOINT} from 'src/app/models/endpoint.model';
 import {SOURCE} from 'src/app/models/source.model';
 import {PrivateService} from '../../private.service';
 import {CreateEndpointComponent} from '../create-endpoint/create-endpoint.component';

--- a/web/ui/dashboard/src/app/private/components/endpoints-filter/endpoints-filter.component.ts
+++ b/web/ui/dashboard/src/app/private/components/endpoints-filter/endpoints-filter.component.ts
@@ -3,7 +3,7 @@ import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild }
 import { Observable, fromEvent, merge, of, from } from 'rxjs';
 import { map, debounceTime, distinctUntilChanged, switchMap, tap, finalize } from 'rxjs/operators';
 import { DropdownComponent, DropdownOptionDirective } from 'src/app/components/dropdown/dropdown.component';
-import { ENDPOINT } from 'src/app/models/endpoint.model';
+import type { ENDPOINT } from 'src/app/models/endpoint.model';
 import { PrivateService } from '../../private.service';
 import { ListItemComponent } from 'src/app/components/list-item/list-item.component';
 import { SkeletonLoaderComponent } from 'src/app/components/skeleton-loader/skeleton-loader.component';

--- a/web/ui/dashboard/src/app/private/components/event-delivery-filter/event-delivery-filter.component.ts
+++ b/web/ui/dashboard/src/app/private/components/event-delivery-filter/event-delivery-filter.component.ts
@@ -10,7 +10,7 @@ import {SkeletonLoaderComponent} from 'src/app/components/skeleton-loader/skelet
 import {ProjectService} from '../../pages/project/project.service';
 import {SOURCE} from 'src/app/models/source.model';
 import {PrivateService} from '../../private.service';
-import {ENDPOINT} from 'src/app/models/endpoint.model';
+import type {ENDPOINT} from 'src/app/models/endpoint.model';
 import {FormsModule} from '@angular/forms';
 import {GeneralService} from 'src/app/services/general/general.service';
 import {LicensesService} from 'src/app/services/licenses/licenses.service';

--- a/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoint-secret/endpoint-secret.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoint-secret/endpoint-secret.component.ts
@@ -3,7 +3,7 @@ import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { CopyButtonComponent } from 'src/app/components/copy-button/copy-button.component';
 import { GeneralService } from 'src/app/services/general/general.service';
-import { ENDPOINT, SECRET } from 'src/app/models/endpoint.model';
+import type { ENDPOINT, SECRET } from 'src/app/models/endpoint.model';
 import { EndpointsService } from '../endpoints.service';
 
 @Component({

--- a/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/co
 import { CommonModule } from '@angular/common';
 import { PrivateService } from 'src/app/private/private.service';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
-import { ENDPOINT, ENDPOINT_PERIOD_FAILURE_RATE } from 'src/app/models/endpoint.model';
+import type { ENDPOINT, ENDPOINT_PERIOD_FAILURE_RATE } from 'src/app/models/endpoint.model';
 import { CURSOR, PAGINATION } from 'src/app/models/global.model';
 import { DropdownComponent, DropdownOptionDirective } from 'src/app/components/dropdown/dropdown.component';
 import { DialogDirective } from 'src/app/components/dialog/dialog.directive';

--- a/web/ui/dashboard/src/app/private/pages/project/events/event-deliveries/event-deliveries.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/event-deliveries/event-deliveries.component.ts
@@ -9,7 +9,7 @@ import { GeneralService } from 'src/app/services/general/general.service';
 import { EventsService } from '../events.service';
 import { PrivateService } from 'src/app/private/private.service';
 import { ProjectService } from '../../project.service';
-import { ENDPOINT } from 'src/app/models/endpoint.model';
+import type { ENDPOINT } from 'src/app/models/endpoint.model';
 
 @Component({
     selector: 'app-event-deliveries',

--- a/web/ui/dashboard/src/app/private/pages/project/events/events.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/events/events.component.ts
@@ -8,7 +8,7 @@ import { CHARTDATA, PAGINATION } from 'src/app/models/global.model';
 import { PrivateService } from 'src/app/private/private.service';
 import { Router } from '@angular/router';
 import { SOURCE } from 'src/app/models/source.model';
-import { ENDPOINT } from 'src/app/models/endpoint.model';
+import type { ENDPOINT } from 'src/app/models/endpoint.model';
 import { EventDeliveriesComponent } from './event-deliveries/event-deliveries.component';
 
 @Component({

--- a/web/ui/dashboard/src/app/private/pages/project/portal-links/portal-links.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/portal-links/portal-links.component.ts
@@ -6,7 +6,7 @@ import { EmptyStateComponent } from 'src/app/components/empty-state/empty-state.
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { CreatePortalLinkComponent } from 'src/app/private/components/create-portal-link/create-portal-link.component';
 import { PortalLinksService } from './portal-links.service';
-import { PORTAL_LINK } from 'src/app/models/endpoint.model';
+import type { PORTAL_LINK } from 'src/app/models/endpoint.model';
 import { GeneralService } from 'src/app/services/general/general.service';
 import { FormsModule } from '@angular/forms';
 import { DialogDirective } from 'src/app/components/dialog/dialog.directive';

--- a/web/ui/dashboard/src/app/private/pages/project/subscriptions/subscriptions.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/subscriptions/subscriptions.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { ENDPOINT } from 'src/app/models/endpoint.model';
+import type { ENDPOINT } from 'src/app/models/endpoint.model';
 import { FILTER_QUERY_PARAM } from 'src/app/models/event.model';
 import { CURSOR, PAGINATION } from 'src/app/models/global.model';
 import { SUBSCRIPTION } from 'src/app/models/subscription';

--- a/web/ui/dashboard/src/app/private/pages/setup-project/setup-project.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/setup-project/setup-project.component.ts
@@ -10,7 +10,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { GeneralService } from 'src/app/services/general/general.service';
 import { ToggleComponent } from 'src/app/components/toggle/toggle.component';
 import { SOURCE } from 'src/app/models/source.model';
-import { ENDPOINT } from 'src/app/models/endpoint.model';
+import type { ENDPOINT } from 'src/app/models/endpoint.model';
 import { CreateSourceComponent } from '../../components/create-source/create-source.component';
 import { CreateSubscriptionComponent } from '../../components/create-subscription/create-subscription.component';
 import { CreateSubscriptionService } from '../../components/create-subscription/create-subscription.service';

--- a/web/ui/dashboard/src/app/private/private.service.ts
+++ b/web/ui/dashboard/src/app/private/private.service.ts
@@ -1,5 +1,5 @@
 import {EventEmitter, Injectable} from '@angular/core';
-import {ENDPOINT} from 'src/app/models/endpoint.model';
+import type {ENDPOINT} from 'src/app/models/endpoint.model';
 import {HTTP_RESPONSE} from 'src/app/models/global.model';
 import {HttpService} from 'src/app/services/http/http.service';
 import {FLIPT_API_RESPONSE} from '../models/flipt.model';


### PR DESCRIPTION
## Summary
- Staging never picked up #2844/#2845/#2846 because the image job has been failing: `ng build` errors on a value import of the types-only `endpoint.model` module (`export 'ENDPOINT' ... module has no exports`), `scripts/ui.sh` ignores that exit, and `upload-artifact` warns with no `dist`.
- Switch those imports to `import type`, fail `ui.sh` on `ng build` errors, and fail the image job when `dist` is missing.

## Test plan
- [x] Local `npm run build` in `web/ui/dashboard` produces dist (no ENDPOINT error)
- [ ] Image workflow Build UI uploads `dist-without-markdown`
- [ ] `getconvoy/convoy:main-<sha>` exists on Docker Hub
- [ ] Staging bump PR merges to `main-<sha>`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only import and CI/script hardening changes; no runtime API or security behavior changes beyond surfacing UI build failures earlier.
> 
> **Overview**
> Restores a reliable **dashboard UI build** in the Docker image pipeline by fixing how `endpoint.model` symbols are imported and by **failing fast** when the UI build or artifact upload does not produce `dist`.
> 
> Dashboard code that only used `ENDPOINT`, `SECRET`, `PORTAL_LINK`, and related symbols for typing now uses **`import type`** instead of value imports, so `ng build` no longer errors on a types-only module (`export 'ENDPOINT' ... module has no exports`).
> 
> **`scripts/ui.sh`** enables **`set -euo pipefail`** and initializes the build flag so **`npm run build` failures propagate** instead of being ignored. The **Build UI** workflow step sets **`if-no-files-found: error`** on `upload-artifact`, so a missing `web/ui/dashboard/dist` fails the job instead of uploading nothing and letting downstream image builds proceed broken.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a787cde204861e211d141209624f1c92458887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->