### PR TITLE
feat(dashboard): rebuild the data plane panel around a verdict

### DIFF
--- a/database/postgres/data_plane_snapshot.go
+++ b/database/postgres/data_plane_snapshot.go
@@ -30,6 +30,13 @@ const (
 	DELETE FROM convoy.data_plane_snapshots
 	WHERE sampled_at < $1`
 
+	// Keyed on the primary key, so this removes one named row and never a range.
+	// Expiry above deletes by age and takes whatever matches; this one is a
+	// replica retracting itself, and the two must not be able to be confused.
+	deleteDataPlaneSnapshotSQL = `
+	DELETE FROM convoy.data_plane_snapshots
+	WHERE replica = $1`
+
 	// Ordered by replica so a page of replicas does not reshuffle between reads.
 	loadDataPlaneSnapshotsSQL = `
 	SELECT snapshot FROM convoy.data_plane_snapshots ORDER BY replica`
@@ -51,6 +58,33 @@ func (p *Postgres) PublishSnapshot(ctx context.Context, s dataplanestats.Snapsho
 		s.Replica, s.Mode, s.Running, s.SampledAt, payload)
 	if err != nil {
 		return fmt.Errorf("data plane snapshot: publish: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteSnapshot removes one replica's row. It is the counterpart to
+// PublishSnapshot for a plane that is stopping on purpose: the row goes when the
+// replica does, so a rolling restart updates the dashboard at once instead of
+// leaving a row for the whole expiry window. What is left behind afterwards is a
+// plane that did not get to say goodbye, which is the case worth looking at.
+//
+// The replica is the primary key, so at most one row goes. An empty one is
+// refused rather than run: it would match nothing today, but the guard is what
+// keeps a caller that lost its identity from being one column change away from a
+// delete with no subject. Expiry is the backstop for a row this did not remove;
+// there is none for a row it should not have.
+//
+// Removing a row that is already gone is not an error. The caller is a shutdown
+// path with nothing to do about it either way, and reporting it would only turn
+// a repeated stop into a logged failure.
+func (p *Postgres) DeleteSnapshot(ctx context.Context, replica string) error {
+	if replica == "" {
+		return fmt.Errorf("data plane snapshot: replica is required")
+	}
+
+	if _, err := p.GetDB().ExecContext(ctx, deleteDataPlaneSnapshotSQL, replica); err != nil {
+		return fmt.Errorf("data plane snapshot: delete: %w", err)
 	}
 
 	return nil

--- a/database/postgres/data_plane_snapshot_test.go
+++ b/database/postgres/data_plane_snapshot_test.go
@@ -170,3 +170,63 @@ func TestPublishSnapshotRejectsAnUnnamedReplica(t *testing.T) {
 
 	require.Error(t, store.PublishSnapshot(context.Background(), dataplanestats.Snapshot{Mode: "example"}))
 }
+
+// A replica leaving on purpose takes its own row and nothing else. The sibling
+// here is the case that matters: rows outlive their replica by a long expiry
+// window precisely so a crash stays visible, so a delete that reached one row
+// too far would erase that record and nobody would notice for as long as it
+// would have been on the page.
+func TestDeleteSnapshotRemovesOnlyTheNamedReplica(t *testing.T) {
+	store := snapshotStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.PublishSnapshot(ctx, dataplanestats.Snapshot{
+		Replica:   "pod-leaving",
+		Mode:      "example",
+		Running:   true,
+		SampledAt: time.Now(),
+	}))
+	require.NoError(t, store.PublishSnapshot(ctx, dataplanestats.Snapshot{
+		Replica:   "pod-crashed",
+		Mode:      "example",
+		SampledAt: time.Now().Add(-time.Minute),
+	}))
+
+	require.NoError(t, store.DeleteSnapshot(ctx, "pod-leaving"))
+
+	status, err := store.DataPlaneStatus(ctx, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, status.Replicas, 1)
+	require.Equal(t, "pod-crashed", status.Replicas[0].Replica,
+		"the row left behind is the one nothing retracted")
+
+	// Retracting twice is the steady state of a restart loop, and of a stop that
+	// followed a row already swept. It must stay quiet rather than turn a
+	// repeated shutdown into a logged failure.
+	require.NoError(t, store.DeleteSnapshot(ctx, "pod-leaving"))
+
+	status, err = store.DataPlaneStatus(ctx, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, status.Replicas, 1)
+}
+
+// The caller derives the replica from its own identity, so an empty one means it
+// lost that identity rather than that it wants every row gone. Expiry backstops
+// a row this refused; nothing backstops one it should not have taken.
+func TestDeleteSnapshotRejectsAnUnnamedReplica(t *testing.T) {
+	store := snapshotStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.PublishSnapshot(ctx, dataplanestats.Snapshot{
+		Replica:   "pod-live",
+		Mode:      "example",
+		Running:   true,
+		SampledAt: time.Now(),
+	}))
+
+	require.Error(t, store.DeleteSnapshot(ctx, ""))
+
+	status, err := store.DataPlaneStatus(ctx, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, status.Replicas, 1)
+}

--- a/database/postgres/postgres.go
+++ b/database/postgres/postgres.go
@@ -165,10 +165,22 @@ func noticeHandler(logger log.Logger, sink *noticeSink) pgconn.NoticeHandler {
 	}
 }
 
-func parseDBConfig(dbConfig config.DatabaseConfiguration, logger log.Logger, src ...string) (*Postgres, error) {
+// maxConnIdleTime is how long a pooled connection may sit idle before pgx
+// closes it. It is not tied to any configuration knob: an idle connection still
+// occupies a server slot, so every deployment needs it reaped whether or not it
+// tunes pool sizes. Leaving it unset falls back to the pgx default of 30
+// minutes, long enough for a finished load run to keep a whole max_connections
+// budget locked up.
+//
+// pgx enforces this from its health check rather than on a timer per
+// connection, so a connection is closed within one HealthCheckPeriod (one
+// minute by default) of crossing the threshold, not exactly on it.
+const maxConnIdleTime = 5 * time.Minute
+
+func buildPoolConfig(dbConfig config.DatabaseConfiguration, logger log.Logger, src ...string) (*pgxpool.Config, *noticeSink, error) {
 	pgxCfg, err := pgxpool.ParseConfig(dbConfig.BuildDsn())
 	if err != nil {
-		return nil, fmt.Errorf("failed to create %sconnection pool: %w", src, err)
+		return nil, nil, fmt.Errorf("failed to create %sconnection pool: %w", src, err)
 	}
 
 	// Bound the pool even when unset, so a replica cannot open connections until
@@ -178,15 +190,22 @@ func parseDBConfig(dbConfig config.DatabaseConfiguration, logger log.Logger, src
 		pkgLogger.Warn(fmt.Sprintf("[%s]: SetMaxOpenConnections not set or 0, using default: %d. Set CONVOY_DB_MAX_OPEN_CONN to override.", pkgName, maxConns))
 	}
 	pgxCfg.MaxConns = int32(maxConns)
-
-	if dbConfig.SetMaxIdleConnections > 0 {
-		pgxCfg.MaxConnIdleTime = time.Minute * 5
-	}
+	pgxCfg.MaxConnIdleTime = maxConnIdleTime
 
 	pgxCfg.MaxConnLifetime = time.Second * time.Duration(dbConfig.SetConnMaxLifetime)
 	pgxCfg.ConnConfig.Tracer = otelpgx.NewTracer(otelpgx.WithTrimSQLInSpanName())
 	sink := &noticeSink{}
 	pgxCfg.ConnConfig.OnNotice = noticeHandler(logger, sink)
+
+	return pgxCfg, sink, nil
+}
+
+func parseDBConfig(dbConfig config.DatabaseConfiguration, logger log.Logger, src ...string) (*Postgres, error) {
+	pgxCfg, sink, err := buildPoolConfig(dbConfig, logger, src...)
+	if err != nil {
+		return nil, err
+	}
+	maxConns := int(pgxCfg.MaxConns)
 
 	pool, err := pgxpool.NewWithConfig(context.Background(), pgxCfg)
 	if err != nil {

--- a/database/postgres/postgres_idle_reap_test.go
+++ b/database/postgres/postgres_idle_reap_test.go
@@ -1,0 +1,287 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+
+	"github.com/frain-dev/convoy/config"
+)
+
+// idleReapAppName isolates this test's backends from anything else using the
+// same database, so the counts below describe only the pool under test.
+const idleReapAppName = "convoy_idle_reap_test"
+
+// idleReapDBConfig points at a throwaway Postgres. TEST_DB_* is the same
+// convention the other integration tests in this package use.
+func idleReapDBConfig(t *testing.T) config.DatabaseConfiguration {
+	t.Helper()
+
+	port := 5432
+	if v := os.Getenv("TEST_DB_PORT"); v != "" {
+		p, err := strconv.Atoi(v)
+		require.NoError(t, err)
+		port = p
+	}
+
+	return config.DatabaseConfiguration{
+		Scheme:   envOrDefault("TEST_DB_SCHEME", "postgres"),
+		Host:     envOrDefault("TEST_DB_HOST", "localhost"),
+		Username: envOrDefault("TEST_DB_USERNAME", "convoy"),
+		Password: envOrDefault("TEST_DB_PASSWORD", "convoy"),
+		Database: envOrDefault("TEST_DB_DATABASE", "convoy"),
+		Port:     port,
+		Options:  "sslmode=disable&application_name=" + idleReapAppName,
+		// Carried from the compiled default in config.DefaultConfiguration.
+		// Zero is not "no limit" to pgx: it sets every connection's max age to
+		// its creation time, so the pool destroys each one on first use.
+		SetConnMaxLifetime: 3600,
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+// countBackends reports how many server-side connections this test's pool is
+// holding. It runs on its own short-lived connection so it never borrows from
+// the pool it is measuring, which would make an idle connection look busy.
+func countBackends(t *testing.T, dbCfg config.DatabaseConfiguration) int {
+	t.Helper()
+
+	ctrlCfg := dbCfg
+	ctrlCfg.Options = "sslmode=disable&application_name=" + idleReapAppName + "_ctrl"
+
+	pool, err := pgxpool.New(context.Background(), ctrlCfg.BuildDsn())
+	require.NoError(t, err)
+	defer pool.Close()
+
+	var n int
+	err = pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM pg_stat_activity WHERE application_name = $1`,
+		idleReapAppName).Scan(&n)
+	require.NoError(t, err)
+	return n
+}
+
+// waitForBackends polls until the pool has shed connections down to want, and
+// reports the last observed count on failure so a timeout says how far it got
+// rather than only that it expired.
+func waitForBackends(t *testing.T, dbCfg config.DatabaseConfiguration, want int, timeout time.Duration) int {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	last := -1
+	for time.Now().Before(deadline) {
+		last = countBackends(t, dbCfg)
+		if last <= want {
+			return last
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	t.Fatalf("pool still holding %d backends after %s, wanted <= %d", last, timeout, want)
+	return last
+}
+
+// TestPoolReapsIdleConnections proves the pool actually closes idle
+// connections, rather than only that MaxConnIdleTime was assigned. It builds the
+// pool through buildPoolConfig, the same path parseDBConfig uses, so the tracer,
+// notice handler and bounds under test are the shipped ones. Only the two
+// durations that decide how long reaping takes are compressed, because the
+// shipped MaxConnIdleTime is five minutes and the pgx health check that enforces
+// it runs once a minute.
+func TestPoolReapsIdleConnections(t *testing.T) {
+	dbCfg := idleReapDBConfig(t)
+	dbCfg.SetMaxOpenConnections = 20
+	// Left unset on purpose: this is the configuration that shipped broken, and
+	// the one the QA stack runs.
+	dbCfg.SetMaxIdleConnections = 0
+
+	pgxCfg, _, err := buildPoolConfig(dbCfg, &captureLogger{})
+	require.NoError(t, err)
+	require.Equal(t, maxConnIdleTime, pgxCfg.MaxConnIdleTime)
+
+	pgxCfg.MaxConnIdleTime = 2 * time.Second
+	pgxCfg.HealthCheckPeriod = 500 * time.Millisecond
+
+	pool, err := pgxpool.NewWithConfig(context.Background(), pgxCfg)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	require.Equal(t, 0, countBackends(t, dbCfg), "database must be quiet before the test opens anything")
+
+	const want = 15
+	expandPool(t, pool, want)
+
+	peak := countBackends(t, dbCfg)
+	require.GreaterOrEqual(t, peak, want, "pool should have opened the connections the test asked for")
+
+	got := waitForBackends(t, dbCfg, 0, 30*time.Second)
+	require.Zero(t, got, "every idle connection should have been reaped")
+	t.Logf("pgx pool: %d backends at peak, %d after idle reaping", peak, got)
+}
+
+// TestSqlxWrapperReapsIdleConnections covers the layer application code queries
+// through, which is the one that decides whether the fix actually returns slots
+// to the server. database/sql keeps its own free list of connections it has
+// already acquired from pgx, and pgx counts an acquired connection as in use, so
+// MaxConnIdleTime cannot reap anything sitting on that free list. The bound that
+// matters there is SetMaxIdleConns: connections beyond it are released back to
+// pgx as soon as a query finishes, and pgx then reaps them on the idle timeout.
+// This test pins how far the pool actually drains, so a later change to either
+// bound cannot quietly strand connections again.
+func TestSqlxWrapperReapsIdleConnections(t *testing.T) {
+	dbCfg := idleReapDBConfig(t)
+	dbCfg.SetMaxOpenConnections = 20
+	dbCfg.SetMaxIdleConnections = 0
+
+	pgxCfg, _, err := buildPoolConfig(dbCfg, &captureLogger{})
+	require.NoError(t, err)
+
+	pgxCfg.MaxConnIdleTime = 2 * time.Second
+	pgxCfg.HealthCheckPeriod = 500 * time.Millisecond
+
+	pool, err := pgxpool.NewWithConfig(context.Background(), pgxCfg)
+	require.NoError(t, err)
+	defer pool.Close()
+
+	db := sqlx.NewDb(stdlib.OpenDBFromPool(pool), "pgx")
+	defer func() {
+		require.NoError(t, db.Close())
+	}()
+
+	// Exactly what parseDBConfig applies to the wrapper, so the numbers below
+	// describe the shipped configuration and not a tuned-for-green one.
+	maxIdle := idleConnsFor(dbCfg.SetMaxOpenConnections)
+	db.SetMaxOpenConns(dbCfg.SetMaxOpenConnections)
+	db.SetMaxIdleConns(maxIdle)
+	db.SetConnMaxLifetime(time.Second * time.Duration(dbCfg.SetConnMaxLifetime))
+
+	require.Equal(t, 0, countBackends(t, dbCfg), "database must be quiet before the test opens anything")
+
+	const want = 15
+	expandSqlxPool(t, db, want)
+
+	peak := countBackends(t, dbCfg)
+	require.GreaterOrEqual(t, peak, want)
+
+	// The free list is what remains: pgx reaps everything the wrapper hands
+	// back, and holds the rest until SetConnMaxLifetime retires it.
+	got := waitForBackends(t, dbCfg, maxIdle, 30*time.Second)
+	require.LessOrEqual(t, got, maxIdle,
+		"everything above the sqlx free list should have been released to pgx and reaped")
+	t.Logf("sqlx wrapper (max idle %d): %d backends at peak, %d after idle reaping", maxIdle, peak, got)
+}
+
+// expandPool forces the pool to open n distinct connections by holding every
+// acquisition until the last one is in hand.
+func expandPool(t *testing.T, pool *pgxpool.Pool, n int) {
+	t.Helper()
+
+	ctx := context.Background()
+	conns := make([]*pgxpool.Conn, 0, n)
+	for i := 0; i < n; i++ {
+		c, err := pool.Acquire(ctx)
+		require.NoError(t, err)
+
+		var one int
+		require.NoError(t, c.QueryRow(ctx, "SELECT 1").Scan(&one))
+		conns = append(conns, c)
+	}
+	for _, c := range conns {
+		c.Release()
+	}
+}
+
+// expandSqlxPool does the same through database/sql. The queries run
+// concurrently because database/sql hands a single sequential caller the same
+// connection every time and the pool would never grow.
+func expandSqlxPool(t *testing.T, db *sqlx.DB, n int) {
+	t.Helper()
+
+	var wg sync.WaitGroup
+	release := make(chan struct{})
+	errs := make(chan error, n)
+
+	// Unblocks the holders on every exit, including the assertion failure
+	// below, which leaves the test goroutine without running the rest of this
+	// function.
+	var releaseOnce sync.Once
+	releaseAll := func() { releaseOnce.Do(func() { close(release) }) }
+	defer func() {
+		releaseAll()
+		wg.Wait()
+	}()
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			conn, err := db.Connx(context.Background())
+			if err != nil {
+				errs <- err
+				return
+			}
+			defer func() { _ = conn.Close() }()
+
+			var one int
+			if err = conn.QueryRowxContext(context.Background(), "SELECT 1").Scan(&one); err != nil {
+				errs <- err
+				return
+			}
+			<-release
+		}()
+	}
+
+	// Wait for every goroutine to be holding its own connection. This polls in
+	// the test goroutine rather than through require.Eventually, whose
+	// condition runs on its own goroutine where a failed assertion cannot fail
+	// the test. A stall here is usually a connection error rather than a slow
+	// pool, so surface that error: "never reached 15 open connections"
+	// describes the symptom and hides the cause.
+	deadline := time.Now().Add(20 * time.Second)
+	for db.Stats().OpenConnections < n {
+		select {
+		case err := <-errs:
+			require.NoError(t, err, "opening a connection failed while expanding the pool")
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sqlx pool reached only %d of %d open connections", db.Stats().OpenConnections, n)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	releaseAll()
+	wg.Wait()
+
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+// idleConnsFor mirrors the sqlx idle bound parseDBConfig derives when
+// max_idle_conn is unset, so the test exercises the shipped ratio.
+func idleConnsFor(maxOpen int) int {
+	idle := maxOpen / 4
+	if idle < 2 {
+		idle = 2
+	}
+	return idle
+}

--- a/database/postgres/postgres_pool_test.go
+++ b/database/postgres/postgres_pool_test.go
@@ -1,0 +1,88 @@
+package postgres
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/frain-dev/convoy/config"
+)
+
+func poolTestDBConfig() config.DatabaseConfiguration {
+	return config.DatabaseConfiguration{
+		Scheme:   "postgres",
+		Host:     "localhost",
+		Username: "convoy",
+		Password: "convoy",
+		Database: "convoy",
+		Port:     5432,
+		Options:  "sslmode=disable",
+	}
+}
+
+// TestBuildPoolConfigReapsIdleRegardlessOfMaxIdleConnections pins the bug this
+// package shipped with: MaxConnIdleTime used to be set only when
+// SetMaxIdleConnections was above zero, so a deployment that never tuned the
+// idle-connection count silently kept the pgx default of 30 minutes and held a
+// whole max_connections budget open long after a load run finished.
+func TestBuildPoolConfigReapsIdleRegardlessOfMaxIdleConnections(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxIdleConns int
+		maxOpenConns int
+		wantMaxConns int32
+	}{
+		{
+			name:         "max idle connections unset",
+			maxIdleConns: 0,
+			maxOpenConns: 40,
+			wantMaxConns: 40,
+		},
+		{
+			name:         "max idle connections negative",
+			maxIdleConns: -1,
+			maxOpenConns: 40,
+			wantMaxConns: 40,
+		},
+		{
+			name:         "max idle connections set",
+			maxIdleConns: 10,
+			maxOpenConns: 40,
+			wantMaxConns: 40,
+		},
+		{
+			name:         "both pool knobs unset",
+			maxIdleConns: 0,
+			maxOpenConns: 0,
+			wantMaxConns: config.DefaultMaxOpenConnections,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dbCfg := poolTestDBConfig()
+			dbCfg.SetMaxIdleConnections = tc.maxIdleConns
+			dbCfg.SetMaxOpenConnections = tc.maxOpenConns
+
+			pgxCfg, sink, err := buildPoolConfig(dbCfg, &captureLogger{})
+			require.NoError(t, err)
+			require.NotNil(t, sink)
+
+			require.Equal(t, maxConnIdleTime, pgxCfg.MaxConnIdleTime,
+				"idle connections must be reaped whether or not max_idle_conn is set")
+			require.Equal(t, tc.wantMaxConns, pgxCfg.MaxConns)
+		})
+	}
+}
+
+// TestBuildPoolConfigRejectsUnusableDSN keeps the error path returning a nil
+// config rather than a half-built one a caller could still hand to pgx.
+func TestBuildPoolConfigRejectsUnusableDSN(t *testing.T) {
+	dbCfg := poolTestDBConfig()
+	dbCfg.DSN = "://not-a-dsn"
+
+	pgxCfg, sink, err := buildPoolConfig(dbCfg, &captureLogger{})
+	require.Error(t, err)
+	require.Nil(t, pgxCfg)
+	require.Nil(t, sink)
+}

--- a/internal/pkg/dataplanestats/stats.go
+++ b/internal/pkg/dataplanestats/stats.go
@@ -46,13 +46,56 @@ type Snapshot struct {
 	Counters []Metric `json:"counters,omitempty"`
 
 	// Gauges are point-in-time values that are not stage or writer depth.
+	//
+	// This list and Counters above are read name by name, so absence applies to a
+	// name and not only to the list holding it. A present list is not a complete
+	// one: a publisher omits a name it has nothing to say about, so a consumer
+	// that defaults a missing name to zero reports a measurement the plane never
+	// made. The list being here says only that the plane published something,
+	// never that it published this.
+	//
+	// Where several names are one compound value, the publisher omits or sends
+	// them together, and a consumer missing any one of them must treat the whole
+	// value as unknown rather than fill the gap. A group every plane shares is
+	// named in this package and documents itself there; for a name belonging to
+	// one plane's own vocabulary the grouping cannot be told from here, and that
+	// publisher documents it.
+	//
+	// A name that is present with a value of 0 is the opposite of an absent one.
+	// It is a real reading of a plane that did none of that work, which is an
+	// answer an operator needs, so it renders as the number rather than as
+	// unknown.
 	Gauges []Metric `json:"gauges,omitempty"`
 
 	// Outstanding are the durable backlogs, which is the number an operator
 	// compares against a queue depth. Each carries its own known flag because
 	// these are the counts most likely to be unavailable.
 	Outstanding []Backlog `json:"outstanding,omitempty"`
+
+	// Throughput has no section of its own. A plane that measures an interval
+	// publishes it through Gauges, under names carrying the concept rather than
+	// its own vocabulary, which is what lets a queue-based plane publish the same
+	// fact. A plane with no previous reading to difference omits those gauges
+	// entirely: absence is the only encoding of "not measured", so there is no
+	// flag beside it that can disagree, and a consumer must render the absence as
+	// unknown rather than as a plane that moved nothing.
+	//
+	// The monotonic totals are Counters, which is what they already were.
 }
+
+// The gauge names a plane publishes its measured interval under. Named for the
+// concept rather than for any plane's own components, so a queue-based plane can
+// publish the same four and be read by the same consumer.
+//
+// A publisher emits all four or none. A consumer that finds only some of them
+// has no rate: a count without the window it covers is not a rate, and a window
+// without its counts is not a measurement.
+const (
+	GaugeThroughputWindowMS  = "throughput_window_ms"
+	GaugeThroughputAccepted  = "throughput_accepted"
+	GaugeThroughputDelivered = "throughput_delivered"
+	GaugeThroughputFailed    = "throughput_failed"
+)
 
 // Stage is one admission point. Queued is work already admitted; Waiting is
 // callers the stage is currently blocking, which is the saturation signal that
@@ -83,7 +126,11 @@ type Writer struct {
 	Failures int64  `json:"failures"`
 }
 
