### PR TITLE
fix(dashboard): say what a data plane replica actually counts as intake

### DIFF
--- a/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.spec.ts
+++ b/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.spec.ts
@@ -91,7 +91,7 @@ describe('EngineVerdictComponent', () => {
 			const text = render(verdict({ outstanding: { known: true, value: 0 } }));
 
 			expect(component.state).toBe('idle');
-			expect(text).toBe('Running and idle. It measured the last ~5s and accepted nothing, nothing outstanding. If work is arriving on this instance, it is not coming through this engine.');
+			expect(text).toBe('Running and idle. It measured the last ~5s and took in nothing, nothing outstanding. If work is arriving on this instance, it is not coming through this engine.');
 			// A measured zero is not a fault and must not be dressed as one.
 			expect(component.tone).toBe('ok');
 		});
@@ -112,7 +112,7 @@ describe('EngineVerdictComponent', () => {
 			const text = render(verdict({ outstanding: { known: false, value: 0 } }));
 
 			expect(component.state).toBe('holding');
-			expect(text).toContain('Nothing accepted and nothing completed in the last ~5s, outstanding could not be read.');
+			expect(text).toContain('Nothing taken in and nothing completed in the last ~5s, outstanding could not be read.');
 			expect(text).not.toContain('Idle');
 		});
 	});
@@ -131,12 +131,12 @@ describe('EngineVerdictComponent', () => {
 		);
 
 		expect(component.state).toBe('draining');
-		expect(text).toBe('Draining. 1,240 accepted and 1,190 completed in the last ~5s, 50 outstanding.');
+		expect(text).toBe('Draining. 1,240 taken in and 1,190 completed in the last ~5s, 50 outstanding.');
 	});
 
 	// Fanout makes out legitimately larger than in, which a netting sentence
 	// would have to report as an impossible surplus.
