### PR TITLE
ci(build): Skip staging Hub bumps when the image is not getconvoy/convoy

### DIFF
--- a/.github/workflows/bump-convoy-cloud-staging.yml
+++ b/.github/workflows/bump-convoy-cloud-staging.yml
@@ -142,6 +142,22 @@ jobs:
             fi
           }
 
+          # Hub tags do not exist on GHCR. A 7-char private SHA can also
+          # resolve to a different public commit on frain-dev/convoy, so
+          # ancestry compare is not a substitute for this image check.
+          image=$(printf '%s\n' "$content" | python3 -c '
+          import re, sys
+          text = sys.stdin.read()
+          m = re.search(r"(?m)^(?!\s*#)\s*image: &image \"([^\"]+)\"\s*$", text)
+          print(m.group(1) if m else "")
+          ')
+          if [ "$image" != "getconvoy/convoy" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Staging image is ${image:-empty}, not getconvoy/convoy; skipping Hub bump."
+            close_this_bump_pr
+            exit 0
+          fi
+
           if [ "$current" = "$IMAGE_TAG" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Staging already at ${IMAGE_TAG}."


### PR DESCRIPTION
## Summary
- skip the automated staging tag bump when `image: &image` is not `getconvoy/convoy`
- a private GHCR image plus a public `main-<sha>` tag would 404 on pull
- ancestry compare on a 7-char sha is not a substitute; it can resolve to a different public commit

## Test plan
- [ ] dry-read staging values with `image: getconvoy/convoy` still proceeds to the tag rewrite
- [ ] dry-read staging values with `image: ghcr.io/frain-dev/convoy-private` skips and does not open a bump PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guard in the staging bump workflow; no runtime app or auth changes, with fail-open skip behavior when the image is not Docker Hub.
> 
> **Overview**
> The **Skip stale or no-op bumps** step in `bump-convoy-cloud-staging.yml` now reads the active `image: &image` anchor from convoy-cloud staging values **before** tag/ancestry checks.
> 
> If that image is not **`getconvoy/convoy`**, the workflow sets `skip=true`, logs why, closes any open bump PR for this run via `close_this_bump_pr`, and exits—so it no longer opens or chases Docker Hub `main-<sha>` bumps when staging points at GHCR or another registry.
> 
> Comments in the workflow note that Hub tags are not on GHCR and that a short SHA ancestry compare on the public repo is not a safe stand-in for this image gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 248cd314c8e0961d6e356950531083a9a032600e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->