-// Metric is one named number.
+// Metric is one named number. The number carries no unit, so the name has to:
+// a publisher measuring a duration or an interval says so in the name
+// (`..._ms`), because a consumer cannot recover a unit it was never told and a
+// number whose unit is only knowable by reading the producer is how a reader
+// comes to divide milliseconds by seconds.
 type Metric struct {
 	Name  string `json:"name"`
 	Value int64  `json:"value"`
@@ -131,6 +178,13 @@ type Reporter interface {
 // Store keeps the snapshots replicas publish. The publishing process and the
 // process serving the dashboard are not the same one, which is why this crosses
 // the database rather than staying in memory.
+//
+// Deleting a named row is deliberately not here. api/types hands this interface
+// to the dashboard's read path, so a method on it is a method that surface
+// holds: putting the delete here is what would let a read one day remove the
+// evidence of a replica that stopped. A publisher that retracts its own row asks
+// its store for that capability directly, and a store without it is not broken,
+// because expiry removes the row anyway.
 type Store interface {
 	// PublishSnapshot replaces this replica's row.
 	PublishSnapshot(ctx context.Context, s Snapshot) error

--- a/internal/pkg/dataplanestats/stats_test.go
+++ b/internal/pkg/dataplanestats/stats_test.go
@@ -1,0 +1,79 @@
+package dataplanestats
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// The store keeps the snapshot as one JSON document and the handler renders the
+// decoded struct, so JSON is the whole path from publisher to browser. A plane
+// that measured no interval and a plane that moved nothing are different facts,
+// and this is the encode that has to keep them apart.
+//
+// A plane with no previous reading to difference omits the throughput gauges. An
+// omitted gauge list must not decode into a list of zeroes.
+func TestUnmeasuredIntervalPublishesNoThroughputGauges(t *testing.T) {
+	payload, err := json.Marshal(Snapshot{Replica: "agent-1", Running: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if strings.Contains(string(payload), "throughput") {
+		t.Fatalf("a snapshot with no measured interval must carry no throughput gauge, got %s", payload)
+	}
+
+	var decoded Snapshot
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(decoded.Gauges) != 0 {
+		t.Fatalf("absent gauges decoded as present, which reads as a plane that moved nothing: %+v", decoded.Gauges)
+	}
+}
+
+// A genuinely idle interval is reported, not omitted: all four gauges are there
+// and three of them are zero. Metric.Value has no omitempty, which is what makes
+// the zero survive, so this fails the moment it grows one.
+func TestIdleIntervalIsPublishedAsZero(t *testing.T) {
+	payload, err := json.Marshal(Snapshot{
+		Replica: "agent-1",
+		Running: true,
+		Gauges: []Metric{
+			{Name: GaugeThroughputWindowMS, Value: 4954},
+			{Name: GaugeThroughputAccepted, Value: 0},
+			{Name: GaugeThroughputDelivered, Value: 0},
+			{Name: GaugeThroughputFailed, Value: 0},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	if !strings.Contains(string(payload), `"value":0`) {
+		t.Fatalf("an idle interval must send its zeroes rather than omit them, got %s", payload)
+	}
+
+	var decoded Snapshot
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	values := map[string]int64{}
+	for _, gauge := range decoded.Gauges {
+		values[gauge.Name] = gauge.Value
+	}
+
+	// The window is what turns the counts into a rate, so it has to survive
+	// exactly: a sampler reports real elapsed milliseconds, not its period.
+	if values[GaugeThroughputWindowMS] != 4954 {
+		t.Fatalf("window length must survive the round trip exactly: %+v", decoded.Gauges)
+	}
+	if _, ok := values[GaugeThroughputAccepted]; !ok {
+		t.Fatal("a measured zero must arrive as a present zero, not as an absent gauge")
+	}
+	if values[GaugeThroughputAccepted] != 0 || values[GaugeThroughputDelivered] != 0 {
+		t.Fatalf("idle interval decoded as flow: %+v", decoded.Gauges)
+	}
+}

--- a/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.html
+++ b/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.html
@@ -1,0 +1,9 @@
+<!-- One interpolation of one getter. Every state this component knows about
+     resolves through the same chain of early returns, so the template cannot
+     paint two verdicts at once and cannot paint none: there is no @if here to
+     get the conditions wrong in. min-w-0 lets the sentence wrap instead of
+     widening the card past the viewport. -->
+<div class="flex items-start gap-8px min-w-0">
+  <span class="mt-8px w-8px h-8px rounded-full shrink-0" [class]="dotClass"></span>
+  <p class="font-heading font-medium text-[16px] leading-[24px] text-new.text-primary min-w-0 break-words">{{ sentence }}</p>
+</div>

--- a/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.spec.ts
+++ b/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.spec.ts
@@ -1,0 +1,293 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EngineFlow, EngineVerdict, EngineVerdictComponent, EngineWindow } from './engine-verdict.component';
+
+// One measured interval. 4954ms because an engine reports the real elapsed time
+// between its two readings rather than the period it was configured with.
+function measured(overrides: Partial<EngineWindow> = {}): EngineFlow {
+	return { measured: { windowMs: 4954, in: 0, out: 0, failed: 0, ...overrides } };
+}
+
+function verdict(overrides: Partial<EngineVerdict> = {}): EngineVerdict {
+	return {
+		accepting: true,
+		reporting: true,
+		sampledLabel: '2s ago',
+		flow: measured(),
+		outstanding: { known: true, value: 0 },
+		...overrides
+	};
+}
+
+describe('EngineVerdictComponent', () => {
+	let fixture: ComponentFixture<EngineVerdictComponent>;
+	let component: EngineVerdictComponent;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({ imports: [EngineVerdictComponent] }).compileComponents();
+
+		fixture = TestBed.createComponent(EngineVerdictComponent);
+		component = fixture.componentInstance;
+	});
+
+	afterEach(() => {
+		fixture.destroy();
+	});
+
+	// The component's own detector, not fixture.detectChanges: these tests move
+	// the input between passes on purpose, which is exactly what the fixture's
+	// verification pass exists to reject.
+	function render(input: EngineVerdict): string {
+		component.verdict = input;
+		fixture.changeDetectorRef.detectChanges();
+
+		return (fixture.nativeElement as HTMLElement).textContent?.trim() ?? '';
+	}
+
+	// The absences this component exists to keep apart from a zero, and from each
+	// other. An engine with no earlier sample has not said it is idle, an engine
+	// that restarted has not said it is idle, and an engine that measured a zero
+	// has. Each absence names its own cause, because every one of them is
+	// knowable and a sentence that just reported an absence read as a fault in
+	// the panel.
+	describe('unknown is never zero', () => {
+		it('names a first sample as the reason there is no interval', () => {
+			const text = render(verdict({ flow: { absence: 'starting' }, outstanding: { known: true, value: 84088 } }));
+
+			expect(component.state).toBe('starting');
+			expect(text).toBe('Measuring. No earlier sample from this engine to compare against, so there is no interval yet. Next sample carries one. 84,088 outstanding.');
+			expect(text).not.toContain('Idle');
+			expect(text).not.toContain('not reported');
+		});
+
+		it('names a restart as the reason, distinctly from a first sample', () => {
+			const text = render(verdict({ flow: { absence: 'restarted' }, outstanding: { known: true, value: 84088 } }));
+
+			expect(component.state).toBe('restarted');
+			expect(text).toBe('Measuring again. The engine restarted, so the interval spanning the restart was discarded. Next sample carries one. 84,088 outstanding.');
+			expect(text).not.toContain('No earlier sample');
+		});
+
+		// The one absence with no benign explanation, so it is the only one that
+		// still says the answer is unknown.
+		it('says a partly reported interval is unknown', () => {
+			const text = render(verdict({ flow: { absence: 'incomplete' }, outstanding: { known: false, value: 0 } }));
+
+			expect(component.state).toBe('incomplete');
+			expect(text).toBe('Throughput reported incompletely, so whether work is draining is unknown. Outstanding could not be read.');
+			expect(text).not.toContain('Idle');
+			expect(text).not.toContain('nothing outstanding');
+		});
+
+		// The one case that may claim idle, and only because both halves of the
+		// claim were actually read: a measured interval that moved nothing, and a
+		// backlog count that came back zero.
+		//
+		// The sentence says the interval was measured, because an engine that
+		// looked and found nothing is a different fact from an engine that has
+		// not looked, and on a deployment whose events never reach this engine
+		// this is the only place that difference is stated.
+		it('reports a measured zero as an engine that measured and found nothing', () => {
+			const text = render(verdict({ outstanding: { known: true, value: 0 } }));
+
+			expect(component.state).toBe('idle');
+			expect(text).toBe('Running and idle. It measured the last ~5s and accepted nothing, nothing outstanding. If work is arriving on this instance, it is not coming through this engine.');
+			// A measured zero is not a fault and must not be dressed as one.
+			expect(component.tone).toBe('ok');
+		});
+
+		// The panel cannot see the instance's ingest rate, so it cannot say
+		// traffic is bypassing this engine. It states its own reading and leaves
+		// the comparison to the reader.
+		it('does not assert that traffic is going elsewhere', () => {
+			const text = render(verdict({ outstanding: { known: true, value: 0 } }));
+
+			expect(text).toContain('If work is arriving');
+			expect(text).not.toContain('bypass');
+		});
+
+		// A measured zero next to a backlog nobody could read is not idle. The
+		// half that would justify "nothing outstanding" is missing.
+		it('does not call a measured zero idle when the backlog could not be read', () => {
+			const text = render(verdict({ outstanding: { known: false, value: 0 } }));
+
+			expect(component.state).toBe('holding');
+			expect(text).toContain('Nothing accepted and nothing completed in the last ~5s, outstanding could not be read.');
+			expect(text).not.toContain('Idle');
+		});
+	});
+
+	// in and out count different things: on the data plane, events arriving and
+	// deliveries completing, with one event fanning out to a delivery per
+	// matching subscription. A sentence pairing them as "1,240 in and 1,190 out"
+	// invites a subtraction whose answer means nothing, so both are named for
+	// what they count and neither is netted against the other.
+	it('names what each side counts rather than pairing them as one quantity', () => {
+		const text = render(
+			verdict({
+				flow: measured({ in: 1240, out: 1190 }),
+				outstanding: { known: true, value: 50 }
+			})
+		);
+
+		expect(component.state).toBe('draining');
+		expect(text).toBe('Draining. 1,240 accepted and 1,190 completed in the last ~5s, 50 outstanding.');
+	});
+
+	// Fanout makes out legitimately larger than in, which a netting sentence
+	// would have to report as an impossible surplus.
+	it('reports more completed than accepted without calling it a deficit', () => {
+		const text = render(
+			verdict({
+				flow: measured({ in: 3, out: 12 }),
+				outstanding: { known: true, value: 4 }
+			})
+		);
+
+		expect(component.state).toBe('draining');
+		expect(text).toBe('Draining. 3 accepted and 12 completed in the last ~5s, 4 outstanding.');
+		expect(text).not.toContain('more');
+	});
+
+	it('names failures inside a draining interval', () => {
+		const text = render(
+			verdict({
+				flow: measured({ in: 288, out: 287, failed: 30 }),
+				outstanding: { known: true, value: 583 }
+			})
+		);
+
+		// The three window counts stay together and the level stays apart, so the
+		// failures do not read as an explanation of the backlog beside them.
+		expect(text).toBe('Draining. 288 accepted, 287 completed and 30 failed in the last ~5s, 583 outstanding.');
+	});
+
+	// An engine may count more than one way of not completing in that number. The
+	// data plane sums deliveries it discarded without a send with deliveries that
+	// failed after one, because the window answers whether accepted work left the
+	// outstanding set and both of those do, so the sentence takes the word from
+	// the caller rather than naming the count after the narrower outcome.
+	it('lets the engine name what its failed count covers', () => {
+		const text = render(
+			verdict({
+				flow: measured({ in: 288, out: 287, failed: 30 }),
+				outstanding: { known: true, value: 583 },
+				failedWord: 'failed or discarded'
+			})
+		);
+
+		expect(text).toBe('Draining. 288 accepted, 287 completed and 30 failed or discarded in the last ~5s, 583 outstanding.');
+	});
+
+	// Completed nothing over the window against a backlog that is really there.
+	// This is the state that caused a false alarm: every one of those 1,200 can
+	// be a delivery whose next attempt is scheduled for later, which is a working
+	// engine, and nothing in this contract separates that from a stall. So the
+	// sentence reports what was measured and says what it cannot tell, rather
+	// than calling a healthy engine stuck.
+	it('reports an engine that completed nothing as an observation, not as a stall', () => {
+		const text = render(
+			verdict({
+				flow: measured({ in: 20, out: 0 }),
+				outstanding: { known: true, value: 1200 }
+			})
+		);
+
+		expect(component.state).toBe('holding');
+		expect(text).toBe('20 accepted and nothing completed in the last ~5s, 1,200 outstanding. Work waiting on a schedule is outstanding too, so read what that number is made of before taking this as held up.');
+		expect(text).not.toContain('Not draining');
+		expect(text).not.toContain('stuck');
+	});
+
+	// An amber dot is an assertion of its own. Painting one over a backlog of
+	// scheduled retries is the false alarm rendered in colour, so the state the
+	// sentence declines to judge is coloured as unjudged.
+	it('does not colour an unjudged backlog as a fault', () => {
+		render(verdict({ flow: measured({ in: 20, out: 0 }), outstanding: { known: true, value: 1200 } }));
+
+		expect(component.tone).toBe('unknown');
+	});
+
+	it('reports an engine that is up and not accepting', () => {
+		const text = render(verdict({ accepting: false, flow: measured({ in: 999, out: 999 }) }));
+
+		expect(component.state).toBe('stopped');
+		// Distinct in words from the engine that is running and measured a zero,
+		// which is the pair an operator most needs told apart.
+		expect(text).toBe('Not running. This engine is not accepting work, so nothing new is entering it.');
+		expect(text).not.toContain('It measured the last');
+		// The numbers beside a stopped engine describe a stop, so none of them
+		// may reach the sentence.
+		expect(text).not.toContain('999');
+	});
+
+	it('reports a stale sample as not reporting rather than as a rate', () => {
+		const text = render(
+			verdict({
+				reporting: false,
+				sampledLabel: '4m ago',
+				flow: measured({ in: 1240, out: 1190 }),
+				outstanding: { known: true, value: 50 }
+			})
+		);
+
+		expect(component.state).toBe('silent');
+		expect(text).toBe('Not reporting. Last sample 4m ago.');
+		expect(text).not.toContain('1,240');
+	});
+
+	// The engine names its own window, so a plane sampling every five seconds must
+	// not have its interval read aloud as a minute's worth of work. Marked
+	// approximate, because the engine reports elapsed time and 4954ms is not 5s.
+	it('names the window the engine actually sampled, as an approximation', () => {
+		expect(render(verdict({ flow: measured({ windowMs: 4954, in: 4, out: 4 }), outstanding: { known: true, value: 1 } }))).toContain('in the last ~5s');
+		expect(render(verdict({ flow: measured({ windowMs: 120000, in: 4, out: 4 }), outstanding: { known: true, value: 1 } }))).toContain('in the last ~2m');
+		expect(render(verdict({ flow: measured({ windowMs: 0, in: 4, out: 4 }), outstanding: { known: true, value: 1 } }))).toContain('in the last sample');
+	});
+
+	// One interpolation of one getter, so the DOM cannot hold two verdicts. This
+	// asserts the property rather than the implementation: whatever the state, the
+	// rendered text is exactly the one sentence.
+	it('paints exactly one sentence whatever the state', () => {
+		const cases: EngineVerdict[] = [
+			verdict({ accepting: false }),
+			verdict({ reporting: false }),
+			verdict({ flow: { absence: 'starting' } }),
+			verdict({ flow: { absence: 'restarted' } }),
+			verdict({ flow: { absence: 'incomplete' } }),
+			verdict(),
+			verdict({ flow: measured({ in: 1, out: 0 }), outstanding: { known: true, value: 9 } }),
+			verdict({ flow: measured({ in: 5, out: 5 }), outstanding: { known: true, value: 2 } })
+		];
+
+		const states = new Set<string>();
+		for (const input of cases) {
+			const text = render(input);
+			states.add(component.state);
+			expect(text).toBe(component.sentence);
+			expect(text.length).toBeGreaterThan(0);
+		}
+
+		expect(states.size).toBe(cases.length);
+	});
+
+	// A stop is a problem. An absence with a benign cause is not: the engine may
+	// be draining perfectly and simply have no window to prove it over yet, so
+	// the dot must not read as a fault while it waits.
+	it('colours a stop as a warning and an unmeasured interval as unknown, never as a fault', () => {
+		render(verdict({ accepting: false }));
+		expect(component.tone).toBe('warning');
+
+		render(verdict({ flow: { absence: 'starting' } }));
+		expect(component.tone).toBe('unknown');
+
+		render(verdict({ flow: { absence: 'restarted' } }));
+		expect(component.tone).toBe('unknown');
+
+		render(verdict({ flow: { absence: 'incomplete' } }));
+		expect(component.tone).toBe('unknown');
+
+		render(verdict({ flow: measured({ in: 5, out: 5 }), outstanding: { known: true, value: 2 } }));
+		expect(component.tone).toBe('ok');
+	});
+});

--- a/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.ts
+++ b/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.ts
@@ -1,0 +1,266 @@
+import { Component, Input } from '@angular/core';
+
+// One measured interval of an engine's flow, in the vocabulary of the question
+// an operator is asking: is accepted work draining, and if not, where is it
+// stuck. Every number is that interval alone, never a total and never a rate.
+//
+// in and out are counted at the two ends of the engine and are not the same
+// quantity measured twice: on the data plane one accepted event fans out to a
+// delivery per matching subscription, so out legitimately exceeds in. Nothing
+// here may be subtracted from anything else here, which is why this carries no
+// net and the sentence never states one.
+//
+// Both halves of Queue Monitoring can fill this. The data plane fills it from
+// the interval its publisher sampled; the queue fills it from pending, processed
+// and failed. Nothing here names a stage, a lane, a partition or a task, so
+// neither half can pull the sentence into its own vocabulary.
+export interface EngineWindow {
+	// How long the interval actually was, in milliseconds, as the engine measured
+	// it. The sentence names the window from this rather than assuming a minute.
+	windowMs: number;
+
+	in: number;
+	out: number;
+
+	// Work that left the engine without completing. It is named by the caller
+	// through failedWord, because an engine may count more than one way of not
+	// completing here: the data plane sums deliveries it discarded without a send
+	// with deliveries that failed after one, since the window answers whether
+	// accepted work left the outstanding set and both of those do.
+	failed: number;
+}
+
+// Why an engine has no measured interval. Every cause is benign and every one of
+// them is knowable, so the sentence names which rather than reporting an
+// unexplained absence: an operator told the panel could not measure yet waits a
+// few seconds, while one told nothing was reported goes looking for a fault.
+//
+// starting: no earlier reading to difference, which is the first sample after
+// the engine started.
+// restarted: a monotonic total came back lower, so the engine underneath
+// restarted and the interval spanning it was discarded.
+// incomplete: the engine sent part of an interval. A count without its window is
+// not a rate, so this is the one absence the panel cannot explain, and it is kept
+// separate rather than dressed up as one of the two benign causes above.
+export type EngineFlowAbsence = 'starting' | 'restarted' | 'incomplete';
+
+// An engine's flow: either the interval it measured, or the reason there is
+// none. One value rather than a window beside a flag, so there is no pair to
+// keep in agreement and no arrangement that says both.
+export type EngineFlow = { measured: EngineWindow; absence?: never } | { measured?: never; absence: EngineFlowAbsence };
+
+// A count and whether it was read. A backlog rendered as 0 because the query
+// timed out reads as an empty queue, which is the failure this whole screen
+// exists to surface.
+export interface EngineCount {
+	known: boolean;
+	value: number;
+}
+
+export interface EngineVerdict {
+	// False is the engine saying it is up and not taking work, which makes every
+	// number beside it describe a stop rather than a rate.
+	accepting: boolean;
+
+	// False when the engine's last sample is too old to answer for the present.
+	reporting: boolean;
+
+	// How long ago that sample was taken, already phrased by the caller ('4m
+	// ago'), because staleness is the one value read on the client and the caller
+	// is what knows the units it wants.
+	sampledLabel: string;
+
+	// The measured interval or the reason there is none. An absence is not a zero:
+	// an engine that could not measure has not told anyone it is idle.
+	flow: EngineFlow;
+
+	outstanding: EngineCount;
+
+	// What the window's failed count is called in the sentence. Defaults to the
+	// plain word for an engine whose count is only failures; an engine that sums
+	// more than one terminal outcome into it must say so here rather than let the
+	// sentence name it after the narrower one.
+	failedWord?: string;
+}
+
+// stopped: the engine says it is not accepting.
+// silent: its last sample is too old to describe the present.
+// starting, restarted, incomplete: no measured interval, named by cause.
+// idle, holding, draining: it published a measured interval.
+//
+// holding is not "stuck". An engine that completed nothing over one window with
+// work outstanding may be stalled, or every outstanding item may be a retry with
+// a due time in the future, which is future work on a schedule. This contract
+// carries nothing that separates those, so the state is named for what was
+// observed and the sentence points at the outstanding number rather than
+// interpreting it. The data plane does publish the age of its oldest waiting
+// retry and when the next one is due, and says so beside the count those belong
+// to; this sentence stays out of it because the queue engine has no equivalent,
+// and a verdict that firms up for one engine and not the other is how the two
+// halves of one tab drift into two languages.
+//
+// There is no growing state. A backlog rising would have to come from
+// subtracting out from in, which counts two different things, or from
+// differencing two of the client's own polls, which reports a restart as the
+// backlog falling. Outstanding is reported as the level it is instead.
+export type EngineVerdictState = 'stopped' | 'silent' | EngineFlowAbsence | 'idle' | 'holding' | 'draining';
+
+@Component({
+	selector: 'convoy-engine-verdict',
+	imports: [],
+	templateUrl: './engine-verdict.component.html'
+})
+export class EngineVerdictComponent {
+	@Input({ required: true }) verdict!: EngineVerdict;
+
+	// One sentence, resolved by one chain of early returns. The template has a
+	// single interpolation of it, so there is no arrangement of inputs that can
+	// paint two states at once or none: whichever branch answers first is the
+	// only text on the line.
+	get state(): EngineVerdictState {
+		const verdict = this.verdict;
+
+		// Ordered as the spec's table is. A publisher saying it is not accepting
+		// has made a definitive statement about itself; staleness is a fact about
+		// the sample, and it is reported beside this line rather than instead of it.
+		if (!verdict.accepting) return 'stopped';
+		if (!verdict.reporting) return 'silent';
+
+		const flow = verdict.flow;
+		if (flow.absence) return flow.absence;
+
+		const window = flow.measured;
+
+		// Idle is the only state allowed to claim nothing is outstanding, so it
+		// needs the backlog to have actually been read. A failure inside the window
+		// is movement, so it is not idle either.
+		if (!window.in && !window.out && !window.failed && verdict.outstanding.known && !verdict.outstanding.value) return 'idle';
+
+		// Nothing came out over the window while work is outstanding or the
+		// backlog could not be read. Reported as the observation it is: the
+		// sentence does not call this stuck, because a backlog of retries with
+		// future due times looks exactly like this and is healthy.
+		if (!window.out) return 'holding';
+
+		return 'draining';
+	}
+
+	// The two units are named in every sentence that states a count. In is work
+	// arriving and out is work completing, and on the data plane those are events
+	// and deliveries, so a sentence that said "288 in and 287 out" would invite a
+	// subtraction that fanout makes meaningless.
+	get sentence(): string {
+		const verdict = this.verdict;
+		const window = verdict.flow.measured;
+
+		switch (this.state) {
+			// Three different things an operator has to tell apart, and only one
+			// of them is a fault. This engine is up and refusing work; the next is
+			// up and its samples have stopped; idle below is up, measuring, and
+			// finding nothing to do. Rendering any two of them the same way is how
+			// a misconfiguration hides.
+			case 'stopped':
+				return 'Not running. This engine is not accepting work, so nothing new is entering it.';
+			case 'silent':
+				return `Not reporting. Last sample ${verdict.sampledLabel}.`;
+			// Both absences say what happened and what it means for the reader,
+			// and neither reads as a fault: an interval is coming, and until it
+			// arrives the engine may well be draining perfectly.
+			case 'starting':
+				return `Measuring. No earlier sample from this engine to compare against, so there is no interval yet. Next sample carries one. ${sentenceStart(this.outstandingClause())}.`;
+			case 'restarted':
+				return `Measuring again. The engine restarted, so the interval spanning the restart was discarded. Next sample carries one. ${sentenceStart(this.outstandingClause())}.`;
+			// The one absence with no benign explanation, kept apart from the two
+			// that have one rather than being softened into them.
+			case 'incomplete':
+				return `Throughput reported incompletely, so whether work is draining is unknown. ${sentenceStart(this.outstandingClause())}.`;
+			// A measured zero is a reading, not a gap, and the difference is the
+			// whole point: an engine that sampled an interval and found nothing is
+			// telling the operator that work is reaching Convoy some other way, or
+			// not at all. The last clause is conditional because this panel cannot
+			// see the instance's ingest rate and so cannot make the comparison
+			// itself.
+			case 'idle':
+				return `Running and idle. It measured the last ${this.window()} and accepted nothing, nothing outstanding. If work is arriving on this instance, it is not coming through this engine.`;
+			// The observation, then the reason it is not a conclusion. Reading
+			// this as a stall cost an operator twenty minutes on a plane that was
+			// working exactly as designed, so the sentence says outright what it
+			// cannot tell rather than leaving the reader to assume the worst.
+			case 'holding':
+				return `${window?.in ? `${engineCount(window.in)} accepted` : 'Nothing accepted'} and nothing completed in the last ${this.window()}${window?.failed ? `, ${engineCount(window.failed)} ${this.failedWord()}` : ''}, ${this.outstandingClause()}. Work waiting on a schedule is outstanding too, so read what that number is made of before taking this as held up.`;
+			default:
+				return `Draining. ${engineCount(window?.in ?? 0)} accepted${window?.failed ? `, ` : ' and '}${engineCount(window?.out ?? 0)} completed${window?.failed ? ` and ${engineCount(window.failed)} ${this.failedWord()}` : ''} in the last ${this.window()}, ${this.outstandingClause()}.`;
+		}
+	}
+
+	// A state that describes a stop is a problem, and everything the sentence
+	// cannot resolve is unknown. Colour never carries information the sentence
+	// does not already say, and it never asserts what the sentence declines to:
+	// an engine that has not measured an interval yet may be draining perfectly,
+	// and an engine holding a backlog of scheduled retries is doing its job. An
+	// amber dot on either is the false alarm, painted.
+	get tone(): 'ok' | 'warning' | 'unknown' {
+		switch (this.state) {
+			case 'stopped':
+			case 'silent':
+				return 'warning';
+			case 'starting':
+			case 'restarted':
+			case 'incomplete':
+			case 'holding':
+				return 'unknown';
+			default:
+				return 'ok';
+		}
+	}
+
+	get dotClass(): string {
+		if (this.tone === 'warning') return 'bg-warning-9';
+		if (this.tone === 'unknown') return 'bg-new.text-secondary';
+
+		return 'bg-success-9';
+	}
+
+	private outstandingClause(): string {
+		const outstanding = this.verdict.outstanding;
+
+		return outstanding.known ? `${engineCount(outstanding.value)} outstanding` : 'outstanding could not be read';
+	}
+
+	private window(): string {
+		return intervalWindowLabel(this.verdict.flow.measured?.windowMs ?? 0);
+	}
+
+	private failedWord(): string {
+		return this.verdict.failedWord ?? 'failed';
+	}
+}
+
+// The engine names its own window, because a plane sampling every five seconds
+// and one sampling every minute publish the same field. A publisher that sent no
+// window length gets the neutral phrasing rather than a made-up minute.
+//
+// Approximate on purpose, and marked as approximate. A sampler reports the real
+// elapsed time between its two readings, so a five second period arrives
+// anywhere from 4948 to 5008 ms: reading '4.948s' aloud teaches an operator
+// nothing, and reading '5s' claims an interval the engine never promised. The
+// tilde is what keeps the rounding from becoming a claim.
+export function intervalWindowLabel(milliseconds: number): string {
+	const seconds = Math.round(milliseconds / 1000);
+	if (milliseconds <= 0 || seconds <= 0) return 'sample';
+	if (seconds < 60) return `~${seconds}s`;
+
+	return `~${Math.round(seconds / 60)}m`;
+}
+
+// A fixed locale, because these are operator numbers read beside each other and
+// the grouping must not change with the browser's language. Exported so the
+// panels feeding this component group their own numbers identically: the verdict
+// sentence and the numbers under it are read as one paragraph.
+export function engineCount(value: number): string {
+	return value.toLocaleString('en-US');
+}
+
+function sentenceStart(clause: string): string {
+	return clause.charAt(0).toUpperCase() + clause.slice(1);
+}

--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.html
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.html
@@ -1,4 +1,4 @@
-<button type="button" class="relative flex flex-col items-stretch w-full group">
+<button type="button" class="relative flex flex-col items-stretch w-full group" [attr.aria-label]="ariaLabel || null">
   @if (withIcon) {
     <div>
       @if (img) {
@@ -15,6 +15,7 @@
     <ng-content select="[tooltipToggle]"></ng-content>
   </div>
   <div
+    data-tooltip-body
 		class="
 			absolute
 			opacity-0

--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.ts
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.ts
@@ -17,6 +17,14 @@ export class TooltipComponent implements OnInit {
 	@Input('type') type: 'primary' | 'white' = 'white';
 	@Input('className') class!: string;
 
+	// The tooltip body only appears on hover and focus, so a value whose whole
+	// explanation lives in there is unreadable to a screen reader and on touch.
+	// Callers whose toggle is not self-explanatory, a bare dash standing in for a
+	// value that could not be read, pass the same text here. Left unset the
+	// button keeps the name the browser computes from its contents, so existing
+	// callers are unchanged.
+	@Input('ariaLabel') ariaLabel = '';
+
 	constructor() {}
 
 	ngOnInit(): void {}

--- a/web/ui/dashboard/src/app/private/pages/admin/organisation-overrides/organisation-overrides.component.html
+++ b/web/ui/dashboard/src/app/private/pages/admin/organisation-overrides/organisation-overrides.component.html
@@ -25,7 +25,7 @@
     <div class="mb-16px">
       <label convoy-label>Overrides for: {{ selectedOrganisation.name }}</label>
     </div>
-    @if (featureFlags.length === 0) {
+    @if (featureFlagsKnown && featureFlags.length === 0) {
       <div class="p-24px bg-new.surface-muted rounded-8px border border-new.border">
         <p class="font-body font-normal text-[14px] text-new.text-secondary">No feature flags available</p>
       </div>

--- a/web/ui/dashboard/src/app/private/pages/admin/organisation-overrides/organisation-overrides.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/organisation-overrides/organisation-overrides.component.spec.ts
@@ -1,0 +1,122 @@
+import { CommonModule } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+
+import { CardComponent } from 'src/app/components/card/card.component';
+import { LabelComponent } from 'src/app/components/input/input.component';
+import { SelectComponent } from 'src/app/components/select/select.component';
+import { TagComponent } from 'src/app/components/tag/tag.component';
+import { ToggleComponent } from 'src/app/components/toggle/toggle.component';
+import { GeneralService } from 'src/app/services/general/general.service';
+
+import { LoaderModule } from '../../../components/loader/loader.module';
+import { AdminService } from '../admin.service';
+import { OrganisationOverridesComponent } from './organisation-overrides.component';
+
+const EMPTY_COPY = 'No feature flags available';
+
+describe('OrganisationOverridesComponent', () => {
+	let fixture: ComponentFixture<OrganisationOverridesComponent>;
+	let component: OrganisationOverridesComponent;
+	let answerFlags!: (flags: unknown[]) => void;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [OrganisationOverridesComponent],
+			imports: [CommonModule, ReactiveFormsModule, CardComponent, SelectComponent, ToggleComponent, TagComponent, LabelComponent, LoaderModule],
+			providers: [
+				{
+					provide: AdminService,
+					useValue: {
+						// The flag read is held open and the overrides read answers at
+						// once. That is the real ordering this panel has to survive:
+						// selecting an organisation reveals the list before the flags
+						// behind it are known.
+						getAllFeatureFlags: () => new Promise(resolve => (answerFlags = flags => resolve({ data: flags }))),
+						getAllOrganisations: () => Promise.resolve({ data: { content: [{ uid: 'org-1', name: 'Acme' }] } }),
+						getOrganisationOverrides: () => Promise.resolve({ data: [] })
+					}
+				},
+				{ provide: GeneralService, useValue: { showNotification: () => {} } }
+			]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(OrganisationOverridesComponent);
+		component = fixture.componentInstance;
+
+		// The first pass runs ngOnInit, so ngOnInit is never called by hand here:
+		// a second call would start a second pair of reads and overwrite the
+		// resolver the test is holding.
+		fixture.detectChanges();
+	});
+
+	afterEach(() => {
+		fixture.destroy();
+	});
+
+	// The component's own detector, not fixture.detectChanges: these tests move
+	// state between passes on purpose, which is what the fixture's verification
+	// pass exists to reject.
+	function paint() {
+		fixture.changeDetectorRef.detectChanges();
+	}
+
+	function text(): string {
+		return (fixture.nativeElement as HTMLElement).textContent ?? '';
+	}
+
+	async function settle() {
+		for (let turn = 0; turn < 5; turn++) await Promise.resolve();
+	}
+
+	// Selected through the component rather than assigned, so the overrides read
+	// runs the way it does for an operator picking from the dropdown.
+	async function selectOrganisation() {
+		await component.selectOrganisation({ uid: 'org-1', name: 'Acme' });
+		await settle();
+	}
+
+	it('does not claim the instance has no feature flags while the flag read is in flight', async () => {
+		await selectOrganisation();
+
+		paint();
+
+		expect(text()).not.toContain(EMPTY_COPY);
+	});
+
+	it('claims it once the flag read answers with nothing', async () => {
+		await selectOrganisation();
+		answerFlags([]);
+		await settle();
+
+		paint();
+
+		expect(text()).toContain(EMPTY_COPY);
+	});
+
+	it('never claims it once the flag read answers with a flag', async () => {
+		await selectOrganisation();
+		answerFlags([{ uid: 'flag-1', feature_key: 'ip-rules', enabled: true, allow_override: true }]);
+		await settle();
+
+		paint();
+
+		expect(text()).not.toContain(EMPTY_COPY);
+		expect(text()).toContain('IP Rules');
+	});
+
+	// A later read must answer for the present. Leaving the flag set would let a
+	// finished read speak for one that has only just started.
+	it('stops claiming anything while a re-read is in flight', async () => {
+		await selectOrganisation();
+		answerFlags([]);
+		await settle();
+
+		component.loadFeatureFlags();
+		await settle();
+
+		paint();
+
+		expect(text()).not.toContain(EMPTY_COPY);
+	});
+});

--- a/web/ui/dashboard/src/app/private/pages/admin/organisation-overrides/organisation-overrides.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/organisation-overrides/organisation-overrides.component.ts
@@ -44,6 +44,12 @@ export class OrganisationOverridesComponent implements OnInit {
 	selectedOrganisation: Organisation | null = null;
 	organisationOverrides: Map<string, FeatureFlagOverride> = new Map();
 	isLoadingFeatureFlags = false;
+	// Whether the feature flag read has answered. "No feature flags available" is
+	// a definitive claim about the instance, and the overrides read that reveals
+	// this panel can land first: gating the message on the empty list alone
+	// states it while the flag read is still in flight. Cleared at the start of
+	// every read so a later one cannot be answered by an earlier verdict.
+	featureFlagsKnown = false;
 	isLoadingOrganisations = false;
 	isLoadingOverrides = false;
 	isUpdatingOverride = false;
@@ -67,6 +73,7 @@ export class OrganisationOverridesComponent implements OnInit {
 
 	async loadFeatureFlags() {
 		this.isLoadingFeatureFlags = true;
+		this.featureFlagsKnown = false;
 		try {
 			const response = await this.adminService.getAllFeatureFlags();
 			const allFlags: FeatureFlag[] = response.data || [];
@@ -79,6 +86,10 @@ export class OrganisationOverridesComponent implements OnInit {
 			console.error('Error loading feature flags:', error);
 			this.generalService.showNotification({ style: 'error', message: 'Failed to load feature flags' });
 		} finally {
+			// Set on the failure path too, because this page already answers a
+			// failed read with the empty state. That policy is unchanged here; the
+			// only thing this flag adds is that the answer waits for the read.
+			this.featureFlagsKnown = true;
 			this.isLoadingFeatureFlags = false;
 		}
 	}

--- a/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.html
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.html
@@ -5,7 +5,7 @@
 
 <div class="h-[1px] w-full bg-new.border mb-20px"></div>
 
-@if (!hasRetentionLicense) {
+@if (licenseKnown && !hasRetentionLicense) {
   <div class="bg-white-100 border border-new.border rounded-12px p-20px">
     <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Partitioning requires a license key. Contact support to enable it on this instance.</p>
   </div>

--- a/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.spec.ts
@@ -185,3 +185,80 @@ describe('TablePartitionsComponent', () => {
 		expect(component.conversionRuns.length).toBe(0);
 	});
 });
+
+// Separate fixture: the suite above seeds the licence so it can reach the form,
+// which is the one thing these tests must not do. Here the licence read is held
+// open on purpose, because the flash happens in exactly that window.
+describe('TablePartitionsComponent license gate', () => {
+	const UNLICENSED_COPY = 'Partitioning requires a license key';
+
+	let fixture: ComponentFixture<TablePartitionsComponent>;
+	let licensed: boolean;
+	let answerLicense!: () => void;
+
+	beforeEach(async () => {
+		licensed = true;
+
+		await TestBed.configureTestingModule({
+			declarations: [TablePartitionsComponent, RunCardComponent],
+			imports: [CommonModule, ReactiveFormsModule, SelectComponent, TagComponent, StatusColorModule, LabelComponent, InputFieldDirective, InputErrorComponent, InputDirective],
+			providers: [
+				{
+					provide: AdminService,
+					useValue: {
+						listPartitionTables: () => new Promise(() => {}),
+						listPartitionRuns: () => new Promise(() => {}),
+						startPartitionRun: () => new Promise(() => {})
+					}
+				},
+				{ provide: GeneralService, useValue: { showNotification: () => {} } },
+				{
+					provide: LicensesService,
+					useValue: {
+						loadAllLicenses: () => new Promise<void>(resolve => (answerLicense = resolve)),
+						hasInstanceLicense: () => licensed
+					}
+				}
+			]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(TablePartitionsComponent);
+	});
+
+	function rendered(): string {
+		return fixture.nativeElement.textContent as string;
+	}
+
+	// Drains the microtask queue so the awaits inside ngOnInit run to
+	// completion, without a timer or a second fetch getting a turn.
+	async function settle() {
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+	}
+
+	it('does not claim the instance is unlicensed while the license read is in flight', () => {
+		fixture.detectChanges();
+
+		expect(rendered()).not.toContain(UNLICENSED_COPY);
+	});
+
+	it('claims the instance is unlicensed once the license read answers no', async () => {
+		licensed = false;
+		fixture.detectChanges();
+
+		answerLicense();
+		await settle();
+		fixture.changeDetectorRef.detectChanges();
+
+		expect(rendered()).toContain(UNLICENSED_COPY);
+	});
+
+	it('never claims the instance is unlicensed when the license read answers yes', async () => {
+		fixture.detectChanges();
+
+		answerLicense();
+		await settle();
+		fixture.changeDetectorRef.detectChanges();
+
+		expect(rendered()).not.toContain(UNLICENSED_COPY);
+	});
+});

--- a/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/admin/table-partitions/table-partitions.component.ts
@@ -61,6 +61,11 @@ export class TablePartitionsComponent implements OnInit, OnDestroy {
 	isStarting = false;
 	isLoadingRuns = false;
 	hasRetentionLicense = false;
+	// Whether the license read has been attempted, not that it succeeded:
+	// loadAllLicenses swallows transport errors, so a failed read falls back to
+	// the cache and reads as unlicensed on a cold one. What it buys is that
+	// "requires a license key" waits for the read, not the initial false.
+	licenseKnown = false;
 
 	private pollInterval: any;
 	private tableChanges: Subscription;
@@ -133,6 +138,7 @@ export class TablePartitionsComponent implements OnInit, OnDestroy {
 		// deployment licenser alone, same as the CLI, and partitioning is an
 		// instance-wide operation like queue monitoring.
 		this.hasRetentionLicense = this.licenseService.hasInstanceLicense('RetentionPolicy');
+		this.licenseKnown = true;
 		if (!this.hasRetentionLicense) return;
 
 		await this.loadTableStates();

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-asynqmon.component.html
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-asynqmon.component.html
@@ -1,4 +1,4 @@
-@if (!hasAsynqLicense()) {
+@if (licenseKnown && !hasAsynqLicense()) {
   <div class="p-20px border border-warning-100 bg-warning-a3 rounded-12px mb-16px">
     <p class="font-body font-normal text-[14px] leading-normal text-new.text-primary">Your license does not include Asynq monitoring.</p>
   </div>
@@ -13,7 +13,7 @@
   <div class="qm-layout" [class.qm-layout--fullscreen]="iframeFullscreen && iframeVisible">
     <div class="qm-card bg-white-100 border border-new.border rounded-12px p-0 overflow-hidden flex flex-col">
       <div class="qm-main">
-        @if (sessionStatus === 'minting' && !iframeVisible) {
+        @if ((isLoadingSession || sessionStatus === 'minting') && !iframeVisible) {
           <div class="qm-loading">
             <convoy-loader position="relative"></convoy-loader>
           </div>
@@ -36,7 +36,7 @@
           >
           {{ iframeFullscreen ? 'Exit Fullscreen' : 'Expand Fullscreen' }}
         </button>
-        <button type="button" class="px-12px py-8px rounded-full bg-new.primary-400 font-body font-medium text-[13px] leading-[16px] text-white-100 transition-all hover:opacity-90 disabled:opacity-50 disabled:pointer-events-none" [disabled]="sessionStatus === 'minting'" (click)="mintSessionAndLoad()">
+        <button type="button" class="px-12px py-8px rounded-full bg-new.primary-400 font-body font-medium text-[13px] leading-[16px] text-white-100 transition-all hover:opacity-90 disabled:opacity-50 disabled:pointer-events-none" [disabled]="isLoadingSession || sessionStatus === 'minting'" (click)="mintSessionAndLoad()">
           {{ sessionStatus === 'minting' ? 'Refreshing…' : sessionStatus === 'ready' ? 'Refresh' : 'Retry' }}
         </button>
       </div>

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-asynqmon.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-asynqmon.component.spec.ts
@@ -1,0 +1,165 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+
+import { HttpService } from 'src/app/services/http/http.service';
+import { LicensesService } from 'src/app/services/licenses/licenses.service';
+import { RbacService } from 'src/app/services/rbac/rbac.service';
+
+import { QueueMonitoringAsynqmonComponent } from './queue-monitoring-asynqmon.component';
+
+const UNLICENSED_COPY = 'Your license does not include Asynq monitoring';
+
+describe('QueueMonitoringAsynqmonComponent', () => {
+	let fixture: ComponentFixture<QueueMonitoringAsynqmonComponent>;
+	let licensed: boolean;
+	let answerRole!: () => void;
+	let answerLicenses!: () => void;
+
+	beforeEach(async () => {
+		licensed = false;
+
+		await TestBed.configureTestingModule({
+			imports: [QueueMonitoringAsynqmonComponent],
+			providers: [
+				{
+					provide: LicensesService,
+					useValue: {
+						// Held open so a test can paint the page while the read is
+						// still in flight. hasInstanceLicense answers off a cache this
+						// component refreshes first, so that window is every visit.
+						loadAllLicenses: () => new Promise<void>(resolve => (answerLicenses = resolve as () => void)),
+						hasInstanceLicense: () => licensed
+					}
+				},
+				{ provide: RbacService, useValue: { getUserRole: () => new Promise(resolve => (answerRole = () => resolve('INSTANCE_ADMIN'))) } },
+				// No token, so the licensed path stops at the session mint instead of
+				// reaching for the network. The banner is the subject here, not the
+				// iframe behind it.
+				{ provide: HttpService, useValue: { authDetails: () => null } },
+				{ provide: Router, useValue: { navigateByUrl: () => {} } }
+			]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(QueueMonitoringAsynqmonComponent);
+
+		// The first pass runs ngOnInit, so ngOnInit is never called by hand here:
+		// a second call would start a second pair of reads and overwrite the
+		// resolvers the test is holding.
+		fixture.detectChanges();
+	});
+
+	afterEach(() => {
+		fixture.destroy();
+	});
+
+	// The component's own detector, not fixture.detectChanges: these tests move
+	// state between passes on purpose, which is what the fixture's verification
+	// pass exists to reject.
+	function paint() {
+		fixture.changeDetectorRef.detectChanges();
+	}
+
+	function text(): string {
+		return (fixture.nativeElement as HTMLElement).textContent ?? '';
+	}
+
+	function loader(): Element | null {
+		return (fixture.nativeElement as HTMLElement).querySelector('convoy-loader');
+	}
+
+	// Found by copy rather than position: the footer's other button is the
+	// fullscreen toggle, which has its own disabled rule.
+	function refreshButton(): HTMLButtonElement | undefined {
+		const buttons = Array.from((fixture.nativeElement as HTMLElement).querySelectorAll('button'));
+		return buttons.find(button => /Retry|Refresh/.test(button.textContent ?? ''));
+	}
+
+	async function settle() {
+		for (let turn = 0; turn < 5; turn++) await Promise.resolve();
+	}
+
+	it('does not claim the license excludes monitoring before the role read lands', () => {
+		paint();
+
+		expect(text()).not.toContain(UNLICENSED_COPY);
+	});
+
+	it('does not claim it while the license read is in flight', async () => {
+		answerRole();
+		await settle();
+
+		paint();
+
+		expect(text()).not.toContain(UNLICENSED_COPY);
+	});
+
+	it('claims it once the license read answers that monitoring is excluded', async () => {
+		answerRole();
+		await settle();
+		answerLicenses();
+		await settle();
+
+		paint();
+
+		expect(text()).toContain(UNLICENSED_COPY);
+	});
+
+	it('never claims it when the license includes monitoring', async () => {
+		licensed = true;
+
+		answerRole();
+		await settle();
+		answerLicenses();
+		await settle();
+
+		paint();
+
+		expect(text()).not.toContain(UNLICENSED_COPY);
+	});
+
+	// This page only mounts under the parent's licensed gate, so the cache it
+	// reads is already warm and the card is on screen from the first pass. Its
+	// body is what has nothing in it until the mint starts.
+	it('shows a loader in the card while the reads before the mint are in flight', () => {
+		licensed = true;
+
+		paint();
+
+		expect(loader()).not.toBeNull();
+	});
+
+	// A click here mints a session that ngOnInit's own mint then discards, so the
+	// control has to stay dead for as long as the loader is up.
+	it('keeps the refresh button disabled while that loader is up', () => {
+		licensed = true;
+
+		paint();
+
+		expect(refreshButton()?.disabled).toBeTrue();
+	});
+
+	it('drops the loader once the reads resolve and the mint reports', async () => {
+		licensed = true;
+
+		answerRole();
+		await settle();
+		answerLicenses();
+		await settle();
+
+		paint();
+
+		expect(loader()).toBeNull();
+	});
+
+	it('shows no loader once the license read answers that monitoring is excluded', async () => {
+		answerRole();
+		await settle();
+		answerLicenses();
+		await settle();
+
+		paint();
+
+		expect(loader()).toBeNull();
+		expect(text()).toContain(UNLICENSED_COPY);
+	});
+});

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-asynqmon.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-asynqmon.component.ts
@@ -21,6 +21,19 @@ export class QueueMonitoringAsynqmonComponent implements OnInit {
 	/** Iframe loads here (session cookie path matches this prefix only). */
 	embedMonitoringUrl = '';
 
+	// Whether the license read has been attempted, not that it succeeded:
+	// loadAllLicenses swallows transport errors, so a failed read falls back to
+	// the cache and reads as unlicensed on a cold one. What it buys is that the
+	// "does not include Asynq monitoring" claim waits for the read.
+	licenseKnown = false;
+
+	// True while the reads before the session mint are in flight. sessionStatus
+	// cannot cover that window: it is still 'idle' until mintSessionAndLoad runs,
+	// which leaves the card body empty for the same reads the parent page shows a
+	// loader for. Cleared on the non-admin return too, so a navigation that does
+	// not complete cannot leave a spinner with nothing behind it.
+	isLoadingSession = true;
+
 	sessionStatus: 'idle' | 'minting' | 'ready' | 'error' = 'idle';
 	sessionError: string | null = null;
 	iframeVisible = false;
@@ -38,6 +51,7 @@ export class QueueMonitoringAsynqmonComponent implements OnInit {
 	async ngOnInit(): Promise<void> {
 		const role = await this.rbacService.getUserRole();
 		if (role !== 'INSTANCE_ADMIN') {
+			this.isLoadingSession = false;
 			this.router.navigateByUrl('/');
 			return;
 		}
@@ -47,6 +61,10 @@ export class QueueMonitoringAsynqmonComponent implements OnInit {
 		this.loadFullscreenPreference();
 
 		await this.licenses.loadAllLicenses();
+		this.licenseKnown = true;
+		// mintSessionAndLoad sets sessionStatus before its first await, so the
+		// loader hands over to 'minting' without a pass in between.
+		this.isLoadingSession = false;
 
 		if (this.hasAsynqLicense()) {
 			await this.mintSessionAndLoad();

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.html
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.html
@@ -1,6 +1,7 @@
 <!-- Only a read that found replicas, or one that failed, puts anything on the
-     page. Everything else is a deployment with no plane to describe, and a
-     panel describing nothing reads as a plane that is idle.
+     page, and only while this is the segment on screen. Everything else is a
+     deployment with no plane to describe, and a panel describing nothing reads
+     as a plane that is idle.
 
      That covers three cases. 'hidden' is the server saying it wires no data
      plane monitoring. 'empty' is the read succeeding with no replicas, which a
@@ -10,12 +11,12 @@
      reload. 'loading' is the first paint, before any read has landed: showing a
      header and a spinner there would flash a panel onto every instance that
      turns out to have no plane at all, which is every instance today. -->
-@if (state === 'ready' || state === 'unknown') {
-  <div class="mb-24px">
-    <div class="flex items-start justify-between gap-16px mb-16px">
-      <div class="flex flex-col gap-4px">
+@if (active && (state === 'ready' || state === 'unknown')) {
+  <div class="mb-24px min-w-0">
+    <div class="flex items-start justify-between gap-16px mb-16px min-w-0">
+      <div class="flex flex-col gap-4px min-w-0">
         <h3 class="font-heading font-medium text-[18px] leading-[26px] text-new.text-primary">Data plane</h3>
-        <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">What each replica is holding right now, and how much accepted work is still outstanding in the database.</p>
+        <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Whether accepted work is draining, and where it is sitting if it is not.</p>
       </div>
       <button
         type="button"
@@ -37,141 +38,302 @@
     }
 
     @if (state === 'ready') {
-      <div class="flex flex-col gap-16px">
-        @for (replica of replicas; track replica.replica) {
-          <div class="bg-white-100 border border-new.border rounded-12px overflow-hidden">
-            <div class="flex items-center justify-between gap-12px flex-wrap px-20px py-16px border-b border-new.border">
-              <div class="flex items-center gap-8px flex-wrap">
-                <span class="font-menlo text-[13px] text-new.text-primary" [title]="replica.replica">{{ replica.replica }}</span>
-                @if (replica.mode) {
-                  <convoy-tag color="neutral" size="sm">{{ replica.mode }}</convoy-tag>
+      <div class="flex flex-col gap-16px min-w-0">
+        @for (row of rows; track row.replica.replica) {
+          <!-- No overflow on the card. The wide tables inside carry their own
+               overflow-x-auto wrapper, which is the only thing that has to
+               scroll, and clipping the whole card would cut off the tooltips on
+               the absent values: a clip is not a stacking question, so no
+               z-index can lift a tooltip out of a clipping ancestor. Same
+               structure as the endpoints table card. -->
+          <div class="bg-white-100 border border-new.border rounded-12px min-w-0">
+            <div class="flex items-center justify-between gap-12px flex-wrap px-20px py-16px border-b border-new.border min-w-0">
+              <div class="flex items-center gap-8px flex-wrap min-w-0">
+                <!-- The scope note sits on the identity because it is a fact
+                     about this replica rather than about any one number, and
+                     because a reader who has just found a card of zeros looks
+                     at the name at the top of it. -->
+                <div class="flex items-center min-w-0">
+                  <span class="font-menlo text-[13px] text-new.text-primary break-all min-w-0" [title]="row.replica.replica">{{ row.replica.replica }}</span>
+                  <!-- Anchored to the left edge of its own trigger, like the
+                       tooltips on the absent values below it: this one opens
+                       from the leftmost thing on the card, and a body that
+                       centres or right-anchors itself there starts off the left
+                       of the page. -->
+                  <convoy-tooltip size="sm" position="bottom" class="ml-4px" className="!min-w-[260px] !left-0 !translate-x-0" [ariaLabel]="replicaScope.aria">
+                    <p>{{ replicaScope.reason }}</p>
+                    <p class="mt-6px text-new.text-secondary">{{ replicaScope.detail }}</p>
+                  </convoy-tooltip>
+                </div>
+                @if (row.replica.mode) {
+                  <convoy-tag color="neutral" size="sm">{{ label(row.replica.mode) }}</convoy-tag>
                 }
-                @if (!replica.running) {
+                @if (!row.replica.running) {
                   <convoy-tag color="warning" size="sm">Not accepting</convoy-tag>
                 }
-                @if (replica.stale) {
+                @if (row.replica.stale) {
                   <convoy-tag color="warning" size="sm">Stale</convoy-tag>
                 }
               </div>
-              <span class="font-body font-normal text-[12px] leading-[16px] text-new.text-secondary whitespace-nowrap">Sampled {{ ageLabel(replica) }}</span>
+              <span class="font-body font-normal text-[12px] leading-[16px] text-new.text-secondary whitespace-nowrap">Sampled {{ ageLabel(row.replica) }}</span>
             </div>
 
-            @if (replica.stale) {
-              <p class="font-body font-normal text-[13px] leading-normal text-new.text-secondary px-20px py-12px border-b border-new.border">This replica stopped publishing. The numbers below describe {{ ageLabel(replica) }} and are not current.</p>
-            }
+            <!-- The five-second answer, and the only line here that has to be
+                 readable without knowing the architecture. -->
+            <div class="px-20px py-16px border-b border-new.border min-w-0">
+              <convoy-engine-verdict [verdict]="row.verdict"></convoy-engine-verdict>
 
-            <!-- Outstanding first: this is the durable backlog, the number that
-                 compares against a queue depth. Channel depth caps out and
-                 cannot represent it. -->
-            @if (replica.outstanding.length) {
-              <div class="px-20px py-16px border-b border-new.border">
-                <p class="font-heading font-medium text-[14px] leading-[20px] text-new.text-primary mb-12px">Outstanding</p>
-                <div class="flex flex-wrap gap-x-32px gap-y-12px">
-                  <!-- Tracked positionally, not by name: the plane chooses these
-                       names and two sharing one would be a duplicate key, which
-                       throws and takes the panel down. The list is replaced
-                       whole on every read, so position is the stable identity. -->
-                  @for (backlog of replica.outstanding; track $index) {
-                    <div class="flex flex-col gap-2px">
-                      <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary uppercase">{{ backlog.name }}</span>
-                      <span
-                        class="font-body font-normal text-[16px] leading-[24px]"
-                        [class]="backlog.known ? 'text-new.text-primary' : 'text-new.text-secondary italic'"
-                        [title]="backlog.known ? 'Read at ' + backlog.as_of : 'This count could not be read, so it is unknown and not zero'"
-                        >
-                        {{ backlogLabel(backlog) }}
-                      </span>
+              @if (row.replica.stale) {
+                <p class="font-body font-normal text-[13px] leading-normal text-new.text-secondary mt-8px">This replica stopped publishing. Everything below describes {{ ageLabel(row.replica) }} and is not current.</p>
+              }
+            </div>
+
+            <!-- In, Out, Outstanding. Nothing else at this level. -->
+            <div class="px-20px py-16px border-b border-new.border min-w-0">
+              <div class="flex flex-wrap gap-x-48px gap-y-16px">
+                @for (number of row.numbers; track number.label) {
+                  <div class="flex flex-col gap-2px min-w-0">
+                    <!-- Two explanations, two hover targets, never stacked on
+                         one: the label says what the metric means and is there
+                         whatever the value, the value below says why it is
+                         missing and only exists when it is. The icon beside the
+                         label is the dashboard's existing "explain this label"
+                         affordance, so the always-available one is the only one
+                         that advertises itself. -->
+                    <div class="flex items-center min-w-0">
+                      <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary">{{ number.label }}</span>
+                      <convoy-tooltip size="sm" position="top-right" class="ml-4px" className="!min-w-[240px]" [ariaLabel]="number.about.aria">
+                        <p>{{ number.about.reason }}</p>
+                        <p class="mt-6px text-new.text-secondary">{{ number.about.detail }}</p>
+                      </convoy-tooltip>
                     </div>
-                  }
-                </div>
-              </div>
-            }
-
-            @if (replica.stages.length) {
-              <div class="w-full overflow-x-auto border-b border-new.border">
-                <table class="w-full min-w-[640px] border-collapse">
-                  <thead>
-                    <tr class="bg-new.surface-subtle border-b border-new.border">
-                      <th class="text-left px-20px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Stage</th>
-                      <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Queued</th>
-                      <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Fullest lane</th>
-                      <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Lanes</th>
-                      <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Waiting</th>
-                      <th class="text-right px-20px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Workers</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    @for (stage of replica.stages; track $index) {
-                      <tr class="border-b border-new.border last:border-b-0">
-                        <td class="px-20px h-44px font-body font-medium text-[14px] leading-normal text-new.text-primary">{{ stage.name }}</td>
-                        <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ stage.queued }}</td>
-                        <!-- Queued alone cannot say whether one tenant is
-                             blocking everyone else, which is what the fullest
-                             lane against its capacity answers. -->
-                        <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-secondary whitespace-nowrap">{{ stage.deepest_partition }} / {{ stage.partition_capacity }}</td>
-                        <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-secondary">{{ stage.partitions }}</td>
-                        <!-- Blocked senders are the saturation signal that tells
-                             backpressure apart from an idle stage. -->
-                        <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal" [class]="stage.waiting ? 'text-error-9' : 'text-new.text-secondary'">{{ stage.waiting }}</td>
-                        <td class="px-20px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-secondary whitespace-nowrap">{{ workersLabel(stage) }}</td>
-                      </tr>
+                    @if (number.absent === null) {
+                      <span data-flow-value class="font-heading font-medium text-[20px] leading-[28px] text-new.text-primary">{{ number.value }}</span>
+                    } @else {
+                      <!-- A dash, the same glyph the dashboard's other no-data
+                           cells use, with the reason in the tooltip. The word
+                           printed under every label instead would make the
+                           quietest state the loudest thing on the panel, and it
+                           gets louder the more a plane omits. Anchored to the
+                           left edge of its own trigger rather than centred on
+                           it, so a 240px body opening from the first number in
+                           the row is not cut off at a phone width. -->
+                      <convoy-tooltip [withIcon]="false" position="bottom" className="!min-w-[240px] !left-0 !translate-x-0" [ariaLabel]="number.absent.aria">
+                        <p>{{ number.absent.reason }}</p>
+                        <p class="mt-6px text-new.text-secondary">{{ number.absent.detail }}</p>
+                        <span tooltipToggle data-flow-value class="font-heading font-medium text-[20px] leading-[28px] text-new.text-secondary">-</span>
+                      </convoy-tooltip>
                     }
-                  </tbody>
-                </table>
-              </div>
-            }
-
-            @if (replica.writers.length) {
-              <div class="w-full overflow-x-auto border-b border-new.border">
-                <table class="w-full min-w-[480px] border-collapse">
-                  <thead>
-                    <tr class="bg-new.surface-subtle border-b border-new.border">
-                      <th class="text-left px-20px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Writer</th>
-                      <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Pending</th>
-                      <th class="text-right px-20px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Failed batches</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    @for (writer of replica.writers; track $index) {
-                      <tr class="border-b border-new.border last:border-b-0">
-                        <td class="px-20px h-44px font-body font-medium text-[14px] leading-normal text-new.text-primary">{{ writer.name }}</td>
-                        <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ writer.pending }}</td>
-                        <td class="px-20px h-44px text-right font-body font-normal text-[14px] leading-normal" [class]="writer.failures ? 'text-error-9' : 'text-new.text-secondary'">{{ writer.failures }}</td>
-                      </tr>
+                    <!-- One line per fact about the number. The interval numbers
+                         name their window here; Outstanding names how old its
+                         oldest waiting retry is and when the next one is due. -->
+                    @for (note of number.notes; track $index) {
+                      <span class="font-body font-normal text-[12px] leading-[16px] text-new.text-secondary">{{ note }}</span>
                     }
-                  </tbody>
-                </table>
+                  </div>
+                }
+              </div>
+            </div>
+
+            <!-- Where items are sitting, stated as an observation. The heading
+                 used to say "Where it is stuck", which is a conclusion this
+                 section cannot reach: an item queued in a stage is an item
+                 queued in a stage. What the retry backlog is doing is said
+                 beside the count it belongs to, on Outstanding above. -->
+            @if (row.holding.length) {
+              <div class="px-20px py-16px border-b border-new.border min-w-0">
+                <p class="font-heading font-medium text-[14px] leading-[20px] text-new.text-primary mb-8px">Where work is sitting</p>
+                <ul class="flex flex-col gap-4px">
+                  <!-- Tracked positionally: two places can be named the same
+                       thing by a plane that names its own stages, and a
+                       duplicate key throws and takes the panel down. -->
+                  @for (line of row.holding; track $index) {
+                    <li class="font-body font-normal text-[14px] leading-normal text-new.text-primary break-words">{{ line }}</li>
+                  }
+                </ul>
               </div>
             }
 
-            @if (replica.gauges.length) {
-              <div class="px-20px py-16px border-b border-new.border">
-                <p class="font-heading font-medium text-[14px] leading-[20px] text-new.text-primary mb-12px">Current</p>
-                <div class="flex flex-wrap gap-x-32px gap-y-12px">
-                  @for (gauge of replica.gauges; track $index) {
-                    <div class="flex flex-col gap-2px">
-                      <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary uppercase">{{ gauge.name }}</span>
-                      <span class="font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ gauge.value }}</span>
-                    </div>
+            <!-- A separate section on purpose. These are totals across every
+                 endpoint the plane serves, so placing them under the backlog
+                 would suggest they explain it, and the last time the card did
+                 that the two numbers turned out to belong to different
+                 endpoints entirely. -->
+            @if (row.failures.length) {
+              <div class="px-20px py-16px border-b border-new.border min-w-0">
+                <p class="font-heading font-medium text-[14px] leading-[20px] text-new.text-primary mb-8px">Failures reported</p>
+                <ul class="flex flex-col gap-4px">
+                  @for (line of row.failures; track $index) {
+                    <li class="font-body font-normal text-[14px] leading-normal text-new.text-primary break-words">{{ line }}</li>
                   }
-                </div>
+                </ul>
+                <p class="font-body font-normal text-[12px] leading-[16px] text-new.text-secondary mt-8px">
+                  Counted across everything this plane serves, and not attributed to the work outstanding above. Discarded means the plane never sent it, so it never joined that backlog; failed means it was sent and did not succeed.
+                </p>
               </div>
             }
 
-            <!-- Totals for the life of this process, so they do not drop to zero
-                 on a quiet minute and do reset when the replica restarts. -->
-            @if (replica.counters.length) {
-              <div class="px-20px py-16px">
-                <p class="font-heading font-medium text-[14px] leading-[20px] text-new.text-primary mb-12px">Since this replica started</p>
-                <div class="flex flex-wrap gap-x-32px gap-y-12px">
-                  @for (counter of replica.counters; track $index) {
-                    <div class="flex flex-col gap-2px">
-                      <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary uppercase">{{ counter.name }}</span>
-                      <span class="font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ counter.value }}</span>
-                    </div>
-                  }
+            <!-- Everything that was on this panel before. Closed by default: it
+                 is opened by a reader who has decided the verdict is not
+                 enough. -->
+            <div class="px-20px py-12px min-w-0">
+              <button
+                type="button"
+                class="flex items-center gap-8px font-body font-medium text-[13px] leading-[20px] text-new.text-secondary transition-all hover:text-new.text-primary"
+                [attr.aria-expanded]="isOpen(row.replica.replica)"
+                (click)="toggleDiagnostics(row.replica.replica)"
+                >
+                <span>{{ isOpen(row.replica.replica) ? 'Hide diagnostics' : 'Show diagnostics' }}</span>
+              </button>
+            </div>
+
+            @if (isOpen(row.replica.replica)) {
+              @if (row.replica.outstanding.length) {
+                <div class="px-20px py-16px border-t border-new.border min-w-0">
+                  <p class="font-heading font-medium text-[14px] leading-[20px] text-new.text-primary mb-12px">Outstanding</p>
+                  <div class="flex flex-wrap gap-x-32px gap-y-12px">
+                    <!-- Tracked positionally, not by name: the plane chooses these
+                         names and two sharing one would be a duplicate key, which
+                         throws and takes the panel down. The list is replaced
+                         whole on every read, so position is the stable identity. -->
+                    @for (backlog of row.replica.outstanding; track $index) {
+                      <div class="flex flex-col gap-2px min-w-0">
+                        <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary">{{ label(backlog.name) }}</span>
+                        @if (backlog.known) {
+                          <span class="font-body font-normal text-[16px] leading-[24px] text-new.text-primary" [title]="'Read at ' + backlog.as_of">{{ backlogLabel(backlog) }}</span>
+                        } @else {
+                          <!-- Same convention as the numbers above, so one glyph
+                               covers every absent value on the panel. -->
+                          <convoy-tooltip [withIcon]="false" position="top" className="!min-w-[240px] !left-0 !translate-x-0" [ariaLabel]="backlogAria(backlog)">
+                            <p>{{ unreadCount.reason }}</p>
+                            <p class="mt-6px text-new.text-secondary">{{ unreadCount.detail }}</p>
+                            <span tooltipToggle class="font-body font-normal text-[16px] leading-[24px] text-new.text-secondary">{{ backlogLabel(backlog) }}</span>
+                          </convoy-tooltip>
+                        }
+                      </div>
+                    }
+                  </div>
                 </div>
+              }
+
+              @if (row.replica.stages.length) {
+                <div class="w-full overflow-x-auto border-t border-new.border">
+                  <table class="w-full min-w-[640px] border-collapse">
+                    <thead>
+                      <tr class="bg-new.surface-subtle border-b border-new.border">
+                        <th class="text-left px-20px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Stage</th>
+                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Queued</th>
+                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Fullest lane</th>
+                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Lanes</th>
+                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Waiting</th>
+                        <th class="text-right px-20px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Workers</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      @for (stage of row.replica.stages; track $index) {
+                        <tr class="border-b border-new.border last:border-b-0">
+                          <td class="px-20px h-44px font-body font-medium text-[14px] leading-normal text-new.text-primary">{{ label(stage.name) }}</td>
+                          <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ stage.queued }}</td>
+                          <!-- Queued alone cannot say whether one tenant is
+                               blocking everyone else, which is what the fullest
+                               lane against its capacity answers. -->
+                          <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-secondary whitespace-nowrap">{{ stage.deepest_partition }} / {{ stage.partition_capacity }}</td>
+                          <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-secondary">{{ stage.partitions }}</td>
+                          <!-- Blocked senders are the saturation signal that tells
+                               backpressure apart from an idle stage. -->
+                          <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal" [class]="stage.waiting ? 'text-error-9' : 'text-new.text-secondary'">{{ stage.waiting }}</td>
+                          <td class="px-20px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-secondary whitespace-nowrap">{{ workersLabel(stage) }}</td>
+                        </tr>
+                      }
+                    </tbody>
+                  </table>
+                </div>
+              }
+
+              @if (row.replica.writers.length) {
+                <div class="w-full overflow-x-auto border-t border-new.border">
+                  <table class="w-full min-w-[480px] border-collapse">
+                    <thead>
+                      <tr class="bg-new.surface-subtle border-b border-new.border">
+                        <th class="text-left px-20px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Writer</th>
+                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Pending</th>
+                        <th class="text-right px-20px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Failed batches</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      @for (writer of row.replica.writers; track $index) {
+                        <tr class="border-b border-new.border last:border-b-0">
+                          <td class="px-20px h-44px font-body font-medium text-[14px] leading-normal text-new.text-primary">{{ label(writer.name) }}</td>
+                          <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ writer.pending }}</td>
+                          <td class="px-20px h-44px text-right font-body font-normal text-[14px] leading-normal" [class]="writer.failures ? 'text-error-9' : 'text-new.text-secondary'">{{ writer.failures }}</td>
+                        </tr>
+                      }
+                    </tbody>
+                  </table>
+                </div>
+              }
+
+              <!-- The measured interval, read through the same accessor as the
+                   verdict and the numbers above rather than out of the gauge list
+                   itself. Reading it twice is what let this table report a
+                   throughput the verdict had just called absent. -->
+              <div class="px-20px py-16px border-t border-new.border min-w-0">
+                <p class="font-heading font-medium text-[14px] leading-[20px] text-new.text-primary mb-12px">Last measured interval</p>
+                @if (row.flow.measured) {
+                  <div class="flex flex-wrap gap-x-32px gap-y-12px">
+                    <div class="flex flex-col gap-2px min-w-0">
+                      <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary">Window</span>
+                      <span class="font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ row.flow.measured.windowMs }} ms</span>
+                    </div>
+                    <div class="flex flex-col gap-2px min-w-0">
+                      <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary">Events accepted</span>
+                      <span class="font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ row.flow.measured.in }}</span>
+                    </div>
+                    <div class="flex flex-col gap-2px min-w-0">
+                      <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary">Deliveries delivered</span>
+                      <span class="font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ row.flow.measured.out }}</span>
+                    </div>
+                    <div class="flex flex-col gap-2px min-w-0">
+                      <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary">Deliveries failed</span>
+                      <span class="font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ row.flow.measured.failed }}</span>
+                    </div>
+                  </div>
+                } @else {
+                  <!-- The same reason the dash upstairs carries, so a reader who
+                       opened diagnostics to find out why is not sent back up. -->
+                  <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">{{ absentReason(row) }}</p>
+                }
               </div>
+
+              @if (row.gauges.length) {
+                <div class="px-20px py-16px border-t border-new.border min-w-0">
+                  <p class="font-heading font-medium text-[14px] leading-[20px] text-new.text-primary mb-12px">Current</p>
+                  <div class="flex flex-wrap gap-x-32px gap-y-12px">
+                    @for (gauge of row.gauges; track $index) {
+                      <div class="flex flex-col gap-2px min-w-0">
+                        <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary">{{ label(gauge.name) }}</span>
+                        <span class="font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ gauge.value }}</span>
+                      </div>
+                    }
+                  </div>
+                </div>
+              }
+
+              <!-- Totals for the life of this process, so they do not drop to zero
+                   on a quiet minute and do reset when the replica restarts. -->
+              @if (row.replica.counters.length) {
+                <div class="px-20px py-16px border-t border-new.border min-w-0">
+                  <p class="font-heading font-medium text-[14px] leading-[20px] text-new.text-primary mb-12px">Counters since this replica started</p>
+                  <div class="flex flex-wrap gap-x-32px gap-y-12px">
+                    @for (counter of row.replica.counters; track $index) {
+                      <div class="flex flex-col gap-2px min-w-0">
+                        <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary">{{ label(counter.name) }}</span>
+                        <span class="font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ counter.value }}</span>
+                      </div>
+                    }
+                  </div>
+                </div>
+              }
             }
           </div>
         }

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.spec.ts
@@ -1,11 +1,15 @@
 import { CommonModule } from '@angular/common';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { EngineVerdictComponent } from 'src/app/components/engine-verdict/engine-verdict.component';
 import { TagComponent } from 'src/app/components/tag/tag.component';
 import { AdminService } from 'src/app/private/pages/admin/admin.service';
 
-import { QueueMonitoringDataplaneComponent } from './queue-monitoring-dataplane.component';
+import { DataPlaneReport, QueueMonitoringDataplaneComponent } from './queue-monitoring-dataplane.component';
 
+// Default gauges carry no throughput, which is the plane's first sample after it
+// starts: the publisher has no earlier reading to difference and omits the four
+// interval gauges together.
 function replica(overrides: any = {}) {
 	return {
 		replica: 'agent-1',
@@ -23,6 +27,49 @@ function replica(overrides: any = {}) {
 	};
 }
 
+// A measured interval, as gauges, with the names spelled exactly as the
+// persisted snapshot spells them. There is no throughput section on the wire:
+// throughput arrives as entries in the same flat gauges array as everything else,
+// and a fixture that invented a nested shape would pass against a reader looking
+// for the same invention, which is the bug this shape exists to catch.
+//
+// 4954ms because the publisher reports the real elapsed time between its two
+// readings rather than its configured 5s period.
+function measured(overrides: { window_ms?: number; accepted?: number; delivered?: number; failed?: number } = {}) {
+	const window = { window_ms: 4954, accepted: 0, delivered: 0, failed: 0, ...overrides };
+
+	return [
+		{ name: 'throughput_window_ms', value: window.window_ms },
+		{ name: 'throughput_accepted', value: window.accepted },
+		{ name: 'throughput_delivered', value: window.delivered },
+		{ name: 'throughput_failed', value: window.failed }
+	];
+}
+
+// The restart sample: the restart gauge alone, with the four interval gauges
+// absent, because the interval that spanned the restart was discarded rather
+// than reported. So a restart is also an unmeasured sample.
+function restarted() {
+	return [{ name: 'throughput_restarted', value: 1 }];
+}
+
+// The retry backlog's schedule, as gauges, spelled as the persisted snapshot
+// spells them. Both or neither: an age with no due time says nothing about
+// whether the backlog is draining, and a due time with no age says nothing about
+// how long it has not been.
+//
+// Signed on purpose. A negative due time is a retry that was due that long ago.
+function retrySchedule(oldestAgeMs: number, nextDueInMs: number) {
+	return [
+		{ name: 'outstanding_oldest_retry_age_ms', value: oldestAgeMs },
+		{ name: 'outstanding_next_retry_due_in_ms', value: nextDueInMs }
+	];
+}
+
+function retries(count: number, known = true) {
+	return [{ name: 'deliveries_retry', count, known, as_of: '2026-09-01T08:00:00Z' }];
+}
+
 function status(replicas: any[], staleAfterSeconds = 15) {
 	return { data: { replicas, stale_after_seconds: staleAfterSeconds } };
 }
@@ -38,13 +85,15 @@ describe('QueueMonitoringDataplaneComponent', () => {
 	let component: QueueMonitoringDataplaneComponent;
 	let reads: Array<() => Promise<any>>;
 	let calls: number;
+	let reports: DataPlaneReport[];
 
 	beforeEach(async () => {
 		reads = [];
 		calls = 0;
+		reports = [];
 
 		await TestBed.configureTestingModule({
-			imports: [CommonModule, TagComponent, QueueMonitoringDataplaneComponent],
+			imports: [CommonModule, TagComponent, EngineVerdictComponent, QueueMonitoringDataplaneComponent],
 			providers: [
 				{
 					provide: AdminService,
@@ -64,6 +113,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 		fixture = TestBed.createComponent(QueueMonitoringDataplaneComponent);
 		component = fixture.componentInstance;
+		component.reported.subscribe(report => reports.push(report));
 
 		// The first change detection runs ngOnInit, which reads. Doing it here,
 		// before any read is scripted, leaves that read pending forever, so every
@@ -97,14 +147,749 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		return (fixture.nativeElement as HTMLElement).textContent ?? '';
 	}
 
-	it('reports a backlog it could not read as unknown, not as zero', async () => {
+	function openDiagnostics() {
+		component.toggleDiagnostics('agent-1');
+		paint();
+	}
+
+	// Every absent value on the panel, as the two kinds of reader reach it: the
+	// glyph in the value slot, and the label a screen reader or a tablet gets,
+	// since the tooltip body only appears on hover and focus.
+	function absentValues(): Array<{ glyph: string; label: string }> {
+		return Array.from((fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('convoy-tooltip')).map(tooltip => ({
+			glyph: (tooltip.querySelector<HTMLElement>('[tooltipToggle]')?.textContent ?? '').trim(),
+			label: tooltip.querySelector('button')?.getAttribute('aria-label') ?? ''
+		}));
+	}
+
+	// Every tooltip on the panel as a keyboard or screen reader user reaches it.
+	function tooltipLabels(): string[] {
+		return Array.from((fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('convoy-tooltip button')).map(button => button.getAttribute('aria-label') ?? '');
+	}
+
+	// A plane on its first sample: no interval to report yet. Both causes of an
+	// absent interval are benign and both are knowable from the sample, so the
+	// panel names the cause rather than reporting an unexplained absence, and it
+	// must not fill the gap with a zero or look empty while doing it.
+	describe('a plane with no measured interval', () => {
+		it('names the reason rather than reporting an unexplained absence', async () => {
+			reads.push(() => Promise.resolve(status([replica()])));
+
+			await render();
+
+			expect(text()).toContain('Measuring. No earlier sample from this engine to compare against, so there is no interval yet. Next sample carries one. 84,088 outstanding.');
+			expect(text()).not.toContain('not reported');
+			expect(text()).not.toContain('Idle');
+			expect(text()).not.toContain('Nothing accepted');
+		});
+
+		// A dash an operator cannot account for reads as a broken panel, so the
+		// tooltip and the accessible label both carry the cause.
+		it('renders the two interval numbers as a dash carrying that reason', async () => {
+			reads.push(() => Promise.resolve(status([replica()])));
+
+			await render();
+
+			const absent = absentValues().filter(value => value.glyph === '-');
+			expect(absent.length).toBe(2);
+			expect(absent[0].label).toContain('Events in: No earlier sample yet.');
+			expect(absent[0].label).toContain('A number appears on the next sample. Nothing is wrong.');
+			expect(absent[1].label).toContain('Deliveries out: No earlier sample yet.');
+		});
+
+		// A benign absence is not a fault, so the leading dot must not paint one.
+		it('does not paint a benign absence as a problem', async () => {
+			reads.push(() => Promise.resolve(status([replica()])));
+
+			await render();
+
+			const dot = (fixture.nativeElement as HTMLElement).querySelector('convoy-engine-verdict span');
+			expect(dot?.className).toContain('bg-new.text-secondary');
+			expect(dot?.className).not.toContain('bg-warning-9');
+		});
+
+		// The durable backlog is real data the plane does publish, so the panel is
+		// not empty in this state even though two of the three numbers are not.
+		it('still shows the outstanding backlog it does have', async () => {
+			reads.push(() => Promise.resolve(status([replica()])));
+
+			await render();
+
+			expect(text()).toContain('Outstanding');
+			expect(text()).toContain('84,088');
+		});
+
+		// A plane that reported no backlog section has not reported an empty one.
+		it('reports an unread backlog as unknown, not as zero', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							outstanding: [
+								{ name: 'events_pending', count: 0, known: false, as_of: '2026-09-01T08:00:00Z' },
+								{ name: 'deliveries_retry', count: 12, known: true, as_of: '2026-09-01T08:00:00Z' }
+							]
+						})
+					])
+				)
+			);
+
+			await render();
+
+			// The dash, and the reason on the accessible label, for the same
+			// reason the interval numbers use it: an unread count printed as 0
+			// reads as an empty backlog.
+			// Selected by the dash rather than by the label, because the label
+			// tooltip explaining what Outstanding means is on the same metric and
+			// carries the same prefix.
+			const dashes = absentValues().filter(value => value.glyph === '-');
+			const outstanding = dashes.find(value => value.label.startsWith('Outstanding:'));
+			expect(outstanding?.label).toContain('Not read.');
+			expect(outstanding?.label).toContain('unknown rather than zero');
+			expect(text()).toContain('Outstanding could not be read');
+			expect(text()).not.toContain('nothing outstanding');
+
+			openDiagnostics();
+			expect(text()).toContain('12');
+		});
+
+		it('reports an absent backlog section as unknown too', async () => {
+			reads.push(() => Promise.resolve(status([replica({ outstanding: [] })])));
+
+			await render();
+
+			expect(text()).toContain('Outstanding could not be read');
+			expect(text()).not.toContain('Idle');
+		});
+	});
+
+	describe('a plane that measured an interval', () => {
+		// The regression the panel shipped with: the verdict and the numbers read
+		// one shape while the diagnostics table iterated the gauges the plane
+		// actually sends, so the card reported "not reported" above its own live
+		// throughput. The gauge names here are written out rather than built by
+		// the helper, because a helper renamed alongside the reader would hide
+		// exactly this.
+		it('reads the interval the plane published rather than reporting it absent', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							gauges: [
+								{ name: 'throughput_window_ms', value: 4994 },
+								{ name: 'throughput_accepted', value: 288 },
+								{ name: 'throughput_delivered', value: 287 },
+								{ name: 'throughput_failed', value: 30 },
+								{ name: 'reference_projects', value: 1 }
+							],
+							outstanding: [{ name: 'deliveries_retry', count: 583, known: true, as_of: '2026-09-01T08:00:00Z' }]
+						})
+					])
+				)
+			);
+
+			await render();
+
+			expect(text()).toContain('Draining. 288 accepted, 287 completed and 30 failed or discarded in the last ~5s, 583 outstanding.');
+			expect(text()).toContain('288');
+			expect(text()).toContain('287');
+			expect(text()).not.toContain('not reported');
+			expect(absentValues().filter(value => value.glyph === '-').length).toBe(0);
+		});
+
+		// The same fields at zero with a valid window, which is the idle plane
+		// thirteen seconds later. A dash here would make an idle plane look
+		// broken, which is the same error in the opposite direction.
+		it('renders a measured zero as zero rather than as a dash', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							gauges: [
+								{ name: 'throughput_window_ms', value: 4997 },
+								{ name: 'throughput_accepted', value: 0 },
+								{ name: 'throughput_delivered', value: 0 },
+								{ name: 'throughput_failed', value: 0 }
+							],
+							outstanding: [{ name: 'events_pending', count: 0, known: true, as_of: '2026-09-01T08:00:00Z' }]
+						})
+					])
+				)
+			);
+
+			await render();
+
+			expect(text()).toContain('Running and idle. It measured the last ~5s and accepted nothing, nothing outstanding.');
+			expect(absentValues().filter(value => value.glyph === '-').length).toBe(0);
+
+			const values = Array.from((fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('[data-flow-value]')).map(node => (node.textContent ?? '').trim());
+			expect(values).toEqual(['0', '0', '0']);
+		});
+
+		// The staging state: a plane that is up, measured an interval and took
+		// nothing, on an instance whose events all reach Convoy some other way.
+		// A card of zeros cannot be told from a quiet plane, so the zero on the
+		// intake says it was measured, and the identity says why this replica
+		// might be the only thing that is quiet.
+		it('says a measured zero intake was a reading rather than a gap', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							gauges: measured({ accepted: 0, delivered: 0 }),
+							outstanding: [{ name: 'events_pending', count: 0, known: true, as_of: '2026-09-01T08:00:00Z' }]
+						})
+					])
+				)
+			);
+
+			await render();
+
+			expect(text()).toContain('measured, nothing reached this replica');
+			expect(text()).toContain('If work is arriving on this instance, it is not coming through this engine.');
+
+			const scope = tooltipLabels().find(label => label.includes('Replica scope'));
+			expect(scope).toContain('This replica only counts work its own process accepted.');
+			expect(scope).toContain('agent HTTP port');
+			expect(scope).toContain('carried by the queue instead');
+		});
+
+		// The note is a reading, so it may only appear where there was one. Beside
+		// a dash it would read as an explanation of the absence.
+		it('keeps the measured note off an interval it could not measure', async () => {
+			reads.push(() => Promise.resolve(status([replica({})])));
+
+			await render();
+
+			expect(text()).not.toContain('measured, nothing reached this replica');
+		});
+
+		// Events in and deliveries out count different things, so the sentence
+		// must not invite a subtraction that fanout makes meaningless: one event
+		// legitimately produces more than one delivery.
+		it('states both units and never nets them against each other', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							gauges: measured({ accepted: 3, delivered: 12 }),
+							outstanding: [{ name: 'events_pending', count: 4, known: true, as_of: '2026-09-01T08:00:00Z' }]
+						})
+					])
+				)
+			);
+
+			await render();
+
+			expect(text()).toContain('Draining. 3 accepted and 12 completed in the last ~5s, 4 outstanding.');
+			expect(text()).toContain('Events in');
+			expect(text()).toContain('Deliveries out');
+			expect(text()).not.toContain('more out than in');
+			expect(text()).not.toContain('Backlog growing');
+		});
+
+		// The card Smart read as an incident: a backlog of 583 while the window
+		// completed nothing, next to a failure total of 1,176. The plane was
+		// healthy. Those outstanding items were deliveries scheduled to retry
+		// later, and most of the failures belonged to a different, paused
+		// endpoint whose deliveries never entered the backlog at all.
+		it('does not call a backlog of scheduled retries stuck', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							gauges: [...measured({ accepted: 40, delivered: 0, failed: 0 }), ...retrySchedule(96_000, 42_000)],
+							counters: [{ name: 'deliveries_discarded', value: 1176 }],
+							outstanding: retries(583)
+						})
+					])
+				)
+			);
+
+			await render();
+
+			expect(text()).toContain('40 accepted and nothing completed in the last ~5s, 583 outstanding.');
+			expect(text()).toContain('Work waiting on a schedule is outstanding too, so read what that number is made of before taking this as held up.');
+
+			// And the schedule says which it is: an oldest retry a minute and a
+			// half old with the next one due shortly is a backlog draining on
+			// time, which is the reading the card could not make when this was an
+			// incident.
+			expect(text()).toContain('oldest retry 1m old');
+			expect(text()).toContain('next due in 40s');
+			expect(text()).not.toContain('overdue');
+			expect(text()).not.toContain('stuck');
+			expect(text()).not.toContain('Not draining');
+
+			// And not painted as one either.
+			const dot = (fixture.nativeElement as HTMLElement).querySelector('convoy-engine-verdict span');
+			expect(dot?.className).not.toContain('bg-warning-9');
+		});
+
+		// The window counts a discard the same as an exhausted retry, because it
+		// answers whether accepted work left the outstanding set and both of those
+		// do. Naming it after the narrower outcome now that the lifetime totals
+		// are split would make the other one invisible here.
+		it('names the interval count for both terminal outcomes, not just failure', async () => {
+			reads.push(() => Promise.resolve(status([replica({ gauges: measured({ accepted: 10, delivered: 8, failed: 2 }) })])));
+
+			await render();
+
+			expect(text()).toContain('Failures reported');
+			expect(text()).toContain('2 deliveries failed or discarded in the last ~5s');
+			expect(text()).not.toContain('2 deliveries failed in the last');
+			expect(text()).not.toContain('Where it is stuck');
+		});
+	});
+
+	// A restart discards the interval that spanned it, so the plane sends the
+	// restart gauge alone. That is an unmeasured sample with a knowable cause.
+	describe('a plane that restarted underneath the sampler', () => {
+		it('says the restart is why there is no interval, without calling it a fault', async () => {
+			reads.push(() => Promise.resolve(status([replica({ gauges: restarted() })])));
+
+			await render();
+
+			expect(text()).toContain('Measuring again. The engine restarted, so the interval spanning the restart was discarded. Next sample carries one. 84,088 outstanding.');
+			expect(text()).not.toContain('No earlier sample');
+
+			const dot = (fixture.nativeElement as HTMLElement).querySelector('convoy-engine-verdict span');
+			expect(dot?.className).not.toContain('bg-warning-9');
+		});
+
+		it('gives the dash a different reason from a plane that has only just started', async () => {
+			reads.push(() => Promise.resolve(status([replica({ gauges: restarted() })])));
+
+			await render();
+
+			const absent = absentValues().filter(value => value.glyph === '-');
+			expect(absent[0].label).toContain('Events in: Plane restarted.');
+			expect(absent[0].label).not.toContain('No earlier sample yet.');
+		});
+	});
+
+	// The four interval gauges are one compound value. A count without the window
+	// it covers is not a rate, so a partial publish is unknown rather than a
+	// number with a zero defaulted into the hole. The failure count is non-zero
+	// on purpose: a zero would be skipped by the count check alone, and the test
+	// would pass with the omitted-together rule removed.
+	it('treats a partly published interval as unknown rather than defaulting the rest to zero', async () => {
+		reads.push(() => Promise.resolve(status([replica({ writers: [], stages: [], counters: [], gauges: [{ name: 'throughput_failed', value: 3 }] })])));
+
+		await render();
+
+		expect(text()).not.toContain('deliveries failed in the last');
+		expect(text()).toContain('Throughput reported incompletely, so whether work is draining is unknown.');
+		expect(absentValues().filter(value => value.glyph === '-').length).toBe(2);
+	});
+
+	// What the backlog is doing, which is the reading the bare count could not
+	// give. The two gauges are one compound value on the same rule as the
+	// interval, and the difference between a backlog that is empty and one that
+	// could not be read is carried by the flag the count already has rather than
+	// by their absence, because they are absent in both cases.
+	describe('the retry schedule under the outstanding count', () => {
+		it('states the oldest retry and the next due time as two plain readings', async () => {
+			reads.push(() => Promise.resolve(status([replica({ gauges: [...measured({ accepted: 12, delivered: 9 }), ...retrySchedule(140_000, 25_000)], outstanding: retries(31) })])));
+
+			await render();
+
+			expect(text()).toContain('oldest retry 2m old');
+			expect(text()).toContain('next due in 23s');
+			expect(text()).not.toContain('overdue');
+			expect(absentValues().filter(value => value.glyph === '-').length).toBe(0);
+		});
+
+		// An empty backlog has no oldest retry and nothing due, so the publisher
+		// omits both gauges. That is an answer, not a gap: rendering the dash here
+		// would report a backlog it could not read when it read an empty one. The
+		// publisher does not send zeros for it either, because a zero age already
+		// means a retry created this instant.
+		it('reads a known empty backlog as empty rather than as unknown', async () => {
+			reads.push(() => Promise.resolve(status([replica({ gauges: measured({ accepted: 4, delivered: 4 }), outstanding: retries(0) })])));
+
+			await render();
+
+			expect(text()).toContain('no retries waiting');
+			expect(text()).not.toContain('oldest retry');
+			expect(absentValues().filter(value => value.glyph === '-').length).toBe(0);
+
+			const values = Array.from((fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('[data-flow-value]')).map(node => (node.textContent ?? '').trim());
+			expect(values).toEqual(['4', '4', '0']);
+		});
+
+		// The count could not be read, so neither could its schedule. The dash on
+		// the count already carries that, and a schedule line beside it would be a
+		// reading of rows nobody counted.
+		it('says nothing about the schedule of a backlog it could not read', async () => {
+			reads.push(() => Promise.resolve(status([replica({ gauges: measured({ accepted: 4, delivered: 4 }), outstanding: retries(0, false) })])));
+
+			await render();
+
+			expect(text()).not.toContain('no retries waiting');
+			expect(text()).not.toContain('oldest retry');
+
+			const dashes = absentValues().filter(value => value.glyph === '-');
+			expect(dashes.find(value => value.label.startsWith('Outstanding:'))?.label).toContain('Not read.');
+		});
+
+		// Overdue is not stuck. A retry can be a little late because the scanner
+		// has not reached it, and one sample cannot see whether that is what this
+		// is, so the numbers are stated and the extra line only appears past a
+		// minute, which is an order of magnitude beyond scan latency and beyond
+		// the age of the sample being read.
+		it('states an overdue retry as overdue and stops short of calling it stuck', async () => {
+			reads.push(() => Promise.resolve(status([replica({ gauges: [...measured({ accepted: 0, delivered: 0 }), ...retrySchedule(3_600_000, -720_000)], outstanding: retries(583) })])));
+
+			await render();
+
+			expect(text()).toContain('oldest retry 1h old');
+			expect(text()).toContain('next due 12m ago');
+			expect(text()).toContain('overdue by longer than a scan cycle explains');
+			expect(text()).not.toContain('stuck');
+		});
+
+		// A few seconds late is the scanner working, so it gets the reading and
+		// nothing more.
+		it('leaves a slightly overdue retry as a reading', async () => {
+			reads.push(() => Promise.resolve(status([replica({ gauges: [...measured({ accepted: 6, delivered: 6 }), ...retrySchedule(30_000, -8_000)], outstanding: retries(2) })])));
+
+			await render();
+
+			expect(text()).toContain('next due 10s ago');
+			expect(text()).not.toContain('overdue by longer');
+		});
+
+		// Both readings are carried forward by the snapshot's own age, from the
+		// server that read sampled_at, and never by the browser's clock. Crossing
+		// two clocks here would fold their skew into a number an operator pages
+		// on, which is the reason the publisher sends an age rather than a
+		// timestamp. A reader subtracting the browser's now from sampled_at would
+		// report months, this fixture being dated.
+		it('ages the schedule by the snapshot, not by the browser clock', async () => {
+			reads.push(() => Promise.resolve(status([replica({ age_seconds: 45, gauges: [...measured({ accepted: 1, delivered: 1 }), ...retrySchedule(15_000, 60_000)], outstanding: retries(9) })])));
+
+			await render();
+
+			expect(text()).toContain('oldest retry 1m old');
+			expect(text()).toContain('next due in 15s');
+		});
+
+		// A total is unknown as soon as any one backlog is, and the retry rows can
+		// still have been read. Refusing to state a schedule that was read, over an
+		// unread count somewhere else, would drop the most useful thing on the card.
+		it('states a schedule it read even when another backlog made the total unknown', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							gauges: [...measured({ accepted: 2, delivered: 2 }), ...retrySchedule(20_000, 10_000)],
+							outstanding: [{ name: 'events_pending', count: 0, known: false, as_of: '2026-09-01T08:00:00Z' }, ...retries(6)]
+						})
+					])
+				)
+			);
+
+			await render();
+
+			const dashes = absentValues().filter(value => value.glyph === '-');
+			expect(dashes.find(value => value.label.startsWith('Outstanding:'))?.label).toContain('Not read.');
+			expect(text()).toContain('oldest retry 22s old');
+			expect(text()).toContain('next due in 8s');
+		});
+
+		// Carrying the reading forward is a display convenience, so it may not
+		// become a claim about what happened while nobody was looking. An old
+		// sample of a healthy backlog crosses any threshold just by sitting there,
+		// and a panel that turned its own staleness into an overdue claim would be
+		// the false alarm again with a new cause. So the line is judged on what
+		// the plane read, and only the number shown moves.
+		it('does not turn its own staleness into an overdue retry', async () => {
+			reads.push(() => Promise.resolve(status([replica({ age_seconds: 300, stale: true, gauges: [...measured({ accepted: 2, delivered: 2 }), ...retrySchedule(60_000, 30_000)], outstanding: retries(5) })])));
+
+			await render();
+
+			expect(text()).toContain('next due 4m ago');
+			expect(text()).not.toContain('overdue by longer');
+		});
+
+		// The contract says a non-zero known count comes with both gauges, since
+		// the count and the readings come from one statement over one set of rows.
+		// A count without them is a plane that is not running or a bug, so the
+		// panel says nothing rather than inventing a schedule, and the count it
+		// did read stays a count.
+		it('says nothing about a schedule the plane did not publish beside a real count', async () => {
+			reads.push(() => Promise.resolve(status([replica({ gauges: measured({ accepted: 2, delivered: 2 }), outstanding: retries(44) })])));
+
+			await render();
+
+			expect(text()).toContain('44');
+			expect(text()).not.toContain('oldest retry');
+			expect(text()).not.toContain('no retries waiting');
+			expect(absentValues().filter(value => value.glyph === '-').length).toBe(0);
+		});
+
+		// Consumed above, so the table cannot print the same two numbers again
+		// under their raw names beside the sentence that already used them.
+		it('keeps the schedule gauges out of diagnostics', async () => {
+			reads.push(() => Promise.resolve(status([replica({ gauges: [...measured({ accepted: 2, delivered: 2 }), ...retrySchedule(1_000, 1_000)], outstanding: retries(3) })])));
+
+			await render();
+			openDiagnostics();
+
+			expect(text()).not.toContain('Outstanding oldest retry age ms');
+			expect(text()).not.toContain('Outstanding next retry due in ms');
+		});
+	});
+
+	// The section that caused the false alarm. A climbing backlog under a heading
+	// reading "Where it is stuck", with a failure total listed beneath it, was
+	// read as one phenomenon. It was two: deliveries legitimately waiting on a
+	// retry schedule, and terminal discards belonging to a different, paused
+	// endpoint. The panel states both as observations now, in separate sections.
+	describe('where work is sitting, and failures, as separate facts', () => {
+		it('names the place rather than printing a table row', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							stages: [{ name: 'deliver', queued: 512, waiting: 3, workers: 0, partitions: 4, partition_capacity: 10000, deepest_partition: 400 }],
+							writers: [{ name: 'event_deliveries', pending: 1200, failures: 4 }],
+							counters: []
+						})
+					])
+				)
+			);
+
+			await render();
+
+			expect(text()).toContain('Where work is sitting');
+			expect(text()).toContain('Deliver: 512 queued, 3 senders waiting');
+			expect(text()).toContain('Event deliveries writer: 1,200 pending');
+			expect(text()).toContain('4 write batches failed');
+			// The heading that asserted a conclusion the data cannot reach.
+			expect(text()).not.toContain('Where it is stuck');
+		});
+
+		// The failure totals cover every endpoint the plane serves, and a paused
+		// endpoint's deliveries are discarded before dispatch without ever
+		// joining the backlog. So a failure count sitting under the backlog is an
+		// attribution the plane never made.
+		it('keeps failures out of the section that lists where work is sitting', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							stages: [{ name: 'deliver', queued: 512, waiting: 0, workers: 4, partitions: 4, partition_capacity: 10000, deepest_partition: 400 }],
+							writers: [],
+							counters: [{ name: 'delivery_failures', value: 1176 }]
+						})
+					])
+				)
+			);
+
+			await render();
+
+			const sections = Array.from((fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('ul')).map(list => (list.previousElementSibling?.textContent ?? '') + '|' + (list.textContent ?? ''));
+			const sitting = sections.find(section => section.startsWith('Where work is sitting'));
+			const failures = sections.find(section => section.startsWith('Failures reported'));
+
+			expect(sitting).toContain('512 queued');
+			expect(sitting).not.toContain('1,176');
+			expect(failures).toContain('Delivery failures: 1,176');
+			expect(text()).toContain('not attributed to the work outstanding above');
+		});
+
+		// Failures and recovery errors are the only counters that always mean
+		// something is wrong. A counter whose name carries none of those words
+		// stays in diagnostics, because the plane names its own counters and this
+		// build cannot have a dictionary of names it has never seen.
+		it('promotes a non-zero failure counter and leaves a neutral one behind', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							stages: [],
+							writers: [],
+							counters: [
+								{ name: 'recovery_errors', value: 6 },
+								{ name: 'handoff_recovered', value: 900 },
+								{ name: 'recovery_errors_previous', value: 0 }
+							]
+						})
+					])
+				)
+			);
+
+			await render();
+
+			expect(text()).toContain('Recovery errors: 6');
+			expect(text()).not.toContain('Handoff recovered: 900');
+		});
+
+		// The two lifetime totals are different events and the card said one
+		// number. That was half of why it read as an incident: the number was
+		// dominated by a paused endpoint's discards, which never joined the
+		// backlog beside it, while the backlog belonged to an endpoint retrying
+		// normally.
+		it('states discarded and failed as the two different outcomes they are', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							stages: [],
+							writers: [],
+							counters: [
+								{ name: 'deliveries_discarded', value: 1176 },
+								{ name: 'deliveries_failed', value: 12 }
+							]
+						})
+					])
+				)
+			);
+
+			await render();
+
+			expect(text()).toContain('1,176 deliveries discarded before any attempt');
+			expect(text()).toContain('12 deliveries failed after an attempt');
+			expect(text()).toContain('Discarded means the plane never sent it, so it never joined that backlog');
+
+			// And the word rule that promoted the failed total on its name must
+			// not print it a second time under its raw label.
+			expect(text()).not.toContain('Deliveries failed: 12');
+		});
+
+		it('renders neither section when nothing is non-zero', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							stages: [{ name: 'ingest', queued: 0, waiting: 0, workers: 8, partitions: 2, partition_capacity: 10000, deepest_partition: 0 }],
+							writers: [{ name: 'events', pending: 0, failures: 0 }],
+							counters: [{ name: 'dropped_items', value: 0 }]
+						})
+					])
+				)
+			);
+
+			await render();
+
+			expect(text()).not.toContain('Where work is sitting');
+			expect(text()).not.toContain('Failures reported');
+		});
+	});
+
+	describe('labels', () => {
+		it('never renders a raw identifier in the primary view', async () => {
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							stages: [{ name: 'HANDOFF_DELIVER', queued: 5, waiting: 0, workers: 4, partitions: 1, partition_capacity: 10, deepest_partition: 5 }],
+							writers: [],
+							counters: [{ name: 'RECOVERY_ERRORS', value: 3 }]
+						})
+					])
+				)
+			);
+
+			await render();
+
+			expect(text()).toContain('Handoff deliver: 5 queued');
+			expect(text()).toContain('Recovery errors: 3');
+			expect(text()).not.toContain('HANDOFF_DELIVER');
+			expect(text()).not.toContain('RECOVERY_ERRORS');
+		});
+
+		it('humanises a name it has never seen and keeps acronyms upper case', () => {
+			expect(component.label('applied_lsn')).toBe('Applied LSN');
+			expect(component.label('SOME_NEW_THING')).toBe('Some new thing');
+			expect(component.label('deliveries-retry')).toBe('Deliveries retry');
+			expect(component.label('')).toBe('Unnamed');
+		});
+	});
+
+	describe('diagnostics', () => {
+		it('is collapsed by default and holds the tables that used to be on top', async () => {
+			reads.push(() => Promise.resolve(status([replica()])));
+
+			await render();
+
+			expect(component.isOpen('agent-1')).toBeFalse();
+			expect(text()).toContain('Show diagnostics');
+			expect(text()).not.toContain('Fullest lane');
+			expect(text()).not.toContain('3 / 10000');
+			expect(text()).not.toContain('Failed batches');
+		});
+
+		it('expands to the full stage table, writer table, gauges and counters', async () => {
+			reads.push(() => Promise.resolve(status([replica()])));
+
+			await render();
+			openDiagnostics();
+
+			expect(component.isOpen('agent-1')).toBeTrue();
+			expect(text()).toContain('Hide diagnostics');
+			expect(text()).toContain('Fullest lane');
+			expect(text()).toContain('3 / 10000');
+			expect(text()).toContain('Failed batches');
+			expect(text()).toContain('Endpoints');
+			expect(text()).toContain('Counters since this replica started');
+		});
+
+		it('collapses again on a second click', async () => {
+			reads.push(() => Promise.resolve(status([replica()])));
+
+			await render();
+			openDiagnostics();
+			openDiagnostics();
+
+			expect(component.isOpen('agent-1')).toBeFalse();
+			expect(text()).not.toContain('Fullest lane');
+		});
+
+		// Replicas come and go. An open flag for one that left must not survive
+		// for the life of the tab.
+		it('forgets an open replica once it stops reporting', async () => {
+			reads.push(() => Promise.resolve(status([replica()])));
+			reads.push(() => Promise.resolve(status([replica({ replica: 'agent-2' })])));
+
+			await render();
+			openDiagnostics();
+
+			await render();
+
+			expect(component.isOpen('agent-1')).toBeFalse();
+		});
+	});
+
+	// The plane names its own stages, writers, counters and backlogs. Two sharing
+	// one name is a duplicate key, which throws and takes the whole panel down,
+	// so every one of these lists is tracked positionally.
+	it('renders a plane that reports duplicate item names', async () => {
 		reads.push(() =>
 			Promise.resolve(
 				status([
 					replica({
+						stages: [
+							{ name: 'deliver', queued: 1, waiting: 0, workers: 1, partitions: 1, partition_capacity: 10, deepest_partition: 1 },
+							{ name: 'deliver', queued: 2, waiting: 0, workers: 1, partitions: 1, partition_capacity: 10, deepest_partition: 2 }
+						],
+						writers: [
+							{ name: 'events', pending: 3, failures: 0 },
+							{ name: 'events', pending: 4, failures: 0 }
+						],
+						counters: [
+							{ name: 'recovery_errors', value: 1 },
+							{ name: 'recovery_errors', value: 2 }
+						],
+						gauges: [
+							{ name: 'endpoints', value: 5 },
+							{ name: 'endpoints', value: 6 }
+						],
 						outstanding: [
-							{ name: 'events_pending', count: 0, known: false, as_of: '2026-09-01T08:00:00Z' },
-							{ name: 'deliveries_retry', count: 12, known: true, as_of: '2026-09-01T08:00:00Z' }
+							{ name: 'events_pending', count: 7, known: true, as_of: '2026-09-01T08:00:00Z' },
+							{ name: 'events_pending', count: 8, known: true, as_of: '2026-09-01T08:00:00Z' }
 						]
 					})
 				])
@@ -112,19 +897,16 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		);
 
 		await render();
+		openDiagnostics();
 
-		expect(text()).toContain('unknown');
-		expect(text()).toContain('12');
-	});
-
-	it('renders the depth, the fullest lane and the durable backlog', async () => {
-		reads.push(() => Promise.resolve(status([replica()])));
-
-		await render();
-
-		expect(text()).toContain('84088');
-		expect(text()).toContain('3 / 10000');
-		expect(text()).toContain('agent-1');
+		expect(component.state).toBe('ready');
+		// Both duplicates rendered, and the backlog total is their sum rather
+		// than whichever one won a key collision.
+		expect(text()).toContain('15');
+		expect(text()).toContain('Deliver: 1 queued');
+		expect(text()).toContain('Deliver: 2 queued');
+		expect(text()).toContain('Recovery errors: 1');
+		expect(text()).toContain('Recovery errors: 2');
 	});
 
 	it('renders nothing when the deployment wires no data plane monitoring', async () => {
@@ -192,7 +974,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		reads.push(() => Promise.reject(httpError(500)));
 
 		await render();
-		expect(text()).toContain('84088');
+		expect(text()).toContain('84,088');
 
 		await component.load();
 		paint();
@@ -200,8 +982,8 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		expect(component.state).toBe('unknown');
 		// Dropped, not merely hidden: a later render must not be able to bring
 		// the previous depth back as though it described the present.
-		expect(component.replicas).toEqual([]);
-		expect(text()).not.toContain('84088');
+		expect(component.rows).toEqual([]);
+		expect(text()).not.toContain('84,088');
 		expect(text()).toContain('unknown');
 	});
 
@@ -246,13 +1028,47 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		expect(text()).toContain('agent-1');
 	});
 