-	it('reports more completed than accepted without calling it a deficit', () => {
+	it('reports more completed than taken in without calling it a deficit', () => {
 		const text = render(
 			verdict({
 				flow: measured({ in: 3, out: 12 }),
@@ -145,7 +145,7 @@ describe('EngineVerdictComponent', () => {
 		);
 
 		expect(component.state).toBe('draining');
-		expect(text).toBe('Draining. 3 accepted and 12 completed in the last ~5s, 4 outstanding.');
+		expect(text).toBe('Draining. 3 taken in and 12 completed in the last ~5s, 4 outstanding.');
 		expect(text).not.toContain('more');
 	});
 
@@ -159,7 +159,7 @@ describe('EngineVerdictComponent', () => {
 
 		// The three window counts stay together and the level stays apart, so the
 		// failures do not read as an explanation of the backlog beside them.
-		expect(text).toBe('Draining. 288 accepted, 287 completed and 30 failed in the last ~5s, 583 outstanding.');
+		expect(text).toBe('Draining. 288 taken in, 287 completed and 30 failed in the last ~5s, 583 outstanding.');
 	});
 
 	// An engine may count more than one way of not completing in that number. The
@@ -176,7 +176,7 @@ describe('EngineVerdictComponent', () => {
 			})
 		);
 
-		expect(text).toBe('Draining. 288 accepted, 287 completed and 30 failed or discarded in the last ~5s, 583 outstanding.');
+		expect(text).toBe('Draining. 288 taken in, 287 completed and 30 failed or discarded in the last ~5s, 583 outstanding.');
 	});
 
 	// Completed nothing over the window against a backlog that is really there.
@@ -194,7 +194,7 @@ describe('EngineVerdictComponent', () => {
 		);
 
 		expect(component.state).toBe('holding');
-		expect(text).toBe('20 accepted and nothing completed in the last ~5s, 1,200 outstanding. Work waiting on a schedule is outstanding too, so read what that number is made of before taking this as held up.');
+		expect(text).toBe('20 taken in and nothing completed in the last ~5s, 1,200 outstanding. Work waiting on a schedule is outstanding too, so read what that number is made of before taking this as held up.');
 		expect(text).not.toContain('Not draining');
 		expect(text).not.toContain('stuck');
 	});

--- a/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.ts
+++ b/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.ts
@@ -19,6 +19,13 @@ export interface EngineWindow {
 	// it. The sentence names the window from this rather than assuming a minute.
 	windowMs: number;
 
+	// in is work the engine took on, by whichever route work reaches it. An
+	// engine may be handed work by a client it serves, or take on work that was
+	// already durable somewhere it can read, and both are work it is now
+	// answerable for. The sentences say "taken in" rather than "accepted" for
+	// that reason: an engine placed where no client can reach it does all its
+	// work through the second route, and a number labelled "accepted" would be
+	// read as a broken ingest on a deployment that was never going to have one.
 	in: number;
 	out: number;
 
@@ -181,15 +188,15 @@ export class EngineVerdictComponent {
 			// see the instance's ingest rate and so cannot make the comparison
 			// itself.
 			case 'idle':
-				return `Running and idle. It measured the last ${this.window()} and accepted nothing, nothing outstanding. If work is arriving on this instance, it is not coming through this engine.`;
+				return `Running and idle. It measured the last ${this.window()} and took in nothing, nothing outstanding. If work is arriving on this instance, it is not coming through this engine.`;
 			// The observation, then the reason it is not a conclusion. Reading
 			// this as a stall cost an operator twenty minutes on a plane that was
 			// working exactly as designed, so the sentence says outright what it
 			// cannot tell rather than leaving the reader to assume the worst.
 			case 'holding':
-				return `${window?.in ? `${engineCount(window.in)} accepted` : 'Nothing accepted'} and nothing completed in the last ${this.window()}${window?.failed ? `, ${engineCount(window.failed)} ${this.failedWord()}` : ''}, ${this.outstandingClause()}. Work waiting on a schedule is outstanding too, so read what that number is made of before taking this as held up.`;
+				return `${window?.in ? `${engineCount(window.in)} taken in` : 'Nothing taken in'} and nothing completed in the last ${this.window()}${window?.failed ? `, ${engineCount(window.failed)} ${this.failedWord()}` : ''}, ${this.outstandingClause()}. Work waiting on a schedule is outstanding too, so read what that number is made of before taking this as held up.`;
 			default:
-				return `Draining. ${engineCount(window?.in ?? 0)} accepted${window?.failed ? `, ` : ' and '}${engineCount(window?.out ?? 0)} completed${window?.failed ? ` and ${engineCount(window.failed)} ${this.failedWord()}` : ''} in the last ${this.window()}, ${this.outstandingClause()}.`;
+				return `Draining. ${engineCount(window?.in ?? 0)} taken in${window?.failed ? `, ` : ' and '}${engineCount(window?.out ?? 0)} completed${window?.failed ? ` and ${engineCount(window.failed)} ${this.failedWord()}` : ''} in the last ${this.window()}, ${this.outstandingClause()}.`;
 		}
 	}
 

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.html
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.html
@@ -16,7 +16,7 @@
     <div class="flex items-start justify-between gap-16px mb-16px min-w-0">
       <div class="flex flex-col gap-4px min-w-0">
         <h3 class="font-heading font-medium text-[18px] leading-[26px] text-new.text-primary">Data plane</h3>
-        <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Whether accepted work is draining, and where it is sitting if it is not.</p>
+        <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Whether work the plane has taken on is draining, and where it is sitting if it is not.</p>
       </div>
       <button
         type="button"
@@ -286,7 +286,7 @@
                       <span class="font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ row.flow.measured.windowMs }} ms</span>
                     </div>
                     <div class="flex flex-col gap-2px min-w-0">
-                      <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary">Events accepted</span>
+                      <span class="font-body font-medium text-[12px] leading-normal text-new.text-secondary">Events taken in</span>
                       <span class="font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ row.flow.measured.in }}</span>
                     </div>
                     <div class="flex flex-col gap-2px min-w-0">

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.spec.ts
@@ -180,7 +180,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 			expect(text()).toContain('Measuring. No earlier sample from this engine to compare against, so there is no interval yet. Next sample carries one. 84,088 outstanding.');
 			expect(text()).not.toContain('not reported');
 			expect(text()).not.toContain('Idle');
-			expect(text()).not.toContain('Nothing accepted');
+			expect(text()).not.toContain('Nothing taken in');
 		});
 
 		// A dash an operator cannot account for reads as a broken panel, so the