+	it('renders nothing while another segment is on screen, and keeps polling', async () => {
+		component.active = false;
+		reads.push(() => Promise.resolve(status([replica()])));
+
+		await component.ngOnInit();
+		paint();
+
+		expect(component.state).toBe('ready');
+		expect(text().trim()).toBe('');
+		expect(component.polling).toBeTrue();
+	});
+
 	it('marks a replica whose last sample is stale', async () => {
 		reads.push(() => Promise.resolve(status([replica({ stale: true, age_seconds: 240 })])));
 
 		await render();
 
 		expect(text()).toContain('Stale');
-		expect(text()).toContain('are not current');
+		expect(text()).toContain('Not reporting. Last sample 4m ago.');
+		expect(text()).toContain('is not current');
+	});
+
+	// A stale sample's numbers describe a moment that has passed, so the verdict
+	// must not read a rate off them however healthy they looked.
+	it('does not read a rate off a stale sample', async () => {
+		reads.push(() =>
+			Promise.resolve(
+				status([
+					replica({
+						stale: true,
+						age_seconds: 240,
+						gauges: measured({ accepted: 1240, delivered: 1190 })
+					})
+				])
+			)
+		);
+
+		await render();
+
+		expect(text()).toContain('Not reporting. Last sample 4m ago.');
+		expect(text()).not.toContain('Draining');
 	});
 
 	// Running false means the live gauges describe nothing. The publisher already
@@ -266,8 +1082,8 @@ describe('QueueMonitoringDataplaneComponent', () => {
 					replica({
 						running: false,
 						stages: [{ name: 'ingest', queued: 9999, waiting: 3, workers: 4, partitions: 2, partition_capacity: 10000, deepest_partition: 9999 }],
-						writers: [{ name: 'events', pending: 42, batches: 7, flush_failures: 0 }],
-						gauges: [{ name: 'cached_projects', value: 12 }]
+						writers: [{ name: 'events', pending: 42, failures: 0 }],
+						gauges: [{ name: 'cached_projects', value: 12 }, ...measured({ accepted: 5000, delivered: 4000 })]
 					})
 				])
 			)
@@ -276,12 +1092,43 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		await render();
 
 		expect(text()).toContain('Not accepting');
-		expect(text()).not.toContain('Fullest lane');
+		// A plane that is not running reads as that, in words, and never as the
+		// running plane that measured an interval and found nothing in it.
+		expect(text()).toContain('Not running. This engine is not accepting work, so nothing new is entering it.');
+		expect(text()).not.toContain('It measured the last');
 		expect(text()).not.toContain('9999');
-		expect(text()).not.toContain('cached_projects');
-		expect(component.replicas[0].stages).toEqual([]);
-		expect(component.replicas[0].writers).toEqual([]);
-		expect(component.replicas[0].gauges).toEqual([]);
+		expect(text()).not.toContain('5,000');
+		expect(component.rows[0].replica.stages).toEqual([]);
+		expect(component.rows[0].replica.writers).toEqual([]);
+		expect(component.rows[0].replica.gauges).toEqual([]);
+		// The interval came out of those dropped gauges, so it goes with them, and
+		// it goes as an absence rather than as a zero: a stopped plane has not
+		// reported an idle interval.
+		expect(component.rows[0].flow.measured).toBeUndefined();
+	});
+
+	// The gauges of a stopped replica are dropped on the way in, so the accessor
+	// sees the same empty list a plane on its first sample publishes and can only
+	// call it a first sample. Saying a number arrives next sample promises one
+	// from a plane that has stopped taking work, and it says it in the one place
+	// a keyboard or screen reader user reads, directly under a verdict saying the
+	// opposite.
+	it('does not promise a next sample from a replica that stopped accepting', async () => {
+		reads.push(() => Promise.resolve(status([replica({ running: false })])));
+
+		await render();
+		openDiagnostics();
+
+		const dashes = absentValues().filter(value => value.glyph === '-');
+		const intake = dashes.find(value => value.label.startsWith('Events in:'))?.label ?? '';
+
+		expect(intake).toContain('Plane not accepting.');
+		expect(intake).not.toContain('No earlier sample yet.');
+		expect(dashes.find(value => value.label.startsWith('Deliveries out:'))?.label).toContain('Plane not accepting.');
+		// Diagnostics reads the same reason off the row, so a reader who opened it
+		// to find out why is not given the other account.
+		expect(text()).toContain('Plane not accepting.');
+		expect(text()).not.toContain('A number appears on the next sample.');
 	});
 
 	// Counters and the durable backlog are not run-scoped: a total still