@@ -290,7 +290,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 			await render();
 
-			expect(text()).toContain('Draining. 288 accepted, 287 completed and 30 failed or discarded in the last ~5s, 583 outstanding.');
+			expect(text()).toContain('Draining. 288 taken in, 287 completed and 30 failed or discarded in the last ~5s, 583 outstanding.');
 			expect(text()).toContain('288');
 			expect(text()).toContain('287');
 			expect(text()).not.toContain('not reported');
@@ -319,7 +319,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 			await render();
 
-			expect(text()).toContain('Running and idle. It measured the last ~5s and accepted nothing, nothing outstanding.');
+			expect(text()).toContain('Running and idle. It measured the last ~5s and took in nothing, nothing outstanding.');
 			expect(absentValues().filter(value => value.glyph === '-').length).toBe(0);
 
 			const values = Array.from((fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('[data-flow-value]')).map(node => (node.textContent ?? '').trim());
@@ -349,9 +349,14 @@ describe('QueueMonitoringDataplaneComponent', () => {
 			expect(text()).toContain('If work is arriving on this instance, it is not coming through this engine.');
 
 			const scope = tooltipLabels().find(label => label.includes('Replica scope'));
-			expect(scope).toContain('This replica only counts work its own process accepted.');
-			expect(scope).toContain('agent HTTP port');
-			expect(scope).toContain('carried by the queue instead');
+			expect(scope).toContain('This replica only counts work it took on itself.');
+			// Both routes named, and neither asserted as the only one. A note that
+			// said work arrives on this process's port would read as ruling out
+			// durable work a plane picks up, and a deployment may well take in
+			// everything that way.
+			expect(scope).toContain('a client that sent it to this process');
+			expect(scope).toContain('durable work the plane picks up');
+			expect(scope).toContain('not about the instance');
 		});
 
 		// The note is a reading, so it may only appear where there was one. Beside
@@ -381,7 +386,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 			await render();
 
-			expect(text()).toContain('Draining. 3 accepted and 12 completed in the last ~5s, 4 outstanding.');
+			expect(text()).toContain('Draining. 3 taken in and 12 completed in the last ~5s, 4 outstanding.');
 			expect(text()).toContain('Events in');
 			expect(text()).toContain('Deliveries out');
 			expect(text()).not.toContain('more out than in');
@@ -408,7 +413,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 			await render();
 
-			expect(text()).toContain('40 accepted and nothing completed in the last ~5s, 583 outstanding.');
+			expect(text()).toContain('40 taken in and nothing completed in the last ~5s, 583 outstanding.');
 			expect(text()).toContain('Work waiting on a schedule is outstanding too, so read what that number is made of before taking this as held up.');
 
 			// And the schedule says which it is: an oldest retry a minute and a

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.ts
@@ -221,8 +221,8 @@ const ABSENT_REASONS: Record<EngineFlowAbsence, Explained> & { stopped: Explaine
 // reads that surplus as impossible or a deficit as a backlog forming.
 const METRIC_MEANINGS = {
 	in: {
-		reason: 'Events accepted in the last measured interval.',
-		detail: 'Counted once the plane has taken responsibility for the event, and counted as events. Not comparable with Deliveries out: one event fans out to a delivery per matching subscription, so the two are the ends of the plane rather than two sides of a sum. A count for the interval, not a rate.'
+		reason: 'Events taken in during the last measured interval.',
+		detail: 'Counted once the plane has taken responsibility for the event, and counted as events. That includes work a client sent to this process and work the plane picked up because it was already durable, because both are events it is now answerable for. Not comparable with Deliveries out: one event fans out to a delivery per matching subscription, so the two are the ends of the plane rather than two sides of a sum. A count for the interval, not a rate.'
 	},
 	out: {
 		reason: 'Deliveries completed in the last measured interval.',
@@ -236,26 +236,26 @@ const METRIC_MEANINGS = {
 	// says what the number counts and points at the schedule lines, which are
 	// where a reader can tell a backlog draining on time from one that is not.
 	outstanding: {
-		reason: 'Work accepted and not yet done.',
+		reason: 'Work taken on and not yet done.',
 		detail: 'The durable backlog, so it survives a restart. It counts deliveries waiting on a retry schedule as well as work waiting to be attempted, and a scheduled retry is future work with a due time rather than work held up. A steady arrival rate against a retry schedule holds a roughly constant number here, so a count that rises and then settles is what a working plane looks like. The lines under it say how old the oldest waiting retry is and when the next one is due, which is what separates a backlog draining on schedule from one that is not.'
 	}
 };
 
 // Said where someone staring at a row of zeros will read it, on the identity
-// those zeros belong to. Which process accepted the work is the whole
-// difference between a plane that is broken and a plane nothing is being sent
-// to, and nothing else in the product would tell an operator that an agent
-// running a plane only takes what was posted to its own port.
+// those zeros belong to. A replica's numbers are its own, and the difference
+// between a plane that is broken and a plane that is simply not the one carrying
+// the work is a distinction nothing else in the product would draw for an
+// operator.
 //
-// Worded for the contract rather than for one plane: any plane can publish this
-// shape, so the note says what is true of a replica and then names the
-// agent-port case, instead of asserting an agent port on a plane that may not
-// have one.
-// What the queue carries instead is on the segment caveat above, not repeated
-// here.
+// Worded for the contract rather than for one plane, because any plane can
+// publish this shape. In particular it does not say how work reaches a plane:
+// that is the deployment's, a replica may be handed work by a client or pick up
+// work that is already durable, and a note asserting one of those would be read
+// as ruling out the other. Saying only what a replica's numbers cover stays true
+// of every arrangement, which is what a caveat has to be.
 const REPLICA_SCOPE: Explained = {
-	reason: 'This replica only counts work its own process accepted.',
-	detail: 'On an agent running a data plane that is work posted to the agent HTTP port. Work that reaches the instance any other way is carried by the queue instead, so this replica can be accepting nothing while the instance itself is busy. The numbers below are a fact about this replica, not about the instance.'
+	reason: 'This replica only counts work it took on itself.',
+	detail: 'Work reaches a plane either from a client that sent it to this process or as durable work the plane picks up, and which of those applies is a property of the deployment rather than of this panel. Either way these numbers are a fact about this replica and not about the instance, so a replica can be taking on nothing while the instance is busy.'
 };
 
 // The gauges a plane publishes its measured interval under, and the only place


### PR DESCRIPTION
## Summary

- The intake number on a replica row counts work that replica took on, and a replica can take work on by more than one route: a client sends it work, or it picks up work that was already durable somewhere it reads. Labelling that number "accepted" reads as the first route only, so a replica doing all its work through the second one looks like a broken ingest. The verdict sentence, the tile label and the tooltip now say "taken in".
- The replica scope note claimed that work reaching the instance any other way is carried by the queue. That is a claim about a deployment the panel cannot see. It now says only what a replica's numbers cover and leaves how work reaches a plane to the deployment.
- Copy, comments and test expectations only. No behaviour, no request, no rendering change.

The queue caveat beside the segmented control is deliberately unchanged: the categories it lists (broadcast and dynamic events, broker sources, replays and batch retries, meta events, emails, retention, backups) still go to the queue.

## Test plan

- [x] `npm run lint` in `web/ui/dashboard` (what CI runs) passes
- [x] `npm run build` in `web/ui/dashboard` (what CI runs) succeeds
- [x] `ng test` back to the same pass/fail counts as `main` (the pre-existing failures on `main` are unrelated Angular DI setup in other suites), with the data plane and verdict suites green
- [x] Verdict, tooltip and label assertions updated in `engine-verdict.component.spec.ts` and `queue-monitoring-dataplane.component.spec.ts`; the scope test still pins the note's substance rather than just its first sentence