@@ -302,8 +1149,10 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 		await render();
 
+		expect(text()).toContain('84,088');
+
+		openDiagnostics();
 		expect(text()).toContain('780');
-		expect(text()).toContain('84088');
 	});
 
 	it('reads zero workers as a mode, not as an absence', () => {
@@ -329,6 +1178,164 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		await slow;
 
 		expect(calls).toBe(2);
-		expect(component.replicas.map(r => r.replica)).toEqual(['agent-2']);
+		expect(component.rows.map(row => row.replica.replica)).toEqual(['agent-2']);
+	});
+
+	// The page around this panel decides whether the Data plane segment exists at
+	// all from these reports, so a failed read must not invent a plane and a
+	// plane that answered once must not lose its segment to one.
+	describe('what it reports to the page', () => {
+		it('reports a plane once a replica has published', async () => {
+			reads.push(() => Promise.resolve(status([replica(), replica({ replica: 'agent-2', running: false })])));
+
+			await render();
+
+			expect(reports.pop()).toEqual({ reports: true, known: true, replicas: 2, accepting: 1 });
+		});
+
+		it('reports no plane while no replica is publishing', async () => {
+			reads.push(() => Promise.resolve(status([])));
+
+			await render();
+
+			expect(reports.pop()).toEqual({ reports: false, known: true, replicas: 0, accepting: 0 });
+		});
+
+		it('reports no plane when the server wires none', async () => {
+			reads.push(() => Promise.reject(httpError(501)));
+
+			await render();
+
+			expect(reports.pop()).toEqual({ reports: false, known: true, replicas: 0, accepting: 0 });
+		});
+
+		// A transport failure is not evidence that a plane exists, so a queue-only
+		// instance must not grow a Data plane segment from one.
+		it('reports no plane when the very first read fails', async () => {
+			reads.push(() => Promise.reject(httpError(500)));
+
+			await render();
+
+			expect(reports.pop()?.reports).toBeFalse();
+		});
+
+		// A failure after the plane has answered is the read breaking, not the
+		// plane leaving. Dropping the segment there would move the queue view
+		// under the operator every time a poll blipped.
+		it('keeps reporting a plane when a later read fails', async () => {
+			reads.push(() => Promise.resolve(status([replica()])));
+			reads.push(() => Promise.reject(httpError(500)));
+
+			await render();
+			await render();
+
+			expect(reports.pop()?.reports).toBeTrue();
+		});
+
+		// The counts are what the page prints beside the control, so a failed read
+		// must mark them as describing nothing. Zero replicas from a read that
+		// broke is not a plane that emptied.
+		it('marks the counts unknown when a read fails and known when it does not', async () => {
+			reads.push(() => Promise.resolve(status([replica()])));
+			reads.push(() => Promise.reject(httpError(500)));
+
+			await render();
+			expect(reports.pop()?.known).toBeTrue();
+
+			await render();
+			expect(reports.pop()).toEqual({ reports: true, known: false, replicas: 0, accepting: 0 });
+		});
+
+		// A plane that goes away and then a failed read must not resurrect the
+		// segment from the memory of the plane that left.
+		it('does not resurrect a plane that left when a later read fails', async () => {
+			reads.push(() => Promise.resolve(status([replica()])));
+			reads.push(() => Promise.resolve(status([])));
+			reads.push(() => Promise.reject(httpError(500)));
+
+			await render();
+			await render();
+			await render();
+
+			expect(reports.pop()?.reports).toBeFalse();
+		});
+	});
+
+	// Karma loads src/styles.scss, so Tailwind is really applied and the browser
+	// really lays out. The panel is given a 375px frame, the narrowest phone
+	// width the dashboard is expected to survive, and asked whether anything
+	// pushes past it. A wide table is allowed to scroll inside its own wrapper;
+	// what is not allowed is the panel making the page scroll sideways.
+	describe('at a 375px viewport', () => {
+		it('keeps everything inside the frame, with diagnostics open and long names', async () => {
+			const host = fixture.nativeElement as HTMLElement;
+			const frame = host.parentElement as HTMLElement;
+			frame.style.width = '375px';
+			frame.style.overflow = 'hidden';
+
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							// Names the plane chose, not names this build knows. One of
+							// them carries no separator at all, so it humanises to a
+							// single unbreakable word, which is the shape that pushed
+							// the old panel off the side of the page.
+							replica: 'convoydataplaneagentdeploymentreplicasixfourceninebseven',
+							stages: [{ name: 'http_ingest_partitioned_fair_queue_admission', queued: 1234567, waiting: 890123, workers: 0, partitions: 4096, partition_capacity: 1000000, deepest_partition: 999999 }],
+							writers: [{ name: 'event_deliveries_bulk_writer', pending: 1234567, failures: 89012 }],
+							counters: [
+								{ name: 'handoffrecoveryerrorstotalfromacustomplanewithnoseparators', value: 1234567890 },
+								{ name: 'deliveries_discarded', value: 1234567890 },
+								{ name: 'deliveries_failed', value: 1234567890 }
+							],
+							// The overdue reading, because it is the longest thing the
+							// schedule can put under a number, on the narrowest card.
+							gauges: [{ name: 'subscription_cache_entries', value: 1234567 }, ...measured({ accepted: 1234567, delivered: 1234567 }), ...retrySchedule(359_999_000, -720_000)],
+							outstanding: [{ name: 'eventdeliveriespendingretrywithnoseparatorsatall', count: 1234567890, known: true, as_of: '2026-09-01T08:00:00Z' }, ...retries(1234567890)]
+						})
+					])
+				)
+			);
+
+			await render();
+			openDiagnostics();
+
+			expect(frame.clientWidth).toBe(375);
+			expect(overflowing(host)).toEqual([]);
+		});
 	});
 });
+
+// A box whose content is wider than the box, and which will neither clip nor
+// scroll it, is what makes the page itself scroll sideways. A table inside an
+// overflow-x-auto wrapper is not that: its content is wider on purpose and the
+// wrapper takes the scroll, so only boxes computing to overflow-x: visible are
+// counted. Elements with no box of their own are skipped, because clientWidth is
+// 0 on an inline and every one of them would read as an overflow.
+//
+// Tooltip bodies are taken out of the measurement first. They are absolutely
+// positioned overlays that are meant to extend past the card, which is the whole
+// reason the card no longer clips its own content, and they are laid out even
+// while transparent, so leaving them in would report the panel's own layout as
+// broken for doing the thing it was fixed to do. Their placement is a hover
+// question, checked in a browser rather than here.
+function overflowing(root: HTMLElement): string[] {
+	const overlays = Array.from(root.querySelectorAll<HTMLElement>('[data-tooltip-body]'));
+	for (const overlay of overlays) overlay.style.display = 'none';
+
+	try {
+		return Array.from(root.querySelectorAll<HTMLElement>('*'))
+			.filter(element => {
+				if (!element.clientWidth) return false;
+				if (getComputedStyle(element).overflowX !== 'visible') return false;
+
+				// A pixel of tolerance, because subpixel layout rounds against a
+				// fractional container width and one pixel is not a broken page.
+				return element.scrollWidth - element.clientWidth > 1;
+			})
+			.map(element => `${element.tagName.toLowerCase()}.${element.className}`);
+	} finally {
+		for (const overlay of overlays) overlay.style.display = '';
+	}
+}

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.ts
@@ -1,7 +1,9 @@
 import { CommonModule } from '@angular/common';
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 
 import { TagComponent } from 'src/app/components/tag/tag.component';
+import { TooltipComponent } from 'src/app/components/tooltip/tooltip.component';
+import { EngineCount, EngineFlow, EngineFlowAbsence, EngineVerdict, EngineVerdictComponent, engineCount, intervalWindowLabel } from 'src/app/components/engine-verdict/engine-verdict.component';
 import { AdminService } from 'src/app/private/pages/admin/admin.service';
 
 // The shapes the server publishes. Nothing here names a stage, a writer or a
@@ -54,6 +56,91 @@ interface DataPlaneReplica {
 	outstanding: DataPlaneBacklog[];
 }
 
+// Two tooltip lines and the accessible label carrying both. The tooltip body
+// only appears on hover and focus, so the label is the only route a screen
+// reader or a tablet has to the same text.
+interface Explainer {
+	reason: string;
+	detail: string;
+	aria: string;
+}
+
+// One of the three numbers under the verdict.
+//
+// Two explanations, on two separate hover targets, because they answer two
+// different questions and stacking them on one target would have them fight:
+// about sits on the label and says what the metric means, always, whatever the
+// value; absent sits on the value and says why that particular number is not
+// there.
+//
+// value null is the absence, and the template renders the dash for it rather
+// than a word: "Not reported" printed under every label makes the quiet state
+// the loudest thing on the panel, and the more a plane omits the more the page
+// shouts about it.
+interface FlowNumber {
+	label: string;
+	value: string | null;
+	about: Explainer;
+	// null exactly when value is not, so the dash and its reason cannot be
+	// rendered apart.
+	absent: Explainer | null;
+	// Facts about the number, each on its own line under it, in the order given.
+	// The interval numbers name the window they were counted over; Outstanding
+	// names how old its oldest waiting retry is and when the next one is due,
+	// which is what turns a level into something an operator can judge.
+	notes: string[];
+}
+
+// What the plane said about its retry backlog's schedule. Three answers, and the
+// difference between the last two is the whole point: a backlog with nothing in
+// it has no oldest retry, and that is a reading rather than a gap.
+type RetrySchedule = { kind: 'reported'; oldestAgeMs: number; nextDueInMs: number } | { kind: 'empty' } | { kind: 'unknown' };
+
+// A replica with everything derived from it computed once. The derived values
+// are objects and arrays, so a template getter would hand the renderer a new
+// identity on every change detection pass; building them on the way in gives
+// each one a single identity for as long as the reply it came from is on screen.
+interface DataPlaneRow {
+	replica: DataPlaneReplica;
+	verdict: EngineVerdict;
+	numbers: FlowNumber[];
+
+	// Two lists, never merged. holding is where items are sitting; failures are
+	// totals the plane counts across everything it serves. Putting a failure
+	// count under a heading that says work is stuck asserts a causal link this
+	// contract cannot support, and that assertion is what caused a false alarm.
+	holding: string[];
+	failures: string[];
+
+	// What throughputOf made of this replica's gauges, and the gauges it did not
+	// consume. Diagnostics renders both from here rather than reaching for the
+	// gauge list itself, so the table cannot show numbers the verdict above it
+	// has just called absent.
+	flow: EngineFlow;
+	gauges: DataPlaneMetric[];
+
+	// Why there is no interval, decided once for the whole row. The dashes in the
+	// numbers and the line in diagnostics both read it, so the card cannot give
+	// two accounts of one absence.
+	absentFlow: Explained | null;
+}
+
+// What this panel tells the page around it. The page needs it to decide whether
+// the Data plane segment exists at all and which segment an operator lands on,
+// and neither question can be answered from inside a segment that may not be
+// rendered.
+export interface DataPlaneReport {
+	reports: boolean;
+	// False when the counts below come from a read that failed. reports can still
+	// be true on the same report: a plane that answered once is still there when
+	// a poll blips, so the segment stays, but the counts describe nothing and a
+	// consumer must not state them as facts about now. Zero replicas after a
+	// failed read is unknown, not an empty plane.
+	known: boolean;
+	replicas: number;
+	accepting: number;
+}
+
 // loading: no read has landed yet. Nothing renders, because most instances turn
 // out to have no plane and a spinner would flash a panel onto every one of them.
 // hidden: the server wires no data plane monitoring at all (501), so there is
@@ -64,16 +151,185 @@ interface DataPlaneReplica {
 // unknown: the read failed, so the last numbers no longer describe the present.
 type DataPlaneState = 'loading' | 'ready' | 'empty' | 'hidden' | 'unknown';
 
+// The plane names its own counters, so no dictionary can be trusted to list
+// them. These are the words that mean something went wrong whatever the plane
+// calls the thing it happened to. A counter carrying none of them stays in
+// diagnostics, which is the safe direction to be wrong in: a missed promotion
+// costs a click, a wrong one puts a healthy number under "where it is stuck".
+const PROBLEM_WORDS = ['error', 'errors', 'fail', 'failed', 'failure', 'failures', 'abandoned', 'dropped', 'lost', 'rejected', 'timeout', 'timeouts'];
+
+// The glyph for a value there is nothing to print for, matching the no-data
+// cells the dashboard already has. A dash conventionally means no data, which a
+// zero does not, and it holds the row rhythm so a reader can still scan the
+// labels beside it.
+const NO_VALUE = '-';
+
+// Why a value is a dash. Every absence on this panel comes from here, so the
+// same glyph never has to stand for two reasons without saying which: a plane
+// that is not accepting, one on its first sample, one that restarted underneath
+// the sampler, one that sent part of an interval, and a count the plane could
+// not read. The first line is the reason and the second is what it means for the
+// number, matching the dashboard's existing no-data cells.
+const ABSENT_REASONS: Record<EngineFlowAbsence, Explained> & { stopped: Explained; unread: Explained; unreadCount: Explained } = {
+	// A replica that is not accepting publishes no interval, and the run-scoped
+	// sections are dropped on the way in, so the gauge list is empty for a reason
+	// that has nothing to do with sampling. Saying a number appears on the next
+	// sample would promise one from a plane that has stopped taking work, which is
+	// the opposite of what the verdict beside it says.
+	stopped: {
+		reason: 'Plane not accepting.',
+		detail: 'This replica reported that it is not accepting work, so it measured no interval. No number appears here until it is accepting again.'
+	},
+	// The first two say a number is coming and that nothing is wrong. A dash an
+	// operator cannot account for reads as a broken panel, and the wire says
+	// exactly which of the two it is, so neither has to be vague about it.
+	starting: {
+		reason: 'No earlier sample yet.',
+		detail: 'This is the first sample since the plane started, so there is nothing to compare it against. A number appears on the next sample. Nothing is wrong.'
+	},
+	restarted: {
+		reason: 'Plane restarted.',
+		detail: 'A total went backwards, so the interval spanning the restart was discarded rather than reported as a rate. A number appears on the next sample. Nothing is wrong.'
+	},
+	incomplete: {
+		reason: 'Reported incompletely.',
+		detail: 'The plane sent part of an interval, and a count without the window it covers is not a rate. This is unknown rather than zero.'
+	},
+	unread: {
+		reason: 'Not read.',
+		detail: 'At least one backlog count could not be read, so the total is unknown rather than zero.'
+	},
+	unreadCount: {
+		reason: 'Not read.',
+		detail: 'The plane could not read this count, so it is unknown rather than zero.'
+	}
+};
+
+// What each metric means, available on its label whether or not the value is
+// known. A number an operator cannot interpret is not information: "Outstanding
+// is growing" is only alarming to a reader who knows it counts work not yet
+// done, so where a direction has a meaning it is stated.
+//
+// Only the metrics whose meaning this build actually knows are described. The
+// plane names its own stages, counters and backlogs, so no copy can be written
+// for those without inventing it, and an invented explanation is worse than
+// none.
+// The two interval numbers count different things, so each says what it counts
+// and the pair says outright that it must not be subtracted. One accepted event
+// fans out to a delivery per matching subscription, so deliveries out routinely
+// exceeds events in, and a reader who takes these for one quantity measured twice
+// reads that surplus as impossible or a deficit as a backlog forming.
+const METRIC_MEANINGS = {
+	in: {
+		reason: 'Events accepted in the last measured interval.',
+		detail: 'Counted once the plane has taken responsibility for the event, and counted as events. Not comparable with Deliveries out: one event fans out to a delivery per matching subscription, so the two are the ends of the plane rather than two sides of a sum. A count for the interval, not a rate.'
+	},
+	out: {
+		reason: 'Deliveries completed in the last measured interval.',
+		detail: 'Successful deliveries only, counted as deliveries. It can exceed Events in, because one event fans out to a delivery per matching subscription, so the difference between the two means nothing. Zero over a window is not by itself a stall: deliveries waiting on a retry schedule complete when they are due, not when they are counted. A count for the interval, not a rate.'
+	},
+	// Deliberately not "growing means the plane is behind". A delivery waiting on
+	// a retry schedule is outstanding for as long as its schedule says, so under
+	// steady load the count climbs to the arrival rate times that schedule and
+	// then sits there, which is the system working. Reading that plateau as a
+	// stuck plane is the false alarm this copy exists to prevent, so the copy
+	// says what the number counts and points at the schedule lines, which are
+	// where a reader can tell a backlog draining on time from one that is not.
+	outstanding: {
+		reason: 'Work accepted and not yet done.',
+		detail: 'The durable backlog, so it survives a restart. It counts deliveries waiting on a retry schedule as well as work waiting to be attempted, and a scheduled retry is future work with a due time rather than work held up. A steady arrival rate against a retry schedule holds a roughly constant number here, so a count that rises and then settles is what a working plane looks like. The lines under it say how old the oldest waiting retry is and when the next one is due, which is what separates a backlog draining on schedule from one that is not.'
+	}
+};
+
+// Said where someone staring at a row of zeros will read it, on the identity
+// those zeros belong to. Which process accepted the work is the whole
+// difference between a plane that is broken and a plane nothing is being sent
+// to, and nothing else in the product would tell an operator that an agent
+// running a plane only takes what was posted to its own port.
+//
+// Worded for the contract rather than for one plane: any plane can publish this
+// shape, so the note says what is true of a replica and then names the
+// agent-port case, instead of asserting an agent port on a plane that may not
+// have one.
+// What the queue carries instead is on the segment caveat above, not repeated
+// here.
+const REPLICA_SCOPE: Explained = {
+	reason: 'This replica only counts work its own process accepted.',
+	detail: 'On an agent running a data plane that is work posted to the agent HTTP port. Work that reaches the instance any other way is carried by the queue instead, so this replica can be accepting nothing while the instance itself is busy. The numbers below are a fact about this replica, not about the instance.'
+};
+
+// The gauges a plane publishes its measured interval under, and the only place
+// those names are spelled. A plane reports throughput through the same
+// vocabulary-neutral gauge list as everything else rather than through a section
+// of its own, and these names carry the concept rather than any plane's
+// components, so a queue-based plane can publish the same set.
+//
+// The first four are one compound value and are omitted together. The fifth is
+// published alone, with those four absent, so a restart sample is also an
+// unmeasured sample: the two coincide rather than being alternatives.
+const THROUGHPUT_GAUGES = {
+	windowMs: 'throughput_window_ms',
+	accepted: 'throughput_accepted',
+	delivered: 'throughput_delivered',
+	failed: 'throughput_failed',
+	restarted: 'throughput_restarted'
+} as const;
+
+// The four that make up the interval. Any one of them missing means the interval
+// is unknown, so this list is what the accessor requires rather than defaulting a
+// member to zero: a count without the window it covers is not a rate, and a
+// window without its counts is not a measurement.
+const WINDOW_GAUGES: readonly string[] = [THROUGHPUT_GAUGES.windowMs, THROUGHPUT_GAUGES.accepted, THROUGHPUT_GAUGES.delivered, THROUGHPUT_GAUGES.failed];
+
+// The two gauges that describe the retry backlog's schedule, and the backlog
+// entry they describe. Same compound rule as the interval: published together or
+// omitted together, because an oldest age without a due time says nothing about
+// whether the backlog is draining and a due time without an age says nothing
+// about how long it has not been.
+const RETRY_GAUGES = {
+	oldestAgeMs: 'outstanding_oldest_retry_age_ms',
+	nextDueInMs: 'outstanding_next_retry_due_in_ms'
+} as const;
+
+// The one backlog name this panel spells, and it spells it because the two
+// gauges above describe that backlog and no other. Which of the plane's backlogs
+// has a schedule is a fact about the schedule, not vocabulary the renderer
+// invented, and a plane that names its retry backlog something else simply
+// publishes no schedule this panel can attribute.
+const RETRY_BACKLOG = 'deliveries_retry';
+
+// How overdue the plane's own reading has to be before the panel says so as well
+// as showing it. One sample cannot see persistence, so the threshold has to be
+// large enough that a single reading carries it: a retry can be a little overdue
+// simply because the scanner has not reached it yet inside its lease window, and
+// the plane publishes every few seconds, so a minute is an order of magnitude
+// above the lateness that is ordinary and cannot be produced by it.
+const OVERDUE_NOTE_MS = 60_000;
+
+// The two lifetime failure totals, which the plane reports separately because
+// they are different events: one delivery was never sent, the other was sent and
+// did not succeed. They are named here rather than left to the problem-word rule
+// below, which would promote one of them and leave the other in diagnostics.
+const FAILURE_COUNTERS = {
+	discarded: 'deliveries_discarded',
+	failed: 'deliveries_failed'
+} as const;
+
+// Words that read worse in sentence case than shouted. This is a spelling list,
+// not a vocabulary list: it does not need to know what any plane calls anything.
+const ACRONYMS = new Set(['lsn', 'id', 'ids', 'db', 'sql', 'http', 'url', 'tls', 'cdc', 'api', 'ttl']);
+
 // An omitted section becomes an empty list once, here, so each list keeps one
 // identity for as long as the reply it came from is on screen.
 //
 // The run-scoped sections are dropped when a replica is not accepting work, and
-// dropped here rather than trusted to arrive empty. Stage depth, writer backlog
-// and the live gauges describe a plane that is running; on one that stopped they
-// are the last thing it saw, and rendering them beside a "not accepting" tag
-// invites reading them as current. Counters and the durable backlog stay: a
-// total still describes the run that ended, and rows outstanding in the database
-// are outstanding whether or not anything is draining them.
+// dropped here rather than trusted to arrive empty. Stage depth, writer backlog,
+// the live gauges and the last interval's flow describe a plane that is running;
+// on one that stopped they are the last thing it saw, and rendering them beside
+// a "not accepting" tag invites reading them as current. Counters and the
+// durable backlog stay: a total still describes the run that ended, and rows
+// outstanding in the database are outstanding whether or not anything is
+// draining them.
 function sections(replica: any): DataPlaneReplica {
 	const running = replica.running === true;
 	return {
@@ -86,15 +342,120 @@ function sections(replica: any): DataPlaneReplica {
 	};
 }
 
+// The one reader of the throughput gauges on this panel. The verdict sentence,
+// the In and Out cells and the diagnostics table all take their answer from
+// here, so the three cannot hold separate opinions of what the plane published:
+// before this existed, one path looked for a `throughput` section the plane does
+// not send while another iterated the gauges it does, and the card reported "not
+// reported" above the numbers themselves.
+//
+// It answers one question three ways: a measured interval, a measured interval
+// that happens to be zero, which is a real answer and prints as 0, or no
+// measurement, which carries the reason there is none and prints as a dash. Every
+// reason is knowable from this one sample, so nothing downstream has to report an
+// unexplained absence.
+function throughputOf(replica: DataPlaneReplica): EngineFlow {
+	const read = (name: string) => readGauge(replica, name);
+
+	const windowMs = read(THROUGHPUT_GAUGES.windowMs);
+	const accepted = read(THROUGHPUT_GAUGES.accepted);
+	const delivered = read(THROUGHPUT_GAUGES.delivered);
+	const failed = read(THROUGHPUT_GAUGES.failed);
+
+	// The restart gauge is published alone, so it is read before the window is
+	// judged missing: it is the reason the window is missing, and it is a more
+	// useful thing to say than that the plane has only just started.
+	if (read(THROUGHPUT_GAUGES.restarted)) return { absence: 'restarted' };
+
+	// None of the four is the plane's first sample, which is the state it is in
+	// for one interval after every start. Some of the four is a partial publish,
+	// which nothing on the wire explains, so the two are kept apart.
+	const present = WINDOW_GAUGES.filter(name => replica.gauges.some(gauge => gauge.name === name)).length;
+	if (!present) return { absence: 'starting' };
+
+	// An interval of no length carries no rate, so it joins the partial publish
+	// rather than becoming a window a label would have to name.
+	if (windowMs === null || windowMs <= 0 || accepted === null || delivered === null || failed === null) return { absence: 'incomplete' };
+
+	return { measured: { windowMs, in: accepted, out: delivered, failed } };
+}
+
+// Number.isFinite rather than a presence check, because a gauge that arrived as
+// a string or a NaN is not a measurement either.
+function readGauge(replica: DataPlaneReplica, name: string): number | null {
+	const gauge = replica.gauges.find(candidate => candidate.name === name);
+	return gauge && Number.isFinite(gauge.value) ? Number(gauge.value) : null;
+}
+
+function readCounter(replica: DataPlaneReplica, name: string): number {
+	const counter = replica.counters.find(candidate => candidate.name === name);
+	return counter && Number.isFinite(counter.value) ? Number(counter.value) : 0;
+}
+
+// The one reader of the retry schedule, for the same reason throughputOf is the
+// one reader of the interval.
+//
+// reported: the retry backlog was read, it has rows, and the plane published
+// both gauges over them. The count and both readings come from one statement
+// over one set of rows, so they agree by construction.
+// empty: the backlog was read and has no rows. There is no oldest retry and
+// nothing is due, which is an answer rather than a gap, so it must not render as
+// the absence dash. The publisher does not send zeros for this, deliberately: a
+// zero age already means a retry created this instant, which is a different fact
+// from there being none, and reading an absence as a zero would put those two
+// back together.
+// unknown: the backlog could not be read, the plane is not running so the gauges
+// carry no meaning and were cleared, or rows exist without the gauges that
+// describe them, which the contract says cannot happen and so is a bug rather
+// than a state to render. All three render nothing rather than a number, and the
+// first is already carried by the dash on the count itself.
+function retryScheduleOf(replica: DataPlaneReplica): RetrySchedule {
+	const retries = replica.outstanding.find(backlog => backlog.name === RETRY_BACKLOG);
+	if (!retries || !retries.known) return { kind: 'unknown' };
+
+	// Checked before the gauges, so a plane that published a schedule alongside
+	// an empty backlog still reads as empty. Rows are what an age describes, and
+	// there are none.
+	if (retries.count <= 0) return { kind: 'empty' };
+
+	const oldestAgeMs = readGauge(replica, RETRY_GAUGES.oldestAgeMs);
+	const nextDueInMs = readGauge(replica, RETRY_GAUGES.nextDueInMs);
+	if (oldestAgeMs === null || nextDueInMs === null) return { kind: 'unknown' };
+
+	return { kind: 'reported', oldestAgeMs, nextDueInMs };
+}
+
+// The gauges left for the diagnostics table once the accessor has taken the ones
+// it reads. Rendering them there as well would put the plane's raw gauge names in
+// front of an operator beside the same numbers already named above, which is the
+// arrangement that let the table contradict the verdict in the first place.
+function diagnosticGauges(replica: DataPlaneReplica): DataPlaneMetric[] {
+	const consumed: readonly string[] = [...Object.values(THROUGHPUT_GAUGES), ...Object.values(RETRY_GAUGES)];
+	return replica.gauges.filter(gauge => !consumed.includes(gauge.name));
+}
+
 @Component({
 	selector: 'convoy-queue-monitoring-dataplane',
-	imports: [CommonModule, TagComponent],
+	imports: [CommonModule, TagComponent, TooltipComponent, EngineVerdictComponent],
 	templateUrl: './queue-monitoring-dataplane.component.html'
 })
 export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
+	// Whether this panel is the segment on screen. It polls either way: the page
+	// reads this panel's report to decide whether the segmented control exists
+	// and which segment is the default, so the poll cannot be tied to being
+	// visible. Defaults true so the panel still renders on its own.
+	@Input() active = true;
+
+	@Output() reported = new EventEmitter<DataPlaneReport>();
+
 	state: DataPlaneState = 'loading';
-	replicas: DataPlaneReplica[] = [];
+	rows: DataPlaneRow[] = [];
 	staleAfterSeconds = 0;
+
+	// Collapsed by default, per replica. Diagnostics is where today's whole panel
+	// went, and it is opened by a reader who has decided the verdict is not
+	// enough.
+	private opened = new Set<string>();
 
 	private timer?: ReturnType<typeof setInterval>;
 	// Every response is checked against the request that is current when it
@@ -104,6 +465,12 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 	// while that read is in flight would otherwise start a timer after
 	// ngOnDestroy has already run, and nothing would ever clear it.
 	private destroyed = false;
+	// Whether a read has ever found a replica in this session. A failed read is
+	// not evidence that a plane exists, so on a queue-only instance the first
+	// failure must not grow a Data plane segment; a failure after the plane has
+	// answered keeps it, because the plane is still there and the read is what
+	// broke.
+	private everReported = false;
 
 	constructor(private readonly adminService: AdminService) {}
 
@@ -126,10 +493,19 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 		return !!this.timer;
 	}
 
-	// A backlog that was not read is unknown. The template asks for the label
-	// rather than the number so there is one place this decision is made.
+	// A backlog that was not read is unknown, and it renders as the same dash the
+	// numbers above it use, for the same reason: the word repeated down a column
+	// of counts reads louder than the counts.
+	readonly unreadCount = ABSENT_REASONS.unreadCount;
+
+	readonly replicaScope = explainer('Replica scope', REPLICA_SCOPE);
+
 	backlogLabel(backlog: DataPlaneBacklog): string {
-		return backlog.known ? `${backlog.count}` : 'unknown';
+		return backlog.known ? engineCount(backlog.count) : NO_VALUE;
+	}
+
+	backlogAria(backlog: DataPlaneBacklog): string {
+		return `${this.label(backlog.name)}: ${this.unreadCount.reason} ${this.unreadCount.detail}`;
 	}
 
 	// The plane reports 0 workers when a stage runs one goroutine per item. That
@@ -145,6 +521,36 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 		return `${Math.round(seconds / 60)}m ago`;
 	}
 
+	// Underscores to spaces, sentence case, and never SCREAMING_SNAKE. A name
+	// this build has never seen still renders as a phrase, which is what keeps
+	// the contract vocabulary-neutral: the UI stops shouting names it does not
+	// know without having to know them.
+	label(name: string): string {
+		const words = (name ?? '')
+			.replace(/[_\-.]+/g, ' ')
+			.trim()
+			.toLowerCase()
+			.split(/\s+/)
+			.filter(word => !!word)
+			.map(word => (ACRONYMS.has(word) ? word.toUpperCase() : word));
+
+		if (!words.length) return 'Unnamed';
+
+		const first = words[0];
+		const head = ACRONYMS.has(first.toLowerCase()) ? first : first.charAt(0).toUpperCase() + first.slice(1);
+
+		return [head, ...words.slice(1)].join(' ');
+	}
+
+	isOpen(replica: string): boolean {
+		return this.opened.has(replica);
+	}
+
+	toggleDiagnostics(replica: string): void {
+		if (this.opened.has(replica)) this.opened.delete(replica);
+		else this.opened.add(replica);
+	}
+
 	async load(): Promise<void> {
 		const id = ++this.fetchId;
 
@@ -152,27 +558,223 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 			const response = await this.adminService.getDataPlaneStatus();
 			if (id !== this.fetchId) return;
 
-			this.replicas = (response.data?.replicas ?? []).map(sections);
+			const replicas = (response.data?.replicas ?? []).map(sections);
+			this.rows = replicas.map((replica: DataPlaneReplica) => this.row(replica));
 			this.staleAfterSeconds = response.data?.stale_after_seconds ?? 0;
-			this.state = this.replicas.length ? 'ready' : 'empty';
+			this.state = this.rows.length ? 'ready' : 'empty';
+			if (this.state === 'ready') this.everReported = true;
+			else this.everReported = false;
 		} catch (error: any) {
 			if (id !== this.fetchId) return;
 
 			// 501 is the server saying this deployment wires no data plane
 			// monitoring, which is a definitive answer and not a failure.
 			if (error?.response?.status === 501) {
-				this.replicas = [];
+				this.rows = [];
+				this.everReported = false;
 				this.state = 'hidden';
 				this.stop();
+				this.publishReport();
 				return;
 			}
 
 			// Anything else is unknown, and the rows already on screen are
 			// dropped with it: a failed refresh must not leave stale depth
-			// answering for the present.
-			this.replicas = [];
+			// answering for the present. everReported is left alone, because a
+			// failed read says nothing about whether a plane exists.
+			this.rows = [];
 			this.state = 'unknown';
 		}
+
+		this.pruneOpened();
+		this.publishReport();
+	}
+
+	// Ids that are no longer on screen are dropped, so a replica that comes and
+	// goes cannot grow this set for the life of the tab.
+	private pruneOpened(): void {
+		const visible = new Set(this.rows.map(row => row.replica.replica));
+		this.opened.forEach(id => {
+			if (!visible.has(id)) this.opened.delete(id);
+		});
+	}
+
+	private publishReport(): void {
+		const reports = this.state === 'ready' || (this.state === 'unknown' && this.everReported);
+
+		this.reported.emit({
+			reports,
+			// Every state but 'unknown' is a read that answered, including the empty
+			// one and the 501: zero replicas from a read that worked is a known
+			// zero. Only a failed read leaves the counts describing nothing.
+			known: this.state !== 'unknown',
+			replicas: this.rows.length,
+			accepting: this.rows.filter(row => row.replica.running).length
+		});
+	}
+
+	// The accessor is called once per replica per reply and its answer is handed
+	// to every consumer below, so the verdict, the numbers, the stuck line and
+	// diagnostics are reading one value rather than each re-deriving it.
+	private row(replica: DataPlaneReplica): DataPlaneRow {
+		const outstanding = this.outstandingTotal(replica);
+		const flow = throughputOf(replica);
+
+		return {
+			replica,
+			// The window sums two terminal outcomes on this plane, so the sentence
+			// is told what to call them rather than naming the count after the
+			// narrower one.
+			verdict: { accepting: replica.running, reporting: !replica.stale, sampledLabel: this.ageLabel(replica), flow, outstanding, failedWord: 'failed or discarded' },
+			numbers: this.flowNumbers(replica, flow, outstanding),
+			holding: this.holdingLines(replica),
+			failures: this.failureLines(replica, flow),
+			flow,
+			gauges: diagnosticGauges(replica),
+			absentFlow: flow.absence ? absenceLines(replica, flow.absence) : null
+		};
+	}
+
+	// The reason diagnostics prints where the interval would be, read off the row
+	// so it cannot differ from the dash's tooltip upstairs.
+	absentReason(row: DataPlaneRow): string {
+		return row.absentFlow ? `${row.absentFlow.reason} ${row.absentFlow.detail}` : '';
+	}
+
+	// The durable backlogs summed, because the verdict asks one question and the
+	// operator compares one number against a queue depth.
+	//
+	// An absent section is absent: a plane that reported no backlog has not
+	// reported an empty one, so an empty list is unknown rather than zero. One
+	// unread count makes the sum a lower bound, which is also unknown, because a
+	// lower bound presented as a total is exactly how a full backlog comes to
+	// read as an empty one.
+	private outstandingTotal(replica: DataPlaneReplica): EngineCount {
+		if (!replica.outstanding.length) return { known: false, value: 0 };
+
+		let total = 0;
+		for (const backlog of replica.outstanding) {
+			if (!backlog.known) return { known: false, value: 0 };
+			total += backlog.count;
+		}
+
+		return { known: true, value: total };
+	}
+
+	// Events in, Deliveries out, Outstanding. Three states per number and never
+	// two of them at once: no measured interval, which is the dash and carries
+	// the reason there is none; a measured value; and a measured zero, which
+	// prints as 0 rather than as a dash, because an idle plane is a real and
+	// meaningful answer and a dash would make it look broken.
+	//
+	// The labels name their units because the first two count different things,
+	// and no note on either compares it against the other: any phrasing of the
+	// two together would be a subtraction, and the plane's own fanout makes that
+	// meaningless. Outstanding's notes describe its own retry rows, nothing else
+	// on the row.
+	private flowNumbers(replica: DataPlaneReplica, flow: EngineFlow, outstanding: EngineCount): FlowNumber[] {
+		// The two interval numbers are absent together or measured together,
+		// because they come from one compound value the plane publishes or omits
+		// as a whole. Branching once here is what makes that structural rather
+		// than a rule each cell has to remember.
+		const interval: FlowNumber[] = flow.absence
+			? [absentNumber('Events in', METRIC_MEANINGS.in, absenceLines(replica, flow.absence)), absentNumber('Deliveries out', METRIC_MEANINGS.out, absenceLines(replica, flow.absence))]
+			: [
+					// A measured zero on the intake gets a second line saying it was
+					// measured. The dash and the 0 are already different glyphs, but a
+					// reader scanning a card of zeros cannot see which of them the plane
+					// looked for and which it never reported, and on this number that is
+					// the difference between a quiet instance and one whose events are
+					// all reaching Convoy somewhere else.
+					measuredNumber('Events in', METRIC_MEANINGS.in, flow.measured.in, flow.measured.windowMs, 'measured, nothing reached this replica'),
+					measuredNumber('Deliveries out', METRIC_MEANINGS.out, flow.measured.out, flow.measured.windowMs)
+				];
+
+		// The snapshot's own age, from the server that read sampled_at, carries the
+		// schedule forward to now without the browser's clock entering into it.
+		const snapshotAgeMs = Number.isFinite(replica.age_seconds) ? Math.max(0, replica.age_seconds * 1000) : 0;
+
+		return [...interval, outstandingNumber(outstanding, retryScheduleOf(replica), snapshotAgeMs)];
+	}
+
+	// Where work is sitting right now, phrased as places rather than table rows,
+	// and rendered only when something is actually non-zero.
+	//
+	// This is the section that was headed "Where it is stuck" and listed a
+	// failure count under it. Both halves of that were claims the data does not
+	// support: an item queued in a stage is an item queued in a stage, and a
+	// failure counter is a lifetime total that is not attributed to any of the
+	// items sitting here. Reading those together turned a plane working exactly
+	// as designed into a twenty minute incident, so the two are separate
+	// sections now and neither asserts a cause.
+	private holdingLines(replica: DataPlaneReplica): string[] {
+		const lines: string[] = [];
+
+		for (const stage of replica.stages) {
+			const parts: string[] = [];
+			if (stage.queued) parts.push(`${engineCount(stage.queued)} queued`);
+			if (stage.waiting) parts.push(`${engineCount(stage.waiting)} senders waiting`);
+			if (parts.length) lines.push(`${this.label(stage.name)}: ${parts.join(', ')}`);
+		}
+
+		for (const writer of replica.writers) {
+			if (writer.pending) lines.push(`${this.label(writer.name)} writer: ${engineCount(writer.pending)} pending`);
+		}
+
+		return lines;
+	}
+
+	// Failures, as counts and nothing more. Every line here is a total the plane
+	// reports for itself, across every endpoint and project it serves, so none of
+	// them can be attributed to the backlog above: a paused endpoint's deliveries
+	// are discarded before dispatch and never join the outstanding set at all,
+	// yet they can dominate this number. The section says so rather than leaving
+	// the adjacency to imply otherwise.
+	//
+	// The two lifetime totals are stated as the different events they are. Half
+	// of why this card read as an incident was one number holding both: it was
+	// dominated by a paused endpoint's discards, which never join the outstanding
+	// set at all, while the backlog beside it belonged to an endpoint that was
+	// retrying normally.
+	private failureLines(replica: DataPlaneReplica, flow: EngineFlow): string[] {
+		const lines: string[] = [];
+
+		const failedBatches = replica.writers.reduce((total, writer) => total + (writer.failures ?? 0), 0);
+		if (failedBatches) lines.push(`${engineCount(failedBatches)} write batches failed`);
+
+		const discarded = readCounter(replica, FAILURE_COUNTERS.discarded);
+		if (discarded) lines.push(`${engineCount(discarded)} deliveries discarded before any attempt`);
+
+		const failed = readCounter(replica, FAILURE_COUNTERS.failed);
+		if (failed) lines.push(`${engineCount(failed)} deliveries failed after an attempt`);
+
+		// Only a measured interval can say anything ended in it, and the accessor
+		// is what decides that: an unmeasured interval carries no window here
+		// rather than a window of zeroes, so there is no unmeasured zero to guard
+		// against.
+		//
+		// Named for both outcomes. The window counts a discard the same as an
+		// exhausted retry on purpose, because it answers whether accepted work
+		// left the outstanding set, and calling it a failure count now that the
+		// lifetime totals are split would make one of the two invisible here.
+		const window = flow.measured;
+		if (window?.failed) {
+			lines.push(`${engineCount(window.failed)} deliveries failed or discarded in the last ${intervalWindowLabel(window.windowMs)}`);
+		}
+
+		// Failures and recovery errors are the only counters that always mean
+		// something went wrong, so they are promoted here whenever they are
+		// non-zero. Everything else stays in diagnostics. The two named above are
+		// skipped: the word rule would promote the failed one a second time and
+		// leave the discarded one out, which is the conflation this split exists
+		// to end.
+		const named: readonly string[] = Object.values(FAILURE_COUNTERS);
+		for (const counter of replica.counters) {
+			if (named.includes(counter.name)) continue;
+			if (counter.value && isProblemCounter(counter.name)) lines.push(`${this.label(counter.name)}: ${engineCount(counter.value)}`);
+		}
+
+		return lines;
 	}
 
 	// One interval owner: the server derives staleness from the same sample time
@@ -184,4 +786,129 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 		const seconds = Math.max(5, Math.round(this.staleAfterSeconds / 3));
 		this.timer = setInterval(() => void this.load(), seconds * 1000);
 	}
+}
+
+// The two authored lines, before the metric they belong to is known.
+type Explained = { readonly reason: string; readonly detail: string };
+
+// The accessible label names the metric, because a screen reader reaching a
+// tooltip button hears only what is in here: the two lines alone would not say
+// which of the three numbers they describe.
+function explainer(label: string, lines: Explained): Explainer {
+	return { reason: lines.reason, detail: lines.detail, aria: `${label}: ${lines.reason} ${lines.detail}` };
+}
+
+// Which absence this is. The accessor names the sampling reason, and it cannot
+// see the one case that is not about sampling: a replica that is not accepting
+// had its run-scoped gauges dropped on the way in, so it reads as the same empty
+// list a plane on its first sample publishes. Telling that reader a number
+// arrives on the next sample promises one from a plane that has stopped taking
+// work, and contradicts the verdict beside it. Both the dashes and diagnostics
+// come through here, so the row cannot give two accounts of one absence.
+function absenceLines(replica: DataPlaneReplica, absence: EngineFlowAbsence): Explained {
+	return replica.running ? ABSENT_REASONS[absence] : ABSENT_REASONS.stopped;
+}
+
+// A dash and the reason for it. The reason is decided above rather than by the
+// cell, so a cell cannot invent an explanation the wire did not give.
+function absentNumber(label: string, about: Explained, lines: Explained): FlowNumber {
+	return { label, value: null, about: explainer(label, about), absent: explainer(label, lines), notes: [] };
+}
+
+// The window is named on the number rather than assumed, and marked approximate
+// by intervalWindowLabel, because the plane reports the elapsed time it actually
+// measured rather than the period it was configured with.
+// zeroNote is for a number whose zero is worth reading as a reading. It is only
+// added when the plane measured the interval, so it can never appear beside a
+// dash and can never be mistaken for an explanation of an absent value.
+function measuredNumber(label: string, about: Explained, value: number, windowMs: number, zeroNote?: string): FlowNumber {
+	const notes = [`last ${intervalWindowLabel(windowMs)}`];
+	if (value === 0 && zeroNote) notes.push(zeroNote);
+
+	return { label, value: engineCount(value), about: explainer(label, about), absent: null, notes };
+}
+
+// The backlog as a level, with the schedule of its retries under it. The level
+// alone is still not described as stuck, behind or growing, because it counts
+// deliveries whose next attempt is scheduled for the future; what separates those
+// from work genuinely held up is the schedule, and the schedule says it in its
+// own lines rather than by colouring the count.
+//
+// Two minutes old with something due in thirty seconds is a backlog draining on
+// time. An hour old with nothing due for a long time is the shape of one nothing
+// is draining. That is the distinction "Where it is stuck" claimed to make and
+// could not, and it lives here, beside the number it is about.
+function outstandingNumber(outstanding: EngineCount, schedule: RetrySchedule, snapshotAgeMs: number): FlowNumber {
+	const about = explainer('Outstanding', METRIC_MEANINGS.outstanding);
+	// The schedule lines survive a total that could not be read, unlike the
+	// measured note on the intake, which is suppressed beside a dash. They are
+	// not the same kind of line: that one would be read as an account of the
+	// missing value, while these describe retry rows the plane did read. A total
+	// is unknown as soon as any one backlog is, so refusing to state a schedule
+	// that was read would throw away the most useful thing on the card over an
+	// unread count somewhere else.
+	const notes = scheduleNotes(schedule, snapshotAgeMs);
+	if (!outstanding.known) return { label: 'Outstanding', value: null, about, absent: explainer('Outstanding', ABSENT_REASONS.unread), notes };
+
+	return { label: 'Outstanding', value: engineCount(outstanding.value), about, absent: null, notes };
+}
+
+// The schedule as two plain readings, and a third line only when one sample can
+// carry it.
+//
+// Both readings are carried forward from the sample rather than recomputed from
+// the browser's clock. The plane published an age and a time-to-due instead of
+// two timestamps precisely so no consumer has to line up two clocks, and neither
+// number crossed a clock boundary to be produced; subtracting the browser's now
+// from anything here would fold plane-to-browser skew into a number an operator
+// pages on. The snapshot's own age is the only thing added, and it comes from
+// the same server that read sampled_at.
+//
+// The third line says the next retry is overdue by more than a scan cycle could
+// explain. It stops short of calling the backlog stuck, because this sample
+// cannot see whether that item is being worked right now, and it stops short of
+// calling it fine, because nothing being due for that long is the shape of a
+// backlog nothing is draining.
+//
+// That line is judged on the plane's own reading rather than on the reading
+// carried forward, deliberately. Carrying forward is a display convenience and
+// says nothing about what happened since: an old sample of a healthy backlog
+// crosses any threshold you like just by sitting there, and a panel that turned
+// its own staleness into an overdue claim would be the false alarm again with a
+// new cause.
+function scheduleNotes(schedule: RetrySchedule, snapshotAgeMs: number): string[] {
+	if (schedule.kind === 'unknown') return [];
+	if (schedule.kind === 'empty') return ['no retries waiting'];
+
+	const oldest = schedule.oldestAgeMs + snapshotAgeMs;
+	const due = schedule.nextDueInMs - snapshotAgeMs;
+
+	const notes = [`oldest retry ${durationLabel(oldest)} old`, due >= 0 ? `next due in ${durationLabel(due)}` : `next due ${durationLabel(-due)} ago`];
+
+	if (-schedule.nextDueInMs > OVERDUE_NOTE_MS) notes.push('overdue by longer than a scan cycle explains');
+
+	return notes;
+}
+
+// Whole units, floored, because these are read beside each other and a value
+// that rounds 59 minutes up to an hour makes the pair inconsistent. Flooring
+// also keeps an age from ever reading older than it is.
+function durationLabel(milliseconds: number): string {
+	const seconds = Math.max(0, Math.floor(milliseconds / 1000));
+	if (seconds < 60) return `${seconds}s`;
+
+	const minutes = Math.floor(seconds / 60);
+	if (minutes < 60) return `${minutes}m`;
+
+	const hours = Math.floor(minutes / 60);
+	const rest = minutes % 60;
+
+	return rest ? `${hours}h ${rest}m` : `${hours}h`;
+}
+
+function isProblemCounter(name: string): boolean {
+	return (name ?? '')
+		.toLowerCase()
+		.split(/[^a-z]+/)
+		.some(word => PROBLEM_WORDS.includes(word));
 }

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring.component.html
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring.component.html
@@ -1,32 +1,77 @@
-@if (!licensed) {
+<!-- Three states, exactly one of them painted: this loader while the reads are in
+     flight, the banner below once the read answered unlicensed, the surfaces
+     once it answered licensed. licensed is assigned in the same synchronous
+     block that clears isLoadingLicense, so no change-detection pass can see
+     this branch alongside either of the others. -->
+@if (isLoadingLicense) {
+  <div class="bg-white-100 border border-new.border rounded-12px p-20px flex items-center justify-center">
+    <convoy-loader position="relative"></convoy-loader>
+  </div>
+}
+
+@if (licenseKnown && !licensed) {
   <div class="bg-white-100 border border-new.border rounded-12px p-20px">
     <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Queue monitoring requires a license key. Contact support to enable it on this instance.</p>
   </div>
 }
 
-<!-- Above the queue surfaces: on a deployment whose events bypass the queue,
-     this is the only panel that can show a backlog at all. It renders nothing
-     when no data plane reports.
-
-     Gated on licensed, which is not a re-check of a server-gated field: the
-     status route answers 401 without the monitoring license, and the HTTP
-     interceptor logs the user out on any 401 before it looks at
-     hideNotification. Rendering this panel unlicensed would send an admin to
-     the login page on page load. -->
 @if (licensed) {
-  <convoy-queue-monitoring-dataplane></convoy-queue-monitoring-dataplane>
-}
+  <!-- Only when a plane reports. A queue-only instance sees the tab exactly as
+       it did before, with nothing above the queue view and nothing pushing it
+       down. Both engines are live when a plane runs, so this selects which
+       one is on screen and never which one is running. -->
+  @if (planeReports) {
+    <div class="flex flex-col gap-8px mb-24px min-w-0">
+      <div class="flex items-stretch h-44px w-fit drop-shadow-[0px_2px_1px_rgba(0,0,0,0.04)]">
+        <button
+          type="button"
+          class="px-16px font-body font-medium text-[14px] leading-[16px] border transition-colors rounded-l-8px"
+          [class]="segment === 'dataplane' ? 'bg-new.primary-400 border-new.primary-400 text-white-100 z-[1] relative' : 'bg-white-100 border-new.border text-new.text-primary hover:bg-new.surface-muted'"
+          [attr.aria-pressed]="segment === 'dataplane'"
+          (click)="selectSegment('dataplane')"
+          >
+          Data plane
+        </button>
+        <button
+          type="button"
+          class="px-16px font-body font-medium text-[14px] leading-[16px] border transition-colors rounded-r-8px -ml-[1px]"
+          [class]="segment === 'queue' ? 'bg-new.primary-400 border-new.primary-400 text-white-100 z-[1] relative' : 'bg-white-100 border-new.border text-new.text-primary hover:bg-new.surface-muted'"
+          [attr.aria-pressed]="segment === 'queue'"
+          (click)="selectSegment('queue')"
+          >
+          Queue
+        </button>
+      </div>
 
-@if (licensed && surface === 'loading') {
-  <div class="bg-white-100 border border-new.border rounded-12px p-20px">
-    <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Loading queue monitoring.</p>
-  </div>
-}
+      <p class="font-body font-normal text-[13px] leading-normal text-new.text-secondary min-w-0 break-words">{{ otherEngineLine }}</p>
+    </div>
+  }
 
-@if (licensed && usePostgresUi) {
-  <convoy-queue-monitoring-broker></convoy-queue-monitoring-broker>
-}
+  <!-- Mounted whether or not it is the segment on screen, because the page reads
+       its report to decide whether the control above exists at all and which
+       segment an operator lands on. A panel that only polled while visible could
+       not answer either question.
 
-@if (licensed && surface === 'redis') {
-  <convoy-queue-monitoring-asynqmon></convoy-queue-monitoring-asynqmon>
+       Gated on licensed, which is not a re-check of a server-gated field: the
+       status route answers 401 without the monitoring license, and the HTTP
+       interceptor logs the user out on any 401 before it looks at
+       hideNotification. Rendering this panel unlicensed would send an admin to
+       the login page on page load. -->
+  <convoy-queue-monitoring-dataplane [active]="segment === 'dataplane'" (reported)="onPlaneReported($event)"></convoy-queue-monitoring-dataplane>
+
+  @if (segment === 'queue') {
+    @if (surface === 'loading') {
+      <div class="bg-white-100 border border-new.border rounded-12px p-20px">
+        <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Loading queue monitoring.</p>
+      </div>
+    }
+
+    @if (usePostgresUi) {
+      <convoy-queue-monitoring-broker></convoy-queue-monitoring-broker>
+    }
+
+    @if (surface === 'redis') {
+      <convoy-queue-monitoring-asynqmon></convoy-queue-monitoring-asynqmon>
+    }
+  }
 }

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring.component.spec.ts
@@ -1,0 +1,460 @@
+import { CommonModule } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { AdminService } from 'src/app/private/pages/admin/admin.service';
+import { LicensesService } from 'src/app/services/licenses/licenses.service';
+import { RbacService } from 'src/app/services/rbac/rbac.service';
+
+import { QueueMonitoringComponent, QueueMonitoringSegment } from './queue-monitoring.component';
+
+const UNLICENSED_COPY = 'Queue monitoring requires a license key';
+
+describe('QueueMonitoringComponent', () => {
+	let fixture: ComponentFixture<QueueMonitoringComponent>;
+	let licensed: boolean;
+	let role: string;
+	let answerRole!: () => void;
+	let answerLicenses!: () => void;
+
+	beforeEach(async () => {
+		licensed = false;
+		role = 'INSTANCE_ADMIN';
+
+		await TestBed.configureTestingModule({
+			imports: [CommonModule, QueueMonitoringComponent],
+			providers: [
+				// Left pending. The surface and data plane reads only happen on a
+				// licensed instance, and neither one is what these tests are about.
+				{
+					provide: AdminService,
+					useValue: {
+						getQueueStats: () => new Promise(() => {}),
+						getDataPlaneStatus: () => new Promise(() => {})
+					}
+				},
+				{
+					provide: LicensesService,
+					useValue: {
+						// Both reads ngOnInit awaits are held open so a test can paint
+						// the page at the moment each one is still in flight. That
+						// moment is the whole subject here: it is the state every
+						// visit to the tab passes through.
+						loadAllLicenses: () => new Promise<void>(resolve => (answerLicenses = resolve as () => void)),
+						hasInstanceLicense: () => licensed
+					}
+				},
+				{ provide: RbacService, useValue: { getUserRole: () => new Promise(resolve => (answerRole = () => resolve(role))) } },
+				{ provide: Router, useValue: { navigateByUrl: () => {}, navigate: () => Promise.resolve(true) } },
+				// The segmented control's selection lives in the URL, so the page
+				// reads the landing query params. No segment is chosen in these
+				// tests; they are about the license gate.
+				{ provide: ActivatedRoute, useValue: { snapshot: { queryParams: {} } } }
+			]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(QueueMonitoringComponent);
+
+		// The first pass runs ngOnInit, so ngOnInit is never called by hand here:
+		// a second call would start a second pair of reads and overwrite the
+		// resolvers the test is holding.
+		fixture.detectChanges();
+	});
+
+	afterEach(() => {
+		fixture.destroy();
+	});
+
+	// The component's own detector, not fixture.detectChanges: these tests move
+	// state between passes on purpose, which is what the fixture's verification
+	// pass exists to reject.
+	function paint() {
+		fixture.changeDetectorRef.detectChanges();
+	}
+
+	function text(): string {
+		return (fixture.nativeElement as HTMLElement).textContent ?? '';
+	}
+
+	// The only loader that can reach the page here is the one under test: the
+	// surface read is left pending, so the asynqmon child (which carries the
+	// other loader in this folder) is never rendered.
+	function loader(): Element | null {
+		return (fixture.nativeElement as HTMLElement).querySelector('convoy-loader');
+	}
+
+	// A resolved promise continues on the microtask queue, so the awaits inside
+	// ngOnInit need a few turns to reach the next read.
+	async function settle() {
+		for (let turn = 0; turn < 5; turn++) await Promise.resolve();
+	}
+
+	it('does not claim the instance is unlicensed before the role read lands', () => {
+		paint();
+
+		expect(text()).not.toContain(UNLICENSED_COPY);
+	});
+
+	it('does not claim the instance is unlicensed while the license read is in flight', async () => {
+		answerRole();
+		await settle();
+
+		paint();
+
+		expect(text()).not.toContain(UNLICENSED_COPY);
+	});
+
+	it('claims it once the license read answers that the instance is unlicensed', async () => {
+		answerRole();
+		await settle();
+		answerLicenses();
+		await settle();
+
+		paint();
+
+		expect(text()).toContain(UNLICENSED_COPY);
+	});
+
+	it('never claims it on a licensed instance', async () => {
+		licensed = true;
+
+		answerRole();
+		await settle();
+		answerLicenses();
+		await settle();
+
+		paint();
+
+		expect(text()).not.toContain(UNLICENSED_COPY);
+	});
+
+	it('shows a loader on the first pass, before the role read lands', () => {
+		paint();
+
+		expect(loader()).not.toBeNull();
+	});
+
+	it('keeps the loader while the license read is in flight', async () => {
+		answerRole();
+		await settle();
+
+		paint();
+
+		expect(loader()).not.toBeNull();
+	});
+
+	it('drops the loader once the license read answers that the instance is unlicensed', async () => {
+		answerRole();
+		await settle();
+		answerLicenses();
+		await settle();
+
+		paint();
+
+		expect(loader()).toBeNull();
+		expect(text()).toContain(UNLICENSED_COPY);
+	});
+
+	it('drops the loader once the license read answers that the instance is licensed', async () => {
+		licensed = true;
+
+		answerRole();
+		await settle();
+		answerLicenses();
+		await settle();
+
+		paint();
+
+		expect(loader()).toBeNull();
+	});
+
+	// A non-admin is navigated away, so no verdict is ever read here. The loader
+	// still has to go: a navigation that does not complete would otherwise leave
+	// it spinning forever, and the banner must stay away because nothing was read.
+	it('drops the loader on the non-admin path without claiming the instance is unlicensed', async () => {
+		role = 'PROJECT_VIEWER';
+
+		answerRole();
+		await settle();
+
+		paint();
+
+		expect(loader()).toBeNull();
+		expect(text()).not.toContain(UNLICENSED_COPY);
+	});
+});
+
+// The segmented control is the placement decision: one tab, two engines, one on
+// screen at a time, and never a mode switch that hides an engine that is running.
+// When a data plane runs both are live, so what this chooses is which half is
+// being read, not which half exists.
+describe('QueueMonitoringComponent segments', () => {
+	const DATA_PLANE: QueueMonitoringSegment = 'dataplane';
+	const QUEUE: QueueMonitoringSegment = 'queue';
+
+	let fixture: ComponentFixture<QueueMonitoringComponent>;
+	let component: QueueMonitoringComponent;
+	let planeReplicas: any[];
+	let queryParams: Record<string, string>;
+	let navigations: any[];
+
+	function replica(overrides: any = {}) {
+		return {
+			replica: 'agent-1',
+			mode: 'example',
+			running: true,
+			sampled_at: '2026-09-01T08:00:00Z',
+			age_seconds: 2,
+			stale: false,
+			stages: [],
+			writers: [],
+			counters: [],
+			gauges: [],
+			outstanding: [{ name: 'events_pending', count: 5, known: true, as_of: '2026-09-01T08:00:00Z' }],
+			...overrides
+		};
+	}
+
+	async function start() {
+		await TestBed.configureTestingModule({
+			imports: [CommonModule, QueueMonitoringComponent],
+			providers: [
+				{
+					provide: AdminService,
+					useValue: {
+						// Left pending, so the surface stays 'loading' and neither
+						// queue surface mounts. Which queue surface renders is not
+						// what these tests are about, and the asynqmon child brings
+						// its own dependencies with it.
+						getQueueStats: () => new Promise(() => {}),
+						getDataPlaneStatus: () => Promise.resolve({ data: { replicas: planeReplicas, stale_after_seconds: 15 } })
+					}
+				},
+				{ provide: LicensesService, useValue: { loadAllLicenses: () => Promise.resolve(), hasInstanceLicense: () => true } },
+				{ provide: RbacService, useValue: { getUserRole: () => Promise.resolve('INSTANCE_ADMIN') } },
+				{
+					provide: Router,
+					useValue: {
+						navigateByUrl: () => {},
+						navigate: (_commands: any[], options: any) => {
+							navigations.push(options);
+							return Promise.resolve(true);
+						}
+					}
+				},
+				{ provide: ActivatedRoute, useValue: { snapshot: { queryParams } } }
+			]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(QueueMonitoringComponent);
+		component = fixture.componentInstance;
+
+		// The page awaits a role read and a license read before the panel is even
+		// created, and the panel then awaits its own first status read before it
+		// can report. Each pass here is one of those hops.
+		fixture.detectChanges();
+		for (let pass = 0; pass < 4; pass++) {
+			await settle();
+			fixture.changeDetectorRef.detectChanges();
+		}
+	}
+
+	beforeEach(() => {
+		TestBed.resetTestingModule();
+		planeReplicas = [replica()];
+		queryParams = {};
+		navigations = [];
+	});
+
+	afterEach(() => {
+		fixture?.destroy();
+	});
+
+	// Resolved promises continue on the microtask queue, and the page awaits a
+	// role read, a license read and the panel's first status read before the
+	// segment can be decided.
+	async function settle() {
+		for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+	}
+
+	function segmentButtons(): HTMLButtonElement[] {
+		return Array.from((fixture.nativeElement as HTMLElement).querySelectorAll('button[aria-pressed]'));
+	}
+
+	function click(label: string) {
+		const button = segmentButtons().find(candidate => candidate.textContent?.trim() === label);
+		button?.click();
+		fixture.changeDetectorRef.detectChanges();
+	}
+
+	// Ownership of HTTP events is read from what the plane published, because the
+	// dashboard has no flag for it. A replica accepting work is the engine those
+	// events go through.
+	it('lands on the data plane when a replica is accepting work', async () => {
+		await start();
+
+		expect(component.planeReports).toBeTrue();
+		expect(component.segment).toBe(DATA_PLANE);
+		expect(segmentButtons().length).toBe(2);
+	});
+
+	// A plane that reports and is accepting nothing has taken no HTTP events, so
+	// the queue is the engine carrying them and the queue is the landing view.
+	it('lands on the queue when the plane reports and nothing is accepting', async () => {
+		planeReplicas = [replica({ running: false })];
+
+		await start();
+
+		expect(component.planeReports).toBeTrue();
+		expect(component.segment).toBe(QUEUE);
+		expect(segmentButtons().length).toBe(2);
+	});
+
+	// A queue-only instance sees the tab exactly as it did before: no control, and
+	// nothing above the queue view pushing it down.
+	it('shows no control at all when no plane reports', async () => {
+		planeReplicas = [];
+
+		await start();
+
+		expect(component.planeReports).toBeFalse();
+		expect(component.segment).toBe(QUEUE);
+		expect(segmentButtons().length).toBe(0);
+	});
+
+	describe('URL round trip', () => {
+		it('lands on the segment the shared link names, against the default rule', async () => {
+			queryParams = { engine: 'queue' };
+
+			await start();
+
+			// The default rule would have chosen the data plane here.
+			expect(component.segment).toBe(QUEUE);
+		});
+
+		it('honours a link naming the data plane once the plane reports', async () => {
+			queryParams = { engine: 'dataplane' };
+			planeReplicas = [replica({ running: false })];
+
+			await start();
+
+			expect(component.segment).toBe(DATA_PLANE);
+		});
+
+		// A link naming a segment that does not exist on this instance must not
+		// leave a blank page: the derived getter falls back to the only view there
+		// is.
+		it('falls back to the queue when a link names the data plane and none reports', async () => {
+			queryParams = { engine: 'dataplane' };
+			planeReplicas = [];
+
+			await start();
+
+			expect(component.segment).toBe(QUEUE);
+			expect(segmentButtons().length).toBe(0);
+		});
+
+		it('ignores a value it does not recognise and applies the default rule', async () => {
+			queryParams = { engine: 'both' };
+
+			await start();
+
+			expect(component.segment).toBe(DATA_PLANE);
+		});
+
+		// An explicit value on every write, merged into the params already there,
+		// and replacing rather than stacking history. A null clear would leave the
+		// previous segment in the URL for the next reader of it.
+		it('writes the chosen segment to the URL', async () => {
+			await start();
+
+			click('Queue');
+
+			expect(component.segment).toBe(QUEUE);
+			expect(navigations.length).toBe(1);
+			expect(navigations[0].queryParams).toEqual({ engine: 'queue' });
+			expect(navigations[0].queryParamsHandling).toBe('merge');
+			expect(navigations[0].replaceUrl).toBeTrue();
+		});
+
+		it('writes nothing when the segment already on screen is clicked again', async () => {
+			await start();
+
+			click('Data plane');
+
+			expect(navigations.length).toBe(0);
+		});
+
+		it('round trips back to the data plane', async () => {
+			await start();
+
+			click('Queue');
+			click('Data plane');
+
+			expect(component.segment).toBe(DATA_PLANE);
+			expect(navigations.map(navigation => navigation.queryParams)).toEqual([{ engine: 'queue' }, { engine: 'dataplane' }]);
+		});
+	});
+
+	// The panel polls, so the report arrives again every few seconds. Re-deciding
+	// the default on each one would move the view under whoever is reading it.
+	it('does not move the segment when a later report changes which engine is accepting', async () => {
+		await start();
+		expect(component.segment).toBe(DATA_PLANE);
+
+		component.onPlaneReported({ reports: true, known: true, replicas: 1, accepting: 0 });
+		fixture.changeDetectorRef.detectChanges();
+
+		expect(component.segment).toBe(DATA_PLANE);
+	});
+
+	it('keeps an operator on the segment they chose when a later report disagrees', async () => {
+		await start();
+
+		click('Queue');
+		component.onPlaneReported({ reports: true, known: true, replicas: 1, accepting: 1 });
+		fixture.changeDetectorRef.detectChanges();
+
+		expect(component.segment).toBe(QUEUE);
+	});
+
+	// The control disappearing must take the selection with it, or the page shows
+	// neither engine.
+	it('returns to the queue when the plane stops reporting', async () => {
+		await start();
+		expect(component.segment).toBe(DATA_PLANE);
+
+		component.onPlaneReported({ reports: false, known: true, replicas: 0, accepting: 0 });
+		fixture.changeDetectorRef.detectChanges();
+
+		expect(component.segment).toBe(QUEUE);
+		expect(segmentButtons().length).toBe(0);
+	});
+
+	// Each view carries one line about the other engine, because when a plane runs
+	// both are live and the answer may be on the other side.
+	it('names the other engine on each side', async () => {
+		await start();
+
+		expect(component.otherEngineLine).toContain('The queue still carries');
+
+		click('Queue');
+
+		expect(component.otherEngineLine).toContain('1 data plane replica reporting');
+		expect(component.otherEngineLine).toContain('1 accepting work');
+	});
+
+	// A blipped poll keeps the segment, because the plane is still there. What it
+	// must not do is turn that line into a count of zero replicas.
+	it('does not count replicas on the line when the plane read failed', async () => {
+		await start();
+
+		click('Queue');
+		component.onPlaneReported({ reports: true, known: false, replicas: 0, accepting: 0 });
+		fixture.changeDetectorRef.detectChanges();
+
+		expect(component.segment).toBe(QUEUE);
+		expect(component.otherEngineLine).toContain('how many replicas are up is unknown');
+		expect(component.otherEngineLine).not.toContain('0 data plane');
+	});
+});

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring.component.ts
@@ -1,49 +1,183 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
+import { LoaderModule } from 'src/app/private/components/loader/loader.module';
 import { AdminService } from 'src/app/private/pages/admin/admin.service';
 import { LicensesService } from 'src/app/services/licenses/licenses.service';
 import { RbacService } from 'src/app/services/rbac/rbac.service';
 
 import { QueueMonitoringAsynqmonComponent } from './queue-monitoring-asynqmon.component';
 import { QueueMonitoringBrokerComponent } from './queue-monitoring-broker.component';
-import { QueueMonitoringDataplaneComponent } from './queue-monitoring-dataplane.component';
+import { DataPlaneReport, QueueMonitoringDataplaneComponent } from './queue-monitoring-dataplane.component';
 
 type QueueMonitoringSurface = 'loading' | 'postgres' | 'redis';
 
+// Two engines, one at a time on screen. Never a mode switch that hides one: when
+// a data plane runs both are live, the plane owning HTTP events for its projects
+// while the queue still carries broadcast and dynamic events, broker sources,
+// replays and batch retries, meta events, emails, retention and backups.
+export type QueueMonitoringSegment = 'dataplane' | 'queue';
+
+const SEGMENT_PARAM = 'engine';
+
 @Component({
 	selector: 'convoy-queue-monitoring',
-	imports: [CommonModule, QueueMonitoringAsynqmonComponent, QueueMonitoringBrokerComponent, QueueMonitoringDataplaneComponent],
+	imports: [CommonModule, LoaderModule, QueueMonitoringAsynqmonComponent, QueueMonitoringBrokerComponent, QueueMonitoringDataplaneComponent],
 	templateUrl: './queue-monitoring.component.html'
 })
 export class QueueMonitoringComponent implements OnInit {
 	licensed = false;
+	// Whether the license read has been attempted, not that it succeeded:
+	// loadAllLicenses swallows transport errors, so a failed read falls back to
+	// the cache and reads as unlicensed on a cold one. What it buys is that
+	// "requires a license key" waits for the read, not the initial false.
+	licenseKnown = false;
+	// True while the reads that decide which panel shows are still in flight.
+	// Not the inverse of licenseKnown: the non-admin return clears this without
+	// setting licenseKnown, because "requires a license key" must not be stated
+	// from a verdict that was never read. Every exit from ngOnInit clears it, so
+	// no path leaves the loader on screen; neither read it awaits can reject.
+	isLoadingLicense = true;
 	surface: QueueMonitoringSurface = 'loading';
+
+	// What the data plane panel last reported about itself. The panel polls even
+	// while the Queue segment is on screen, because these two questions cannot be
+	// answered from inside a segment that may not be rendered.
+	planeReports = false;
+	planeReplicas = 0;
+	planeAccepting = 0;
+	// Whether the two counts above describe a read that succeeded. A failed poll
+	// keeps the segment, because the plane is still there, but it cannot be
+	// allowed to say zero replicas are reporting.
+	planeCountsKnown = false;
+
+	// The segment the operator chose, or the default once the plane has answered.
+	// Read through the segment getter, never directly, so no state can leave the
+	// Data plane segment selected on an instance whose plane does not report.
+	private chosen: QueueMonitoringSegment = 'queue';
+	// True once the choice belongs to the operator, from the URL or a click. The
+	// default rule may not overrule it.
+	private pinned = false;
+	// True once the default rule has run. It runs on the first report only: a
+	// plane that stops accepting later must not move the segment out from under
+	// someone reading it.
+	private defaulted = false;
 
 	constructor(
 		private readonly adminService: AdminService,
 		private readonly licenses: LicensesService,
 		private readonly rbacService: RbacService,
-		private readonly router: Router
+		private readonly router: Router,
+		private readonly route: ActivatedRoute
 	) {}
 
 	async ngOnInit(): Promise<void> {
+		this.readSegmentFromUrl();
+
 		const role = await this.rbacService.getUserRole();
 		if (role !== 'INSTANCE_ADMIN') {
+			this.isLoadingLicense = false;
 			this.router.navigateByUrl('/');
 			return;
 		}
 
 		await this.licenses.loadAllLicenses();
 		this.licensed = this.licenses.hasInstanceLicense('AsynqMonitoring');
+		this.licenseKnown = true;
+		this.isLoadingLicense = false;
 		if (!this.licensed) return;
 
 		await this.resolveSurface();
 	}
 
+	// Which view is on screen. Derived rather than stored: the Data plane segment
+	// only exists while a plane reports, so a shared link naming it, or a plane
+	// that goes away while the tab is open, both land on the queue instead of on
+	// a blank panel.
+	get segment(): QueueMonitoringSegment {
+		return this.planeReports ? this.chosen : 'queue';
+	}
+
 	get usePostgresUi(): boolean {
 		return this.surface === 'postgres';
+	}
+
+	// One line about the engine that is not on screen, so the operator can see
+	// that the answer might be on the other side.
+	get otherEngineLine(): string {
+		if (this.segment === 'dataplane') {
+			return 'The queue still carries broadcast and dynamic events, broker sources, replays and batch retries, meta events, emails, retention and backups.';
+		}
+
+		const tail = 'Events on their projects do not pass through this queue.';
+		if (!this.planeCountsKnown) return `A data plane is reporting on this instance, and its last read failed, so how many replicas are up is unknown. ${tail}`;
+
+		const replicas = `${this.planeReplicas} data plane ${this.planeReplicas === 1 ? 'replica' : 'replicas'} reporting`;
+
+		return `${replicas}, ${this.planeAccepting} accepting work. ${tail}`;
+	}
+
+	// The default segment is whichever engine owns HTTP events on this instance,
+	// read from what the plane published rather than from a flag the dashboard
+	// does not have. A plane with a replica accepting work is the engine those
+	// events go through, so that is where the operator lands; a plane that
+	// reports and is accepting nothing has handed nothing off, so the queue is
+	// the engine carrying HTTP events and the queue is the landing view.
+	//
+	// Applied once. A later poll that changes the answer leaves the segment
+	// alone, because moving the view under a reader is worse than landing them
+	// one click from the other half.
+	onPlaneReported(report: DataPlaneReport): void {
+		this.planeReports = report.reports;
+		this.planeCountsKnown = report.known;
+		// Held from the last read that succeeded, so a blipped poll does not turn
+		// the line beside the control into a claim that the plane emptied.
+		if (report.known) {
+			this.planeReplicas = report.replicas;
+			this.planeAccepting = report.accepting;
+		}
+
+		if (!report.reports) {
+			this.defaulted = false;
+			return;
+		}
+
+		// Only a read that succeeded can say which engine owns HTTP events. A
+		// failed one leaves the rule unapplied so the next good read decides,
+		// rather than reading its zero as a plane accepting nothing.
+		if (this.pinned || this.defaulted || !report.known) return;
+
+		this.defaulted = true;
+		this.chosen = report.accepting > 0 ? 'dataplane' : 'queue';
+	}
+
+	selectSegment(next: QueueMonitoringSegment): void {
+		if (next === this.chosen) return;
+
+		this.chosen = next;
+		this.pinned = true;
+		// An explicit value on every write, never a null clear, so the merge
+		// cannot leave the previous segment behind in the URL. The snapshot is
+		// read once in ngOnInit and never again, so this navigation cannot be
+		// judged against a snapshot it has already replaced.
+		this.router.navigate([], {
+			relativeTo: this.route,
+			queryParams: { [SEGMENT_PARAM]: next },
+			queryParamsHandling: 'merge',
+			replaceUrl: true
+		});
+	}
+
+	// A shared link lands on the view it was shared from. An unrecognised value is
+	// ignored rather than pinned, so a truncated or hand-edited URL falls back to
+	// the default rule instead of freezing the page on a segment nobody chose.
+	private readSegmentFromUrl(): void {
+		const param = this.route.snapshot?.queryParams?.[SEGMENT_PARAM];
+		if (param !== 'dataplane' && param !== 'queue') return;
+
+		this.chosen = param;
+		this.pinned = true;
 	}
 
 	// Redis keeps the existing asynqmon iframe. Postgres uses the native broker

--- a/web/ui/dashboard/src/app/private/pages/settings/early-adopter-features/early-adopter-features.component.html
+++ b/web/ui/dashboard/src/app/private/pages/settings/early-adopter-features/early-adopter-features.component.html
@@ -11,7 +11,7 @@
   </div>
 }
 
-@if (!isLoadingFeatures && earlyAdopterFeatures.length === 0) {
+@if (featuresKnown && !isLoadingFeatures && earlyAdopterFeatures.length === 0) {
   <div class="p-24px bg-white-100 border border-new.border rounded-12px">
     <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">No early adopter features available at this time.</p>
   </div>

--- a/web/ui/dashboard/src/app/private/pages/settings/early-adopter-features/early-adopter-features.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/settings/early-adopter-features/early-adopter-features.component.spec.ts
@@ -1,0 +1,145 @@
+import { CommonModule } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+
+import { ToggleComponent } from 'src/app/components/toggle/toggle.component';
+import { GeneralService } from 'src/app/services/general/general.service';
+import { LicensesService } from 'src/app/services/licenses/licenses.service';
+import { RbacService } from 'src/app/services/rbac/rbac.service';
+
+import { LoaderModule } from '../../../components/loader/loader.module';
+import { PermissionDirective } from '../../../components/permission/permission.directive';
+import { SettingsService } from '../settings.service';
+import { EarlyAdopterFeaturesComponent } from './early-adopter-features.component';
+
+const EMPTY_COPY = 'No early adopter features available';
+
+describe('EarlyAdopterFeaturesComponent', () => {
+	let fixture: ComponentFixture<EarlyAdopterFeaturesComponent>;
+	let answerRole!: () => void;
+	let answerFeatures!: (features: unknown[]) => void;
+	let failFeatures!: () => void;
+	let notifications: Array<{ style: string; message: string }>;
+
+	beforeEach(async () => {
+		localStorage.setItem('CONVOY_ORG', JSON.stringify({ uid: 'org-1' }));
+		notifications = [];
+
+		await TestBed.configureTestingModule({
+			declarations: [EarlyAdopterFeaturesComponent],
+			imports: [CommonModule, ToggleComponent, PermissionDirective, LoaderModule],
+			providers: [
+				{
+					provide: SettingsService,
+					useValue: {
+						// Held open so a test can paint the page while the read is in
+						// flight. The role read lands first, which is what makes the
+						// empty state reachable before this one has answered anything.
+						getEarlyAdopterFeatures: () =>
+							new Promise((resolve, reject) => {
+								answerFeatures = features => resolve({ data: features });
+								failFeatures = () => reject(new Error('network down'));
+							}),
+						updateOrganisationFeatureFlags: () => new Promise(() => {})
+					}
+				},
+				{
+					provide: RbacService,
+					useValue: {
+						getUserRole: () => new Promise(resolve => (answerRole = () => resolve('ORGANISATION_ADMIN'))),
+						userPermission: () => Promise.resolve(['Organisations|MANAGE'])
+					}
+				},
+				{ provide: LicensesService, useValue: { hasLicense: () => true } },
+				{ provide: GeneralService, useValue: { showNotification: (details: { style: string; message: string }) => notifications.push(details) } },
+				{ provide: ActivatedRoute, useValue: { snapshot: { queryParams: {} } } }
+			]
+		}).compileComponents();
+
+		fixture = TestBed.createComponent(EarlyAdopterFeaturesComponent);
+
+		// The first pass runs ngOnInit, so ngOnInit is never called by hand here:
+		// a second call would start a second pair of reads and overwrite the
+		// resolvers the test is holding.
+		fixture.detectChanges();
+	});
+
+	afterEach(() => {
+		fixture.destroy();
+		localStorage.removeItem('CONVOY_ORG');
+	});
+
+	// The component's own detector, not fixture.detectChanges: these tests move
+	// state between passes on purpose, which is what the fixture's verification
+	// pass exists to reject.
+	function paint() {
+		fixture.changeDetectorRef.detectChanges();
+	}
+
+	function text(): string {
+		return (fixture.nativeElement as HTMLElement).textContent ?? '';
+	}
+
+	async function settle() {
+		for (let turn = 0; turn < 5; turn++) await Promise.resolve();
+	}
+
+	it('does not claim the organisation has no features before the role read lands', () => {
+		paint();
+
+		expect(text()).not.toContain(EMPTY_COPY);
+	});
+
+	it('does not claim it while the feature read is in flight', async () => {
+		answerRole();
+		await settle();
+
+		paint();
+
+		expect(text()).not.toContain(EMPTY_COPY);
+	});
+
+	it('claims it once the feature read answers with nothing', async () => {
+		answerRole();
+		await settle();
+		answerFeatures([]);
+		await settle();
+
+		paint();
+
+		expect(text()).toContain(EMPTY_COPY);
+	});
+
+	it('never claims it when the feature read answers with a feature', async () => {
+		answerRole();
+		await settle();
+		answerFeatures([{ key: 'mtls', name: 'Mutual TLS', description: 'Client certificates', enabled: false }]);
+		await settle();
+
+		paint();
+
+		expect(text()).not.toContain(EMPTY_COPY);
+		expect(text()).toContain('Mutual TLS');
+	});
+
+	// The empty state is the same copy either way, so a failed read is
+	// indistinguishable from an empty organisation unless it is reported. The
+	// whole array is asserted so one failure cannot toast twice.
+	it('reports a failed feature read', async () => {
+		answerRole();
+		await settle();
+		failFeatures();
+		await settle();
+
+		expect(notifications).toEqual([{ style: 'error', message: 'Failed to load early adopter features' }]);
+	});
+
+	it('reports nothing when the feature read answers', async () => {
+		answerRole();
+		await settle();
+		answerFeatures([]);
+		await settle();
+
+		expect(notifications).toEqual([]);
+	});
+});

--- a/web/ui/dashboard/src/app/private/pages/settings/early-adopter-features/early-adopter-features.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/settings/early-adopter-features/early-adopter-features.component.ts
@@ -22,6 +22,13 @@ export class EarlyAdopterFeaturesComponent implements OnInit {
 	organisationId!: string;
 	isLoadingFeatures = false;
 	isUpdatingFeatures = false;
+	// Whether the feature read has answered. "No early adopter features
+	// available" is a definitive claim about this organisation, and the loading
+	// flag cannot stand in for it: the role read runs first, so on the first
+	// change detection pass nothing is loading and the list is empty, which
+	// renders the claim for the whole of both round trips. Cleared at the start
+	// of every read so a later one is not answered by an earlier verdict.
+	featuresKnown = false;
 	earlyAdopterFeatures: EarlyAdopterFeature[] = [];
 	private rbacService = inject(RbacService);
 	canManage = false;
@@ -50,6 +57,7 @@ export class EarlyAdopterFeaturesComponent implements OnInit {
 	async getEarlyAdopterFeatures() {
 		if (!this.organisationId || this.isLoadingFeatures) return;
 		this.isLoadingFeatures = true;
+		this.featuresKnown = false;
 		try {
 			const response = await this.settingService.getEarlyAdopterFeatures({ org_id: this.organisationId });
 			const allFeatures = response.data || [];
@@ -59,10 +67,16 @@ export class EarlyAdopterFeaturesComponent implements OnInit {
 				return this.hasFeatureLicense(feature.key);
 			});
 
+			this.featuresKnown = true;
 			this.isLoadingFeatures = false;
 			this.cdr.markForCheck();
 		} catch (error) {
 			console.error('Error fetching features:', error);
+			this.generalService.showNotification({ style: 'error', message: 'Failed to load early adopter features' });
+			// Set on the failure path too, because this page already answers a
+			// failed read with the empty state. That policy is unchanged here; the
+			// only thing this flag adds is that the answer waits for the read.
+			this.featuresKnown = true;
 			this.isLoadingFeatures = false;
 			this.cdr.markForCheck();
 		}


### PR DESCRIPTION
## Summary

The data plane panel was a wall of counters. Every number reading zero looked
healthy, which is also exactly what an armed plane receiving no traffic looks
like, so a replica that had never accepted an event presented as fine.

- The panel opens with a sentence saying whether accepted work is draining and
  where it is sitting if it is not, then three numbers, then diagnostics behind
  a toggle.
- Absence and zero render differently. A field the plane did not publish shows
  a dash with a tooltip naming which absence it is (not measured yet, not
  accepting, not read); a field published as zero shows the zero, because a
  measured idle interval is an answer.
- Outstanding carries the retry schedule under the count, so a backlog draining
  on schedule reads differently from one that is not.
- Failures split between work discarded before any attempt and work that failed
  after one. As a single total, a paused endpoint's discards looked like an
  explanation for a backlog that belonged to a different endpoint.
- Data plane and queue share one tab behind a segmented control, shown only
  when a plane reports.

Two supporting changes on the contract, and two fixes found while testing it.

`Snapshot` gains the shared throughput gauge vocabulary. A plane emits the four
gauges together or omits them together: a count without its window is not a
rate, so a consumer finding only some of them has no measurement. Naming them
for the concept rather than for one plane's components is what lets a
queue-based plane publish the same fact and be read by the same consumer.

`DeleteSnapshot` is the counterpart to `PublishSnapshot` for a plane stopping on
purpose. Rows outlive their replica by a long expiry window so a crash stays
visible; a replica leaving deliberately should not need that window, so it
retracts its own row and the dashboard updates at once. What is left behind
afterwards is a plane that did not get to say goodbye, which is the case worth
looking at. No caller lands in this PR; it completes the store contract that
a data plane consumes.

`MaxConnIdleTime` was applied only when `SetMaxIdleConnections` was above zero,
but that knob configures the `database/sql` free list and has nothing to do with
how long pgx holds an idle connection. Unset, which is the default, the pool
fell back to the pgx default of 30 minutes. A finished load run left one process
holding 96 of 100 connections and the next process could not connect at all.

Three admin pages rendered "requires a licence key" or an empty state from the
initial value of a flag they had not read yet, so every load flashed a claim
they then retracted. Each now waits for the read before saying anything
definitive, and early adopter features shows the error toast its siblings
already show instead of only logging to the console.

## Test plan

- [x] `golangci-lint run --config=.golangci.yml --timeout 5m --new-from-rev=origin/main` clean on the pushed tree
- [x] `go build ./...`, `go vet`, `go test ./internal/pkg/dataplanestats/...`
- [x] Dashboard specs: 310 pass, 65 pre-existing failures unchanged and none in touched files
- [x] New specs cover known-empty, unknown, draining and overdue backlogs, clock anchoring, the failure split, and a stopped replica
- [x] Four specs proven by reverting the source and quoting the failure
- [x] 375px viewport fixture reports zero overflowing elements
- [x] Integration tests for `DeleteSnapshot`: removes only the named row, idempotent on repeat, refuses an unnamed replica
- [ ] Verify on staging once the plane is receiving traffic

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Always-on pgx idle reaping changes connection lifecycle for every deployment; the large dashboard read-path/UI refactor is heavily tested but still broad operational surface area.
> 
> **Overview**
> Rebuilds **queue monitoring’s data plane view** around a single **engine verdict** (`convoy-engine-verdict`): draining vs idle vs unmeasured, with **absent values as dashes** (and tooltips/`aria-label`) versus **published zeros**, retry schedule notes under outstanding, and **discarded vs failed** called out separately so paused-endpoint totals do not read as backlog explanations. Raw stage/writer tables move behind **Show diagnostics**; the panel only renders when its segment is **active** and reports plane presence to the parent for the shared tab.
> 
> On the backend, **`dataplanestats`** documents shared **throughput gauge** names (all four or omit) and absence semantics; **Postgres** gains **`DeleteSnapshot(replica)`** (not on the dashboard `Store` interface) for graceful replica retraction, with integration tests. **`buildPoolConfig`** always sets **`MaxConnIdleTime` to 5 minutes**—fixing the case where unset `max_idle_conn` left pgx’s 30‑minute default and pinned server connections after load runs—with unit and integration pool tests.
> 
> Several admin/queue pages stop **flashing definitive empty or unlicensed copy** before async reads finish (`featureFlagsKnown`, `licenseKnown`, Asynqmon `isLoadingSession`). **Tooltips** accept optional **`ariaLabel`** for screen readers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a61356210dc67e8524fe60d004870b4a411b11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

