### PR TITLE
feat(dashboard): explain data plane diagnostics and prefer live replicas

### DIFF
--- a/database/postgres/data_plane_snapshot.go
+++ b/database/postgres/data_plane_snapshot.go
@@ -37,7 +37,8 @@ const (
 	DELETE FROM convoy.data_plane_snapshots
 	WHERE replica = $1`
 
-	// Ordered by replica so a page of replicas does not reshuffle between reads.
+	// Fetch order is by replica so the scan itself is stable. Presentation
+	// order (live then stale) is applied after staleness is computed.
 	loadDataPlaneSnapshotsSQL = `
 	SELECT snapshot FROM convoy.data_plane_snapshots ORDER BY replica`
 )
@@ -145,5 +146,6 @@ func (p *Postgres) DataPlaneStatus(ctx context.Context, staleAfter time.Duration
 		return status, fmt.Errorf("data plane snapshot: read: %w", err)
 	}
 
+	dataplanestats.OrderReplicas(status.Replicas)
 	return status, nil
 }

--- a/database/postgres/data_plane_snapshot_test.go
+++ b/database/postgres/data_plane_snapshot_test.go
@@ -125,6 +125,35 @@ func TestDataPlaneStatusMarksReplicasStale(t *testing.T) {
 	require.Greater(t, replicaByName(t, status, "pod-old").AgeSeconds, float64(100))
 }
 
+// Container ids are lexical. A leftover row whose id sorts first must still
+// sit below the replica that is still reporting, or a restart opens the page
+// on the ghost.
+func TestDataPlaneStatusListsLiveReplicasBeforeStale(t *testing.T) {
+	store := snapshotStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.PublishSnapshot(ctx, dataplanestats.Snapshot{
+		Replica:   "aaa-stale",
+		Mode:      "example",
+		Running:   true,
+		SampledAt: time.Now().Add(-2 * time.Minute),
+	}))
+	require.NoError(t, store.PublishSnapshot(ctx, dataplanestats.Snapshot{
+		Replica:   "zzz-live",
+		Mode:      "example",
+		Running:   true,
+		SampledAt: time.Now(),
+	}))
+
+	status, err := store.DataPlaneStatus(ctx, 30*time.Second)
+	require.NoError(t, err)
+	require.Len(t, status.Replicas, 2)
+	require.Equal(t, "zzz-live", status.Replicas[0].Replica)
+	require.False(t, status.Replicas[0].Stale)
+	require.Equal(t, "aaa-stale", status.Replicas[1].Replica)
+	require.True(t, status.Replicas[1].Stale)
+}
+
 // A replica that was scaled away has to leave the page rather than keep claiming
 // depth it no longer holds, and expiry must not take the live one with it.
 func TestExpireSnapshotsRemovesOnlyDeadReplicas(t *testing.T) {

--- a/internal/pkg/dataplanestats/stats.go
+++ b/internal/pkg/dataplanestats/stats.go
@@ -10,6 +10,8 @@ package dataplanestats
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"time"
 )
 
@@ -105,14 +107,15 @@ type Stage struct {
 	Queued  int    `json:"queued"`
 	Waiting int    `json:"waiting"`
 
-	// Workers is 0 when the stage runs one goroutine per item rather than a
-	// fixed pool, which is a mode and not an absence.
+	// Workers is 0 when the stage is unbounded (one goroutine per item) rather
+	// than a fixed pool, which is a mode and not an absence.
 	Workers int `json:"workers"`
 
-	// Partitions is how many independent lanes the queued work is spread over,
-	// Capacity is what one lane holds before its senders block, and Deepest is
-	// the fullest single lane. Queued alone cannot say whether one tenant is
-	// blocking, which is what these three answer.
+	// Partitions is how many independent lanes the queued work is spread over.
+	// Capacity is what one lane holds before its senders block; zero is
+	// unbounded (Send never blocks on fullness, and memory is the cap).
+	// Deepest is the fullest single lane. Queued alone cannot say whether one
+	// tenant is blocking, which is what these three answer.
 	Partitions int `json:"partitions"`
 	Capacity   int `json:"partition_capacity"`
 	Deepest    int `json:"deepest_partition"`
@@ -166,6 +169,22 @@ type Replica struct {
 type Status struct {
 	Replicas          []Replica `json:"replicas"`
 	StaleAfterSeconds float64   `json:"stale_after_seconds"`
+}
+
+// OrderReplicas puts reporting replicas first and stale ones last, then by
+// name so peers do not reshuffle. Name-only order is what put a restarted
+// replica's leftover row above the live one: container ids are lexical, not
+// health, and a ghost that sorts first is the card the page opens on.
+func OrderReplicas(replicas []Replica) {
+	slices.SortStableFunc(replicas, func(a, b Replica) int {
+		if a.Stale != b.Stale {
+			if a.Stale {
+				return 1
+			}
+			return -1
+		}
+		return strings.Compare(a.Replica, b.Replica)
+	})
 }
 
 // Reporter is a plane running in this process that can describe itself. Nil

--- a/internal/pkg/dataplanestats/stats_test.go
+++ b/internal/pkg/dataplanestats/stats_test.go
@@ -77,3 +77,25 @@ func TestIdleIntervalIsPublishedAsZero(t *testing.T) {
 		t.Fatalf("idle interval decoded as flow: %+v", decoded.Gauges)
 	}
 }
+
+// A leftover row from a restarted replica is stale, and its name is often a
+// container id that sorts ahead of the live replacement. The page has to open
+// on the replica that is still reporting.
+func TestOrderReplicasPutsStaleLast(t *testing.T) {
+	replicas := []Replica{
+		{Snapshot: Snapshot{Replica: "aaa"}, Stale: true},
+		{Snapshot: Snapshot{Replica: "zzz"}, Stale: false},
+		{Snapshot: Snapshot{Replica: "mmm"}, Stale: false},
+	}
+
+	OrderReplicas(replicas)
+
+	got := make([]string, len(replicas))
+	for i, replica := range replicas {
+		got[i] = replica.Replica
+	}
+	want := []string{"mmm", "zzz", "aaa"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("live then stale, then by name: got %v want %v", got, want)
+	}
+}

--- a/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.spec.ts
+++ b/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.spec.ts
@@ -55,7 +55,7 @@ describe('EngineVerdictComponent', () => {
 			const text = render(verdict({ flow: { absence: 'starting' }, outstanding: { known: true, value: 84088 } }));
 
 			expect(component.state).toBe('starting');
-			expect(text).toBe('Measuring. No earlier sample from this engine to compare against, so there is no interval yet. Next sample carries one. 84,088 outstanding.');
+			expect(text).toBe('Measuring. 84,088 outstanding.');
 			expect(text).not.toContain('Idle');
 			expect(text).not.toContain('not reported');
 		});
@@ -64,7 +64,7 @@ describe('EngineVerdictComponent', () => {
 			const text = render(verdict({ flow: { absence: 'restarted' }, outstanding: { known: true, value: 84088 } }));
 
 			expect(component.state).toBe('restarted');
-			expect(text).toBe('Measuring again. The engine restarted, so the interval spanning the restart was discarded. Next sample carries one. 84,088 outstanding.');
+			expect(text).toBe('Measuring again. 84,088 outstanding.');
 			expect(text).not.toContain('No earlier sample');
 		});
 
@@ -74,7 +74,7 @@ describe('EngineVerdictComponent', () => {
 			const text = render(verdict({ flow: { absence: 'incomplete' }, outstanding: { known: false, value: 0 } }));
 
 			expect(component.state).toBe('incomplete');
-			expect(text).toBe('Throughput reported incompletely, so whether work is draining is unknown. Outstanding could not be read.');
+			expect(text).toBe('Throughput incomplete. Outstanding could not be read.');
 			expect(text).not.toContain('Idle');
 			expect(text).not.toContain('nothing outstanding');
 		});
@@ -91,7 +91,7 @@ describe('EngineVerdictComponent', () => {
 			const text = render(verdict({ outstanding: { known: true, value: 0 } }));
 
 			expect(component.state).toBe('idle');
-			expect(text).toBe('Running and idle. It measured the last ~5s and took in nothing, nothing outstanding. If work is arriving on this instance, it is not coming through this engine.');
+			expect(text).toBe('Idle. Nothing in the last ~5s, nothing outstanding.');
 			// A measured zero is not a fault and must not be dressed as one.
 			expect(component.tone).toBe('ok');
 		});
@@ -102,7 +102,7 @@ describe('EngineVerdictComponent', () => {
 		it('does not assert that traffic is going elsewhere', () => {
 			const text = render(verdict({ outstanding: { known: true, value: 0 } }));
 
-			expect(text).toContain('If work is arriving');
+			expect(text).not.toContain('If work is arriving');
 			expect(text).not.toContain('bypass');
 		});
 
@@ -194,7 +194,7 @@ describe('EngineVerdictComponent', () => {
 		);
 
 		expect(component.state).toBe('holding');
-		expect(text).toBe('20 taken in and nothing completed in the last ~5s, 1,200 outstanding. Work waiting on a schedule is outstanding too, so read what that number is made of before taking this as held up.');
+		expect(text).toBe('20 taken in and nothing completed in the last ~5s, 1,200 outstanding.');
 		expect(text).not.toContain('Not draining');
 		expect(text).not.toContain('stuck');
 	});
@@ -214,7 +214,7 @@ describe('EngineVerdictComponent', () => {
 		expect(component.state).toBe('stopped');
 		// Distinct in words from the engine that is running and measured a zero,
 		// which is the pair an operator most needs told apart.
-		expect(text).toBe('Not running. This engine is not accepting work, so nothing new is entering it.');
+		expect(text).toBe('Not accepting work.');
 		expect(text).not.toContain('It measured the last');
 		// The numbers beside a stopped engine describe a stop, so none of them
 		// may reach the sentence.

--- a/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.ts
+++ b/web/ui/dashboard/src/app/components/engine-verdict/engine-verdict.component.ts
@@ -167,34 +167,19 @@ export class EngineVerdictComponent {
 			// finding nothing to do. Rendering any two of them the same way is how
 			// a misconfiguration hides.
 			case 'stopped':
-				return 'Not running. This engine is not accepting work, so nothing new is entering it.';
+				return 'Not accepting work.';
 			case 'silent':
 				return `Not reporting. Last sample ${verdict.sampledLabel}.`;
-			// Both absences say what happened and what it means for the reader,
-			// and neither reads as a fault: an interval is coming, and until it
-			// arrives the engine may well be draining perfectly.
 			case 'starting':
-				return `Measuring. No earlier sample from this engine to compare against, so there is no interval yet. Next sample carries one. ${sentenceStart(this.outstandingClause())}.`;
+				return `Measuring. ${sentenceStart(this.outstandingClause())}.`;
 			case 'restarted':
-				return `Measuring again. The engine restarted, so the interval spanning the restart was discarded. Next sample carries one. ${sentenceStart(this.outstandingClause())}.`;
-			// The one absence with no benign explanation, kept apart from the two
-			// that have one rather than being softened into them.
+				return `Measuring again. ${sentenceStart(this.outstandingClause())}.`;
 			case 'incomplete':
-				return `Throughput reported incompletely, so whether work is draining is unknown. ${sentenceStart(this.outstandingClause())}.`;
-			// A measured zero is a reading, not a gap, and the difference is the
-			// whole point: an engine that sampled an interval and found nothing is
-			// telling the operator that work is reaching Convoy some other way, or
-			// not at all. The last clause is conditional because this panel cannot
-			// see the instance's ingest rate and so cannot make the comparison
-			// itself.
+				return `Throughput incomplete. ${sentenceStart(this.outstandingClause())}.`;
 			case 'idle':
-				return `Running and idle. It measured the last ${this.window()} and took in nothing, nothing outstanding. If work is arriving on this instance, it is not coming through this engine.`;
-			// The observation, then the reason it is not a conclusion. Reading
-			// this as a stall cost an operator twenty minutes on a plane that was
-			// working exactly as designed, so the sentence says outright what it
-			// cannot tell rather than leaving the reader to assume the worst.
+				return `Idle. Nothing in the last ${this.window()}, nothing outstanding.`;
 			case 'holding':
-				return `${window?.in ? `${engineCount(window.in)} taken in` : 'Nothing taken in'} and nothing completed in the last ${this.window()}${window?.failed ? `, ${engineCount(window.failed)} ${this.failedWord()}` : ''}, ${this.outstandingClause()}. Work waiting on a schedule is outstanding too, so read what that number is made of before taking this as held up.`;
+				return `${window?.in ? `${engineCount(window.in)} taken in` : 'Nothing taken in'} and nothing completed in the last ${this.window()}${window?.failed ? `, ${engineCount(window.failed)} ${this.failedWord()}` : ''}, ${this.outstandingClause()}.`;
 			default:
 				return `Draining. ${engineCount(window?.in ?? 0)} taken in${window?.failed ? `, ` : ' and '}${engineCount(window?.out ?? 0)} completed${window?.failed ? ` and ${engineCount(window.failed)} ${this.failedWord()}` : ''} in the last ${this.window()}, ${this.outstandingClause()}.`;
 		}

--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.html
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.html
@@ -1,4 +1,4 @@
-<button type="button" class="relative flex flex-col items-stretch w-full group" [attr.aria-label]="ariaLabel || null">
+<button type="button" class="relative inline-flex flex-col items-stretch w-full max-w-full group" [attr.aria-label]="ariaLabel || null">
   @if (withIcon) {
     <div>
       @if (img) {
@@ -14,25 +14,7 @@
   <div class="empty:hidden">
     <ng-content select="[tooltipToggle]"></ng-content>
   </div>
-  <div
-    data-tooltip-body
-		class="
-			absolute
-			opacity-0
-			group-hover:opacity-100 group-focus-within:opacity-100 group-focus:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto group-focus:pointer-events-auto
-			pointer-events-none
-			transition-all
-			z-50
-			rounded-8px
-			p-14px
-			text-12 text-left
-			after:content-['']
-			after:absolute
-			font-light
-			after:border-[10px]
-		"
-    [class]="classes"
-    >
+  <div data-tooltip-body [class]="classes">
     @if (tooltipContent) {
       <span>{{ tooltipContent }}</span>
     }

--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.spec.ts
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.spec.ts
@@ -21,4 +21,14 @@ describe('TooltipComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('keeps the body out of layout as an overlay', () => {
+    const body = fixture.nativeElement.querySelector('[data-tooltip-body]') as HTMLElement;
+    expect(body.className.split(/\s+/)).toContain('absolute');
+  });
+
+  it('lets full-width toggles fill their host', () => {
+    const root = fixture.nativeElement.querySelector('button') as HTMLElement;
+    expect(root.className.split(/\s+/)).toContain('w-full');
+  });
 });

--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.ts
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.ts
@@ -42,6 +42,9 @@ export class TooltipComponent implements OnInit {
 			'top-right': `-right-[160px] after:right-[157px] bottom-[calc(100%+20px)] after:-bottom-[19px] after:border-b-transparent after:border-x-transparent`,
 			'top-left': `-right-[16px] after:right-[15px] bottom-[calc(100%+20px)] after:-bottom-[19px] after:border-b-transparent after:border-x-transparent`
 		};
-		return `${positions[this.position]} ${colors[this.color]}  min-w-[192px] ${this.class}`;
+		// Overlay classes live on the same [class] binding as position/color.
+		// A static class= plus [class] string overwrites the static list, which
+		// dropped `absolute` and let min-w-[192px] bodies sit in layout.
+		return `absolute opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 group-focus:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto group-focus:pointer-events-auto pointer-events-none transition-all z-50 rounded-8px p-14px text-12 text-left after:content-[''] after:absolute font-light after:border-[10px] ${positions[this.position]} ${colors[this.color]} min-w-[192px] ${this.class}`;
 	}
 }

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.html
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.html
@@ -13,19 +13,16 @@
      turns out to have no plane at all, which is every instance today. -->
 @if (active && (state === 'ready' || state === 'unknown')) {
   <div class="mb-24px min-w-0">
-    <div class="flex items-start justify-between gap-16px mb-16px min-w-0">
-      <div class="flex flex-col gap-4px min-w-0">
+      <div class="flex items-start justify-between gap-16px mb-16px min-w-0">
         <h3 class="font-heading font-medium text-[18px] leading-[26px] text-new.text-primary">Data plane</h3>
-        <p class="font-body font-normal text-[14px] leading-normal text-new.text-secondary">Whether work the plane has taken on is draining, and where it is sitting if it is not.</p>
+        <button
+          type="button"
+          class="shrink-0 px-16px py-10px rounded-full bg-new.surface-muted font-body font-medium text-[14px] leading-[16px] text-new.text-primary transition-all hover:opacity-80"
+          (click)="load()"
+          >
+          Refresh
+        </button>
       </div>
-      <button
-        type="button"
-        class="shrink-0 px-16px py-10px rounded-full bg-new.surface-muted font-body font-medium text-[14px] leading-[16px] text-new.text-primary transition-all hover:opacity-80"
-        (click)="load()"
-        >
-        Refresh
-      </button>
-    </div>
 
     <!-- A failed read drops the rows with it. Leaving the previous numbers up
          would let a stale depth answer for the present, which is the one thing
@@ -40,11 +37,12 @@
     @if (state === 'ready') {
       <div class="flex flex-col gap-16px min-w-0">
         @for (row of rows; track row.replica.replica) {
-          <!-- No overflow on the card. The wide tables inside carry their own
-               overflow-x-auto wrapper, which is the only thing that has to
-               scroll, and clipping the whole card would cut off the tooltips on
-               the absent values: a clip is not a stacking question, so no
-               z-index can lift a tooltip out of a clipping ancestor. Same
+          <!-- No overflow on the card. Clipping the whole card would cut off
+               the tooltips: a clip is not a stacking question, so no z-index
+               can lift a tooltip out of a clipping ancestor. The stages table
+               also has no overflow wrapper, so the column-term tooltips can
+               open above the header instead of into the rows. Writers still
+               wrap in overflow-x-auto; that table has no tooltips. Same
                structure as the endpoints table card. -->
           <div class="bg-white-100 border border-new.border rounded-12px min-w-0">
             <div class="flex items-center justify-between gap-12px flex-wrap px-20px py-16px border-b border-new.border min-w-0">
@@ -82,17 +80,13 @@
                  readable without knowing the architecture. -->
             <div class="px-20px py-16px border-b border-new.border min-w-0">
               <convoy-engine-verdict [verdict]="row.verdict"></convoy-engine-verdict>
-
-              @if (row.replica.stale) {
-                <p class="font-body font-normal text-[13px] leading-normal text-new.text-secondary mt-8px">This replica stopped publishing. Everything below describes {{ ageLabel(row.replica) }} and is not current.</p>
-              }
             </div>
 
             <!-- In, Out, Outstanding. Nothing else at this level. -->
             <div class="px-20px py-16px border-b border-new.border min-w-0">
               <div class="flex flex-wrap gap-x-48px gap-y-16px">
                 @for (number of row.numbers; track number.label) {
-                  <div class="flex flex-col gap-2px min-w-0">
+                  <div class="flex flex-col gap-2px min-w-[140px]">
                     <!-- Two explanations, two hover targets, never stacked on
                          one: the label says what the metric means and is there
                          whatever the value, the value below says why it is
@@ -108,7 +102,16 @@
                       </convoy-tooltip>
                     </div>
                     @if (number.absent === null) {
-                      <span data-flow-value class="font-heading font-medium text-[20px] leading-[28px] text-new.text-primary">{{ number.value }}</span>
+                      @if (number.notes.length) {
+                        <convoy-tooltip [withIcon]="false" position="bottom" class="inline-block w-fit" className="!min-w-[240px] !left-0 !translate-x-0" [ariaLabel]="valueAria(number)">
+                          @for (note of number.notes; track $index) {
+                            <p [class]="$index ? 'mt-6px text-new.text-secondary' : ''">{{ note }}</p>
+                          }
+                          <span tooltipToggle data-flow-value class="font-heading font-medium text-[20px] leading-[28px] text-new.text-primary">{{ number.value }}</span>
+                        </convoy-tooltip>
+                      } @else {
+                        <span data-flow-value class="font-heading font-medium text-[20px] leading-[28px] text-new.text-primary">{{ number.value }}</span>
+                      }
                     } @else {
                       <!-- A dash, the same glyph the dashboard's other no-data
                            cells use, with the reason in the tooltip. The word
@@ -118,17 +121,27 @@
                            left edge of its own trigger rather than centred on
                            it, so a 240px body opening from the first number in
                            the row is not cut off at a phone width. -->
-                      <convoy-tooltip [withIcon]="false" position="bottom" className="!min-w-[240px] !left-0 !translate-x-0" [ariaLabel]="number.absent.aria">
+                      <convoy-tooltip [withIcon]="false" position="bottom" class="inline-block w-fit" className="!min-w-[240px] !left-0 !translate-x-0" [ariaLabel]="valueAria(number)">
                         <p>{{ number.absent.reason }}</p>
                         <p class="mt-6px text-new.text-secondary">{{ number.absent.detail }}</p>
+                        @for (note of number.notes; track $index) {
+                          <p class="mt-6px text-new.text-secondary">{{ note }}</p>
+                        }
                         <span tooltipToggle data-flow-value class="font-heading font-medium text-[20px] leading-[28px] text-new.text-secondary">-</span>
                       </convoy-tooltip>
                     }
-                    <!-- One line per fact about the number. The interval numbers
-                         name their window here; Outstanding names how old its
-                         oldest waiting retry is and when the next one is due. -->
-                    @for (note of number.notes; track $index) {
-                      <span class="font-body font-normal text-[12px] leading-[16px] text-new.text-secondary">{{ note }}</span>
+                    @if (number.absent === null && number.chart) {
+                      <svg
+                        class="w-full max-w-[140px] h-[36px] text-new.primary-400 mt-4px"
+                        viewBox="0 0 300 80"
+                        preserveAspectRatio="none"
+                        role="img"
+                        [attr.data-flow-chart]="number.label"
+                        [attr.title]="'peak ' + number.chart.peakLabel"
+                        [attr.aria-label]="number.label + ' from ' + number.chart.firstLabel + ' to ' + number.chart.lastLabel + ', peak ' + number.chart.peakLabel"
+                        >
+                        <polyline fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round" stroke-linecap="round" [attr.points]="number.chart.points" />
+                      </svg>
                     }
                   </div>
                 }
@@ -167,9 +180,6 @@
                     <li class="font-body font-normal text-[14px] leading-normal text-new.text-primary break-words">{{ line }}</li>
                   }
                 </ul>
-                <p class="font-body font-normal text-[12px] leading-[16px] text-new.text-secondary mt-8px">
-                  Counted across everything this plane serves, and not attributed to the work outstanding above. Discarded means the plane never sent it, so it never joined that backlog; failed means it was sent and did not succeed.
-                </p>
               </div>
             }
 
@@ -217,16 +227,64 @@
               }
 
               @if (row.replica.stages.length) {
-                <div class="w-full overflow-x-auto border-t border-new.border">
+                <div class="w-full border-t border-new.border">
                   <table class="w-full min-w-[640px] border-collapse">
                     <thead>
                       <tr class="bg-new.surface-subtle border-b border-new.border">
-                        <th class="text-left px-20px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Stage</th>
-                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Queued</th>
-                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Fullest lane</th>
-                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Lanes</th>
-                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Waiting</th>
-                        <th class="text-right px-20px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">Workers</th>
+                        <th class="text-left px-20px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">
+                          <span class="inline-flex items-center gap-4px">
+                            Stage
+                            <convoy-tooltip size="sm" position="top-left" class="inline-block w-fit" className="!min-w-[240px]" [ariaLabel]="stageColumns.stage.aria">
+                              <p>{{ stageColumns.stage.reason }}</p>
+                              <p class="mt-6px text-new.text-secondary">{{ stageColumns.stage.detail }}</p>
+                            </convoy-tooltip>
+                          </span>
+                        </th>
+                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">
+                          <span class="inline-flex items-center justify-end gap-4px">
+                            Queued
+                            <convoy-tooltip size="sm" position="top-left" class="inline-block w-fit" className="!min-w-[240px]" [ariaLabel]="stageColumns.queued.aria">
+                              <p>{{ stageColumns.queued.reason }}</p>
+                              <p class="mt-6px text-new.text-secondary">{{ stageColumns.queued.detail }}</p>
+                            </convoy-tooltip>
+                          </span>
+                        </th>
+                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">
+                          <span class="inline-flex items-center justify-end gap-4px">
+                            Fullest lane
+                            <convoy-tooltip size="sm" position="top-left" class="inline-block w-fit" className="!min-w-[240px]" [ariaLabel]="stageColumns.fullestLane.aria">
+                              <p>{{ stageColumns.fullestLane.reason }}</p>
+                              <p class="mt-6px text-new.text-secondary">{{ stageColumns.fullestLane.detail }}</p>
+                            </convoy-tooltip>
+                          </span>
+                        </th>
+                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">
+                          <span class="inline-flex items-center justify-end gap-4px">
+                            Lanes
+                            <convoy-tooltip size="sm" position="top-left" class="inline-block w-fit" className="!min-w-[240px]" [ariaLabel]="stageColumns.lanes.aria">
+                              <p>{{ stageColumns.lanes.reason }}</p>
+                              <p class="mt-6px text-new.text-secondary">{{ stageColumns.lanes.detail }}</p>
+                            </convoy-tooltip>
+                          </span>
+                        </th>
+                        <th class="text-right px-12px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">
+                          <span class="inline-flex items-center justify-end gap-4px">
+                            Waiting
+                            <convoy-tooltip size="sm" position="top-left" class="inline-block w-fit" className="!min-w-[240px]" [ariaLabel]="stageColumns.waiting.aria">
+                              <p>{{ stageColumns.waiting.reason }}</p>
+                              <p class="mt-6px text-new.text-secondary">{{ stageColumns.waiting.detail }}</p>
+                            </convoy-tooltip>
+                          </span>
+                        </th>
+                        <th class="text-right px-20px h-36px font-heading font-medium text-[14px] leading-[20px] text-new.text-primary">
+                          <span class="inline-flex items-center justify-end gap-4px">
+                            Workers
+                            <convoy-tooltip size="sm" position="top-left" class="inline-block w-fit" className="!min-w-[240px]" [ariaLabel]="stageColumns.workers.aria">
+                              <p>{{ stageColumns.workers.reason }}</p>
+                              <p class="mt-6px text-new.text-secondary">{{ stageColumns.workers.detail }}</p>
+                            </convoy-tooltip>
+                          </span>
+                        </th>
                       </tr>
                     </thead>
                     <tbody>
@@ -234,15 +292,34 @@
                         <tr class="border-b border-new.border last:border-b-0">
                           <td class="px-20px h-44px font-body font-medium text-[14px] leading-normal text-new.text-primary">{{ label(stage.name) }}</td>
                           <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-primary">{{ stage.queued }}</td>
-                          <!-- Queued alone cannot say whether one tenant is
-                               blocking everyone else, which is what the fullest
-                               lane against its capacity answers. -->
-                          <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-secondary whitespace-nowrap">{{ stage.deepest_partition }} / {{ stage.partition_capacity }}</td>
+                          <!-- Queued is a total. Fullest lane is the busiest
+                               single project against that project's limit. -->
+                          <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-secondary whitespace-nowrap" data-fullest-lane>
+                            @if (!stage.partition_capacity) {
+                              <convoy-tooltip [withIcon]="false" position="top" class="inline-block w-fit" className="!min-w-[240px]" [ariaLabel]="laneCapacityAria(stage)">
+                                <p>Unbounded: this project can pile as high as this replica's memory allows.</p>
+                                <p class="mt-6px text-new.text-secondary">This is a mode, not an empty limit. The plane reports 0 for it.</p>
+                                <span tooltipToggle>{{ fullestLaneLabel(stage) }}</span>
+                              </convoy-tooltip>
+                            } @else {
+                              {{ fullestLaneLabel(stage) }}
+                            }
+                          </td>
                           <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-secondary">{{ stage.partitions }}</td>
-                          <!-- Blocked senders are the saturation signal that tells
-                               backpressure apart from an idle stage. -->
+                          <!-- Waiting is new work stuck because a project's
+                               pile is full. Unbounded piles stay at 0. -->
                           <td class="px-12px h-44px text-right font-body font-normal text-[14px] leading-normal" [class]="stage.waiting ? 'text-error-9' : 'text-new.text-secondary'">{{ stage.waiting }}</td>
-                          <td class="px-20px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-secondary whitespace-nowrap">{{ workersLabel(stage) }}</td>
+                          <td class="px-20px h-44px text-right font-body font-normal text-[14px] leading-normal text-new.text-secondary whitespace-nowrap" data-workers-value>
+                            @if (!stage.workers) {
+                              <convoy-tooltip [withIcon]="false" position="top" class="inline-block w-fit" className="!min-w-[240px]" [ariaLabel]="workersAria(stage)">
+                                <p>Unbounded: every item gets a worker of its own.</p>
+                                <p class="mt-6px text-new.text-secondary">This is a mode, not an empty pool. The plane reports 0 for it.</p>
+                                <span tooltipToggle>{{ workersLabel(stage) }}</span>
+                              </convoy-tooltip>
+                            } @else {
+                              {{ workersLabel(stage) }}
+                            }
+                          </td>
                         </tr>
                       }
                     </tbody>

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.spec.ts
@@ -167,6 +167,19 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		return Array.from((fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('convoy-tooltip button')).map(button => button.getAttribute('aria-label') ?? '');
 	}
 
+	// Visible copy between a flow number and its sparkline. Notes belong in the
+	// value tooltip, not as captions that stretch the column under the graph.
+	function captionsUnderNumbers(): string[] {
+		return Array.from((fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('[data-flow-chart]'))
+			.map(chart => {
+				const prev = chart.previousElementSibling as HTMLElement | null;
+				if (!prev) return '';
+				if (prev.hasAttribute('data-flow-value') || prev.querySelector('[data-flow-value]')) return '';
+				return (prev.textContent ?? '').trim();
+			})
+			.filter(text => text.length > 0);
+	}
+
 	// A plane on its first sample: no interval to report yet. Both causes of an
 	// absent interval are benign and both are knowable from the sample, so the
 	// panel names the cause rather than reporting an unexplained absence, and it
@@ -177,7 +190,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 			await render();
 
-			expect(text()).toContain('Measuring. No earlier sample from this engine to compare against, so there is no interval yet. Next sample carries one. 84,088 outstanding.');
+			expect(text()).toContain('Measuring. 84,088 outstanding.');
 			expect(text()).not.toContain('not reported');
 			expect(text()).not.toContain('Idle');
 			expect(text()).not.toContain('Nothing taken in');
@@ -319,11 +332,18 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 			await render();
 
-			expect(text()).toContain('Running and idle. It measured the last ~5s and took in nothing, nothing outstanding.');
+			expect(text()).toContain('Idle. Nothing in the last ~5s, nothing outstanding.');
 			expect(absentValues().filter(value => value.glyph === '-').length).toBe(0);
 
 			const values = Array.from((fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('[data-flow-value]')).map(node => (node.textContent ?? '').trim());
 			expect(values).toEqual(['0', '0', '0']);
+			// Window and retry schedule live on the value tooltip, not as captions
+			// under the sparkline. The verdict still names the window in prose.
+			expect(component.rows[0].numbers[0].notes).toEqual(['last ~5s']);
+			expect(component.rows[0].numbers[1].notes).toEqual(['last ~5s']);
+			expect(tooltipLabels()).toContain(jasmine.stringMatching(/^Events in: 0\. last /));
+			expect(tooltipLabels()).toContain(jasmine.stringMatching(/^Deliveries out: 0\. last /));
+			expect(captionsUnderNumbers()).toEqual([]);
 		});
 
 		// The staging state: a plane that is up, measured an interval and took
@@ -331,7 +351,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		// A card of zeros cannot be told from a quiet plane, so the zero on the
 		// intake says it was measured, and the identity says why this replica
 		// might be the only thing that is quiet.
-		it('says a measured zero intake was a reading rather than a gap', async () => {
+		it('keeps replica scope on the identity rather than on the zeros', async () => {
 			reads.push(() =>
 				Promise.resolve(
 					status([
@@ -345,8 +365,8 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 			await render();
 
-			expect(text()).toContain('measured, nothing reached this replica');
-			expect(text()).toContain('If work is arriving on this instance, it is not coming through this engine.');
+			expect(text()).not.toContain('measured, nothing reached this replica');
+			expect(text()).not.toContain('If work is arriving on this instance');
 
 			const scope = tooltipLabels().find(label => label.includes('Replica scope'));
 			expect(scope).toContain('This replica only counts work it took on itself.');
@@ -414,7 +434,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 			await render();
 
 			expect(text()).toContain('40 taken in and nothing completed in the last ~5s, 583 outstanding.');
-			expect(text()).toContain('Work waiting on a schedule is outstanding too, so read what that number is made of before taking this as held up.');
+			expect(text()).not.toContain('Work waiting on a schedule is outstanding too');
 
 			// And the schedule says which it is: an oldest retry a minute and a
 			// half old with the next one due shortly is a backlog draining on
@@ -455,7 +475,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 			await render();
 
-			expect(text()).toContain('Measuring again. The engine restarted, so the interval spanning the restart was discarded. Next sample carries one. 84,088 outstanding.');
+			expect(text()).toContain('Measuring again. 84,088 outstanding.');
 			expect(text()).not.toContain('No earlier sample');
 
 			const dot = (fixture.nativeElement as HTMLElement).querySelector('convoy-engine-verdict span');
@@ -484,7 +504,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		await render();
 
 		expect(text()).not.toContain('deliveries failed in the last');
-		expect(text()).toContain('Throughput reported incompletely, so whether work is draining is unknown.');
+		expect(text()).toContain('Throughput incomplete.');
 		expect(absentValues().filter(value => value.glyph === '-').length).toBe(2);
 	});
 
@@ -521,6 +541,8 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 			const values = Array.from((fixture.nativeElement as HTMLElement).querySelectorAll<HTMLElement>('[data-flow-value]')).map(node => (node.textContent ?? '').trim());
 			expect(values).toEqual(['4', '4', '0']);
+			expect(tooltipLabels()).toContain(jasmine.stringMatching(/^Outstanding: 0\. no retries waiting/));
+			expect(captionsUnderNumbers()).toEqual([]);
 		});
 
 		// The count could not be read, so neither could its schedule. The dash on
@@ -702,7 +724,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 			expect(sitting).toContain('512 queued');
 			expect(sitting).not.toContain('1,176');
 			expect(failures).toContain('Delivery failures: 1,176');
-			expect(text()).toContain('not attributed to the work outstanding above');
+			expect(text()).not.toContain('not attributed to the work outstanding above');
 		});
 
 		// Failures and recovery errors are the only counters that always mean
@@ -757,7 +779,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 			expect(text()).toContain('1,176 deliveries discarded before any attempt');
 			expect(text()).toContain('12 deliveries failed after an attempt');
-			expect(text()).toContain('Discarded means the plane never sent it, so it never joined that backlog');
+			expect(text()).not.toContain('Discarded means the plane never sent it, so it never joined that backlog');
 
 			// And the word rule that promoted the failed total on its name must
 			// not print it a second time under its raw label.
@@ -1052,7 +1074,24 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 		expect(text()).toContain('Stale');
 		expect(text()).toContain('Not reporting. Last sample 4m ago.');
-		expect(text()).toContain('is not current');
+		expect(text()).not.toContain('is not current');
+	});
+
+	// Name order is the store's fetch order. A leftover row whose id sorts
+	// first still has to sit below the replica that is still reporting.
+	it('lists a stale replica below the ones still reporting', async () => {
+		reads.push(() =>
+			Promise.resolve(
+				status([
+					replica({ replica: 'aaa-stale', stale: true, age_seconds: 240 }),
+					replica({ replica: 'zzz-live', stale: false, age_seconds: 2 })
+				])
+			)
+		);
+
+		await render();
+
+		expect(component.rows.map(row => row.replica.replica)).toEqual(['zzz-live', 'aaa-stale']);
 	});
 
 	// A stale sample's numbers describe a moment that has passed, so the verdict
@@ -1099,7 +1138,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		expect(text()).toContain('Not accepting');
 		// A plane that is not running reads as that, in words, and never as the
 		// running plane that measured an interval and found nothing in it.
-		expect(text()).toContain('Not running. This engine is not accepting work, so nothing new is entering it.');
+		expect(text()).toContain('Not accepting work.');
 		expect(text()).not.toContain('It measured the last');
 		expect(text()).not.toContain('9999');
 		expect(text()).not.toContain('5,000');
@@ -1160,11 +1199,44 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		expect(text()).toContain('780');
 	});
 
-	it('reads zero workers as a mode, not as an absence', () => {
+	it('reads zero workers as unbounded, not as an absence', async () => {
 		const stage = { name: 'deliver', queued: 0, waiting: 0, partitions: 1, partition_capacity: 1, deepest_partition: 0 };
 
-		expect(component.workersLabel({ ...stage, workers: 0 } as any)).toBe('per item');
+		expect(component.workersLabel({ ...stage, workers: 0 } as any)).toBe('unbounded');
 		expect(component.workersLabel({ ...stage, workers: 8 } as any)).toBe('8');
+		expect(component.workersAria({ ...stage, workers: 0 } as any)).toContain('unbounded');
+
+		reads.push(() =>
+			Promise.resolve(
+				status([
+					replica({
+						stages: [{ name: 'deliver', queued: 0, waiting: 0, workers: 0, partitions: 1, partition_capacity: 1, deepest_partition: 0 }]
+					})
+				])
+			)
+		);
+
+		await render();
+		openDiagnostics();
+
+		expect((fixture.nativeElement as HTMLElement).querySelector('[data-workers-value]')?.textContent).toContain('unbounded');
+	});
+
+	it('reads zero lane capacity as unbounded, not as an empty cap', async () => {
+		const stage = { name: 'deliver', queued: 5, waiting: 0, workers: 0, partitions: 1, partition_capacity: 0, deepest_partition: 5 };
+
+		expect(component.laneCapacityLabel(stage as any)).toBe('unbounded');
+		expect(component.fullestLaneLabel(stage as any)).toBe('5 / unbounded');
+		expect(component.laneCapacityAria(stage as any)).toContain('unbounded');
+
+		reads.push(() => Promise.resolve(status([replica({ stages: [stage] })])));
+
+		await render();
+		openDiagnostics();
+
+		expect((fixture.nativeElement as HTMLElement).querySelector('[data-fullest-lane]')?.textContent).toContain('5 / unbounded');
+		expect((fixture.nativeElement as HTMLElement).querySelector('[aria-label^="Queued:"]')?.getAttribute('aria-label')).toContain('How much work is sitting in this step');
+		expect((fixture.nativeElement as HTMLElement).querySelector('[aria-label^="Fullest lane:"]')?.getAttribute('aria-label')).toContain('busiest single project');
 	});
 
 	// The panel polls, so a slow read can land after a later one. Without the
@@ -1266,6 +1338,197 @@ describe('QueueMonitoringDataplaneComponent', () => {
 		});
 	});
 
+	describe('flow over this tab', () => {
+		function chart(label: string): HTMLElement | null {
+			return (fixture.nativeElement as HTMLElement).querySelector(`[data-flow-chart="${label}"]`);
+		}
+
+		function chartPoints(label: string): string[] {
+			const polyline = chart(label)?.querySelector('polyline');
+			return (polyline?.getAttribute('points') ?? '').trim().split(/\s+/).filter(Boolean);
+		}
+
+		function knownOutstanding(count: number, sampledAt: string) {
+			return replica({
+				sampled_at: sampledAt,
+				outstanding: [{ name: 'events_pending', count, known: true, as_of: sampledAt }]
+			});
+		}
+
+		function measuredFlow(sampledAt: string, accepted: number, delivered: number, outstanding = 0) {
+			return replica({
+				sampled_at: sampledAt,
+				gauges: measured({ accepted, delivered }),
+				outstanding: [{ name: 'events_pending', count: outstanding, known: true, as_of: sampledAt }]
+			});
+		}
+
+		it('does not draw a chart from a single sample', async () => {
+			reads.push(() => Promise.resolve(status([knownOutstanding(28832, '2026-09-01T08:00:00Z')])));
+
+			await render();
+
+			expect(chart('Outstanding')).toBeNull();
+			expect(chart('Events in')).toBeNull();
+			expect(chart('Deliveries out')).toBeNull();
+			expect(text()).toContain('28,832');
+		});
+
+		it('draws outstanding across two known samples', async () => {
+			reads.push(() => Promise.resolve(status([knownOutstanding(28832, '2026-09-01T08:00:00Z')])));
+			reads.push(() => Promise.resolve(status([knownOutstanding(2, '2026-09-01T08:00:05Z')])));
+
+			await render();
+			await render();
+
+			expect(chart('Outstanding')).not.toBeNull();
+			expect(chartPoints('Outstanding').length).toBe(2);
+			expect(chart('Outstanding')?.getAttribute('aria-label')).toContain('peak 28,832');
+			expect(text()).not.toContain('This tab since you opened it');
+		});
+
+		it('draws events in across two measured samples', async () => {
+			reads.push(() => Promise.resolve(status([measuredFlow('2026-09-01T08:00:00Z', 120, 0)])));
+			reads.push(() => Promise.resolve(status([measuredFlow('2026-09-01T08:00:05Z', 40, 0)])));
+
+			await render();
+			await render();
+
+			expect(chart('Events in')).not.toBeNull();
+			expect(chartPoints('Events in').length).toBe(2);
+			expect(chart('Events in')?.getAttribute('aria-label')).toContain('peak 120');
+			expect(chart('Deliveries out')).toBeNull();
+			expect(chart('Outstanding')).toBeNull();
+		});
+
+		it('draws deliveries out across two measured samples', async () => {
+			reads.push(() => Promise.resolve(status([measuredFlow('2026-09-01T08:00:00Z', 0, 90)])));
+			reads.push(() => Promise.resolve(status([measuredFlow('2026-09-01T08:00:05Z', 0, 20)])));
+
+			await render();
+			await render();
+
+			expect(chart('Deliveries out')).not.toBeNull();
+			expect(chartPoints('Deliveries out').length).toBe(2);
+			expect(chart('Deliveries out')?.getAttribute('aria-label')).toContain('peak 90');
+			expect(chart('Events in')).toBeNull();
+			expect(chart('Outstanding')).toBeNull();
+		});
+
+		it('hides the sparkline while the current reading is a dash', async () => {
+			reads.push(() => Promise.resolve(status([measuredFlow('2026-09-01T08:00:00Z', 120, 0)])));
+			reads.push(() => Promise.resolve(status([measuredFlow('2026-09-01T08:00:05Z', 40, 0)])));
+			reads.push(() => Promise.resolve(status([replica({ sampled_at: '2026-09-01T08:00:10Z', gauges: restarted() })])));
+
+			await render();
+			await render();
+			await render();
+
+			expect(chart('Events in')).toBeNull();
+			expect(chart('Deliveries out')).toBeNull();
+		});
+
+		it('does not plot an unmeasured interval as zero events in', async () => {
+			reads.push(() => Promise.resolve(status([knownOutstanding(100, '2026-09-01T08:00:00Z')])));
+			reads.push(() => Promise.resolve(status([measuredFlow('2026-09-01T08:00:05Z', 50, 10, 80)])));
+			reads.push(() => Promise.resolve(status([measuredFlow('2026-09-01T08:00:10Z', 40, 8, 70)])));
+
+			await render();
+			await render();
+			await render();
+
+			expect(chartPoints('Events in').length).toBe(2);
+			expect(chart('Events in')?.getAttribute('aria-label')).toContain('peak 50');
+			expect(chartPoints('Outstanding').length).toBe(3);
+		});
+
+		it('does not invent a second point from a Refresh of the same sample', async () => {
+			reads.push(() => Promise.resolve(status([knownOutstanding(28832, '2026-09-01T08:00:00Z')])));
+			reads.push(() => Promise.resolve(status([knownOutstanding(28832, '2026-09-01T08:00:00Z')])));
+
+			await render();
+			await render();
+
+			expect(chart('Outstanding')).toBeNull();
+		});
+
+		it('does not plot an unread outstanding as zero', async () => {
+			reads.push(() => Promise.resolve(status([knownOutstanding(100, '2026-09-01T08:00:00Z')])));
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							sampled_at: '2026-09-01T08:00:05Z',
+							outstanding: [{ name: 'events_pending', count: 0, known: false, as_of: '2026-09-01T08:00:05Z' }]
+						})
+					])
+				)
+			);
+			reads.push(() => Promise.resolve(status([knownOutstanding(50, '2026-09-01T08:00:10Z')])));
+
+			await render();
+			await render();
+			expect(chart('Outstanding')).toBeNull();
+
+			await render();
+			expect(chartPoints('Outstanding').length).toBe(2);
+		});
+
+		it('does not draw a chart of an idle zero series', async () => {
+			reads.push(() => Promise.resolve(status([knownOutstanding(0, '2026-09-01T08:00:00Z')])));
+			reads.push(() => Promise.resolve(status([knownOutstanding(0, '2026-09-01T08:00:05Z')])));
+
+			await render();
+			await render();
+
+			expect(chart('Outstanding')).toBeNull();
+			expect(chart('Events in')).toBeNull();
+			expect(chart('Deliveries out')).toBeNull();
+		});
+
+		it('hides idle zero in and out sparklines while outstanding still draws', async () => {
+			reads.push(() => Promise.resolve(status([measuredFlow('2026-09-01T08:00:00Z', 0, 0, 28832)])));
+			reads.push(() => Promise.resolve(status([measuredFlow('2026-09-01T08:00:05Z', 0, 0, 2)])));
+
+			await render();
+			await render();
+
+			expect(chart('Events in')).toBeNull();
+			expect(chart('Deliveries out')).toBeNull();
+			expect(chart('Outstanding')).not.toBeNull();
+			expect(chartPoints('Outstanding').length).toBe(2);
+		});
+
+		it('keeps the series across a failed read', async () => {
+			reads.push(() => Promise.resolve(status([knownOutstanding(100, '2026-09-01T08:00:00Z')])));
+			reads.push(() => Promise.resolve(status([knownOutstanding(50, '2026-09-01T08:00:05Z')])));
+			reads.push(() => Promise.reject(httpError(500)));
+			reads.push(() => Promise.resolve(status([knownOutstanding(10, '2026-09-01T08:00:10Z')])));
+
+			await render();
+			await render();
+			await render();
+			expect(chart('Outstanding')).toBeNull();
+
+			await render();
+			expect(chartPoints('Outstanding').length).toBe(3);
+		});
+
+		it('drops the series when the plane leaves', async () => {
+			reads.push(() => Promise.resolve(status([knownOutstanding(100, '2026-09-01T08:00:00Z')])));
+			reads.push(() => Promise.resolve(status([knownOutstanding(50, '2026-09-01T08:00:05Z')])));
+			reads.push(() => Promise.resolve(status([])));
+			reads.push(() => Promise.resolve(status([knownOutstanding(40, '2026-09-01T08:00:15Z')])));
+
+			await render();
+			await render();
+			await render();
+			await render();
+
+			expect(chart('Outstanding')).toBeNull();
+		});
+	});
+
 	// Karma loads src/styles.scss, so Tailwind is really applied and the browser
 	// really lays out. The panel is given a 375px frame, the narrowest phone
 	// width the dashboard is expected to survive, and asked whether anything
@@ -1287,6 +1550,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 							// single unbreakable word, which is the shape that pushed
 							// the old panel off the side of the page.
 							replica: 'convoydataplaneagentdeploymentreplicasixfourceninebseven',
+							sampled_at: '2026-09-01T08:00:00Z',
 							stages: [{ name: 'http_ingest_partitioned_fair_queue_admission', queued: 1234567, waiting: 890123, workers: 0, partitions: 4096, partition_capacity: 1000000, deepest_partition: 999999 }],
 							writers: [{ name: 'event_deliveries_bulk_writer', pending: 1234567, failures: 89012 }],
 							counters: [
@@ -1302,7 +1566,27 @@ describe('QueueMonitoringDataplaneComponent', () => {
 					])
 				)
 			);
+			reads.push(() =>
+				Promise.resolve(
+					status([
+						replica({
+							replica: 'convoydataplaneagentdeploymentreplicasixfourceninebseven',
+							sampled_at: '2026-09-01T08:00:05Z',
+							stages: [{ name: 'http_ingest_partitioned_fair_queue_admission', queued: 1234567, waiting: 890123, workers: 0, partitions: 4096, partition_capacity: 1000000, deepest_partition: 999999 }],
+							writers: [{ name: 'event_deliveries_bulk_writer', pending: 1234567, failures: 89012 }],
+							counters: [
+								{ name: 'handoffrecoveryerrorstotalfromacustomplanewithnoseparators', value: 1234567890 },
+								{ name: 'deliveries_discarded', value: 1234567890 },
+								{ name: 'deliveries_failed', value: 1234567890 }
+							],
+							gauges: [{ name: 'subscription_cache_entries', value: 1234567 }, ...measured({ accepted: 1234567, delivered: 1234567 }), ...retrySchedule(359_999_000, -720_000)],
+							outstanding: [{ name: 'eventdeliveriespendingretrywithnoseparatorsatall', count: 12, known: true, as_of: '2026-09-01T08:00:05Z' }, ...retries(12)]
+						})
+					])
+				)
+			);
 
+			await render();
 			await render();
 			openDiagnostics();
 

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.ts
@@ -84,11 +84,13 @@ interface FlowNumber {
 	// null exactly when value is not, so the dash and its reason cannot be
 	// rendered apart.
 	absent: Explainer | null;
-	// Facts about the number, each on its own line under it, in the order given.
-	// The interval numbers name the window they were counted over; Outstanding
-	// names how old its oldest waiting retry is and when the next one is due,
-	// which is what turns a level into something an operator can judge.
+	// Facts about this reading, shown on the value. The label tooltip says what
+	// the metric means; this one says what the current number is: the window the
+	// interval was counted over, or Outstanding's retry schedule.
 	notes: string[];
+	// This tab's polls of this number. Null until two known samples and a
+	// non-zero peak, so an unread count is never drawn as an empty graph.
+	chart: SessionChart | null;
 }
 
 // What the plane said about its retry backlog's schedule. Three answers, and the
@@ -123,6 +125,20 @@ interface DataPlaneRow {
 	// numbers and the line in diagnostics both read it, so the card cannot give
 	// two accounts of one absence.
 	absentFlow: Explained | null;
+}
+
+interface ReplicaSample {
+	sampledAt: string;
+	in?: number;
+	out?: number;
+	outstanding?: number;
+}
+
+interface SessionChart {
+	points: string;
+	peakLabel: string;
+	firstLabel: string;
+	lastLabel: string;
 }
 
 // What this panel tells the page around it. The page needs it to decide whether
@@ -258,6 +274,33 @@ const REPLICA_SCOPE: Explained = {
 	detail: 'Work reaches a plane either from a client that sent it to this process or as durable work the plane picks up, and which of those applies is a property of the deployment rather than of this panel. Either way these numbers are a fact about this replica and not about the instance, so a replica can be taking on nothing while the instance is busy.'
 };
 
+const STAGE_COLUMNS = {
+	stage: explainer('Stage', {
+		reason: 'Which step this replica is working through.',
+		detail: 'Names come from the plane. This page lists whatever it published.'
+	}),
+	queued: explainer('Queued', {
+		reason: 'How much work is sitting in this step right now.',
+		detail: 'The total across every project. It does not tell you whether one project is hogging the step; Fullest lane does.'
+	}),
+	fullestLane: explainer('Fullest lane', {
+		reason: "The busiest single project's pile, shown against that project's limit.",
+		detail: 'If the pile is at the limit, that project is held back and others can still move. Unbounded means there is no limit except this replica\'s memory. A 0 in the second number is that mode, not an empty limit.'
+	}),
+	lanes: explainer('Lanes', {
+		reason: 'How many projects currently have work in this step.',
+		detail: 'Each project has its own lane, so one busy project cannot occupy the whole step.'
+	}),
+	waiting: explainer('Waiting', {
+		reason: "How many new items are stuck because a project's pile is full.",
+		detail: 'A number here means that project cannot take more work yet. Unbounded piles never fill, so this stays 0 even when Queued is high.'
+	}),
+	workers: explainer('Workers', {
+		reason: 'How many workers are pulling work out of this step.',
+		detail: 'A number is a fixed pool size. Unbounded means every item gets a worker of its own, not that none are running. The plane reports 0 for that mode.'
+	})
+};
+
 // The gauges a plane publishes its measured interval under, and the only place
 // those names are spelled. A plane reports throughput through the same
 // vocabulary-neutral gauge list as everything else rather than through a section
@@ -306,6 +349,14 @@ const RETRY_BACKLOG = 'deliveries_retry';
 // above the lateness that is ordinary and cannot be produced by it.
 const OVERDUE_NOTE_MS = 60_000;
 
+// About fifteen minutes at the panel's five-second poll. Older points fall off
+// the left; Reload is what starts a new series.
+const HISTORY_CAP = 180;
+
+const CHART_WIDTH = 300;
+const CHART_HEIGHT = 80;
+const CHART_PAD = 4;
+
 // The two lifetime failure totals, which the plane reports separately because
 // they are different events: one delivery was never sent, the other was sent and
 // did not succeed. They are named here rather than left to the problem-word rule
@@ -340,6 +391,16 @@ function sections(replica: any): DataPlaneReplica {
 		counters: replica.counters ?? [],
 		outstanding: replica.outstanding ?? []
 	};
+}
+
+// Live cards first, leftover (stale) last, then by name. The store's fetch
+// order is replica name, and a restarted agent's container id often sorts
+// ahead of the replacement, which is how a ghost ended up as the first card.
+function orderReplicas(replicas: DataPlaneReplica[]): DataPlaneReplica[] {
+	return [...replicas].sort((a, b) => {
+		if (a.stale !== b.stale) return a.stale ? 1 : -1;
+		return a.replica.localeCompare(b.replica);
+	});
 }
 
 // The one reader of the throughput gauges on this panel. The verdict sentence,
@@ -425,6 +486,55 @@ function retryScheduleOf(replica: DataPlaneReplica): RetrySchedule {
 	return { kind: 'reported', oldestAgeMs, nextDueInMs };
 }
 
+// A polyline of this tab's known readings for one number. Unknown values are
+// never passed in: a missing read plotted as zero is exactly the false empty
+// the panel exists to catch.
+function sessionChart(points: Array<{ sampledAt: string; value: number }>): SessionChart | null {
+	if (points.length < 2) return null;
+
+	let peak = 0;
+	for (const point of points) {
+		if (point.value > peak) peak = point.value;
+	}
+	if (peak <= 0) return null;
+
+	const innerWidth = CHART_WIDTH - CHART_PAD * 2;
+	const innerHeight = CHART_HEIGHT - CHART_PAD * 2;
+	const last = points.length - 1;
+	const line = points
+		.map((point, index) => {
+			const x = CHART_PAD + (index / last) * innerWidth;
+			const y = CHART_PAD + innerHeight - (point.value / peak) * innerHeight;
+			return `${x},${y}`;
+		})
+		.join(' ');
+
+	return {
+		points: line,
+		peakLabel: engineCount(peak),
+		firstLabel: sessionTimeLabel(points[0].sampledAt),
+		lastLabel: sessionTimeLabel(points[last].sampledAt)
+	};
+}
+
+function seriesPoints(samples: ReplicaSample[], key: 'in' | 'out' | 'outstanding'): Array<{ sampledAt: string; value: number }> {
+	const points: Array<{ sampledAt: string; value: number }> = [];
+	for (const sample of samples) {
+		const value = sample[key];
+		if (value === undefined) continue;
+		points.push({ sampledAt: sample.sampledAt, value });
+	}
+
+	return points;
+}
+
+function sessionTimeLabel(sampledAt: string): string {
+	const date = new Date(sampledAt);
+	if (Number.isNaN(date.getTime())) return sampledAt;
+
+	return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
+}
+
 // The gauges left for the diagnostics table once the accessor has taken the ones
 // it reads. Rendering them there as well would put the plane's raw gauge names in
 // front of an operator beside the same numbers already named above, which is the
@@ -471,6 +581,11 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 	// answered keeps it, because the plane is still there and the read is what
 	// broke.
 	private everReported = false;
+	// Readings this tab has seen, keyed by replica. The server holds one snapshot
+	// one snapshot per replica, so a series only exists here. A failed read keeps
+	// it so the next good poll continues the line; a 501 or an empty plane drops
+	// it, because those are "no plane" rather than "the last read blipped".
+	private histories = new Map<string, ReplicaSample[]>();
 
 	constructor(private readonly adminService: AdminService) {}
 
@@ -499,6 +614,7 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 	readonly unreadCount = ABSENT_REASONS.unreadCount;
 
 	readonly replicaScope = explainer('Replica scope', REPLICA_SCOPE);
+	readonly stageColumns = STAGE_COLUMNS;
 
 	backlogLabel(backlog: DataPlaneBacklog): string {
 		return backlog.known ? engineCount(backlog.count) : NO_VALUE;
@@ -508,10 +624,48 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 		return `${this.label(backlog.name)}: ${this.unreadCount.reason} ${this.unreadCount.detail}`;
 	}
 
-	// The plane reports 0 workers when a stage runs one goroutine per item. That
-	// is a mode, not an absence, so it must not read as "no workers".
+	// The value tooltip, for a keyboard or screen reader user who never hovers.
+	// Absence and the reading's extra facts share this one target, because the
+	// glyph is already the hover for a dash and must not grow a second one.
+	valueAria(number: FlowNumber): string {
+		if (number.absent) {
+			return number.notes.length ? `${number.absent.aria} ${number.notes.join('. ')}` : number.absent.aria;
+		}
+
+		return number.notes.length ? `${number.label}: ${number.value}. ${number.notes.join('. ')}` : `${number.label}: ${number.value}`;
+	}
+
+	// The plane reports 0 workers when a stage is unbounded: every item gets
+	// a worker of its own. That is a mode, not an absence, so it must not
+	// read as "no workers".
 	workersLabel(stage: DataPlaneStage): string {
-		return stage.workers ? `${stage.workers}` : 'per item';
+		return stage.workers ? `${stage.workers}` : 'unbounded';
+	}
+
+	workersAria(stage: DataPlaneStage): string {
+		if (stage.workers) {
+			return `${this.label(stage.name)} workers: ${stage.workers}`;
+		}
+
+		return `${this.label(stage.name)} workers: unbounded. Every item gets a worker of its own, not a fixed pool.`;
+	}
+
+	// The plane reports 0 capacity when a lane is unbounded: that project can
+	// pile as high as this replica's memory allows. Same convention as workers.
+	laneCapacityLabel(stage: DataPlaneStage): string {
+		return stage.partition_capacity ? `${stage.partition_capacity}` : 'unbounded';
+	}
+
+	fullestLaneLabel(stage: DataPlaneStage): string {
+		return `${stage.deepest_partition} / ${this.laneCapacityLabel(stage)}`;
+	}
+
+	laneCapacityAria(stage: DataPlaneStage): string {
+		if (stage.partition_capacity) {
+			return `${this.label(stage.name)} fullest lane: ${this.fullestLaneLabel(stage)}`;
+		}
+
+		return `${this.label(stage.name)} fullest lane: ${stage.deepest_partition} / unbounded. No limit except this replica's memory.`;
 	}
 
 	ageLabel(replica: DataPlaneReplica): string {
@@ -558,12 +712,17 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 			const response = await this.adminService.getDataPlaneStatus();
 			if (id !== this.fetchId) return;
 
-			const replicas = (response.data?.replicas ?? []).map(sections);
-			this.rows = replicas.map((replica: DataPlaneReplica) => this.row(replica));
+			const replicas = orderReplicas((response.data?.replicas ?? []).map(sections));
 			this.staleAfterSeconds = response.data?.stale_after_seconds ?? 0;
-			this.state = this.rows.length ? 'ready' : 'empty';
-			if (this.state === 'ready') this.everReported = true;
-			else this.everReported = false;
+			this.state = replicas.length ? 'ready' : 'empty';
+			if (this.state === 'ready') {
+				this.everReported = true;
+				this.recordHistory(replicas);
+			} else {
+				this.everReported = false;
+				this.histories.clear();
+			}
+			this.rows = replicas.map((replica: DataPlaneReplica) => this.row(replica));
 		} catch (error: any) {
 			if (id !== this.fetchId) return;
 
@@ -572,6 +731,7 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 			if (error?.response?.status === 501) {
 				this.rows = [];
 				this.everReported = false;
+				this.histories.clear();
 				this.state = 'hidden';
 				this.stop();
 				this.publishReport();
@@ -599,6 +759,41 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 		});
 	}
 
+	// Known values only. An unread count plotted as zero is the false empty this
+	// panel exists to catch, and a Refresh of a snapshot the plane has not
+	// republished must not invent a second point from the same sample.
+	private recordHistory(replicas: DataPlaneReplica[]): void {
+		const seen = new Set<string>();
+
+		for (const replica of replicas) {
+			seen.add(replica.replica);
+
+			const series = this.histories.get(replica.replica) ?? [];
+			const last = series[series.length - 1];
+			if (last && last.sampledAt === replica.sampled_at) continue;
+
+			const sample: ReplicaSample = { sampledAt: replica.sampled_at };
+			const outstanding = this.outstandingTotal(replica);
+			if (outstanding.known) sample.outstanding = outstanding.value;
+
+			const flow = throughputOf(replica);
+			if (flow.measured) {
+				sample.in = flow.measured.in;
+				sample.out = flow.measured.out;
+			}
+
+			if (sample.outstanding === undefined && sample.in === undefined && sample.out === undefined) continue;
+
+			series.push(sample);
+			if (series.length > HISTORY_CAP) series.splice(0, series.length - HISTORY_CAP);
+			this.histories.set(replica.replica, series);
+		}
+
+		this.histories.forEach((_, id) => {
+			if (!seen.has(id)) this.histories.delete(id);
+		});
+	}
+
 	private publishReport(): void {
 		const reports = this.state === 'ready' || (this.state === 'unknown' && this.everReported);
 
@@ -619,6 +814,11 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 	private row(replica: DataPlaneReplica): DataPlaneRow {
 		const outstanding = this.outstandingTotal(replica);
 		const flow = throughputOf(replica);
+		const series = this.histories.get(replica.replica) ?? [];
+		const numbers = this.flowNumbers(replica, flow, outstanding);
+		numbers[0].chart = numbers[0].absent ? null : sessionChart(seriesPoints(series, 'in'));
+		numbers[1].chart = numbers[1].absent ? null : sessionChart(seriesPoints(series, 'out'));
+		numbers[2].chart = numbers[2].absent ? null : sessionChart(seriesPoints(series, 'outstanding'));
 
 		return {
 			replica,
@@ -626,7 +826,7 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 			// is told what to call them rather than naming the count after the
 			// narrower one.
 			verdict: { accepting: replica.running, reporting: !replica.stale, sampledLabel: this.ageLabel(replica), flow, outstanding, failedWord: 'failed or discarded' },
-			numbers: this.flowNumbers(replica, flow, outstanding),
+			numbers,
 			holding: this.holdingLines(replica),
 			failures: this.failureLines(replica, flow),
 			flow,
@@ -679,16 +879,7 @@ export class QueueMonitoringDataplaneComponent implements OnInit, OnDestroy {
 		// than a rule each cell has to remember.
 		const interval: FlowNumber[] = flow.absence
 			? [absentNumber('Events in', METRIC_MEANINGS.in, absenceLines(replica, flow.absence)), absentNumber('Deliveries out', METRIC_MEANINGS.out, absenceLines(replica, flow.absence))]
-			: [
-					// A measured zero on the intake gets a second line saying it was
-					// measured. The dash and the 0 are already different glyphs, but a
-					// reader scanning a card of zeros cannot see which of them the plane
-					// looked for and which it never reported, and on this number that is
-					// the difference between a quiet instance and one whose events are
-					// all reaching Convoy somewhere else.
-					measuredNumber('Events in', METRIC_MEANINGS.in, flow.measured.in, flow.measured.windowMs, 'measured, nothing reached this replica'),
-					measuredNumber('Deliveries out', METRIC_MEANINGS.out, flow.measured.out, flow.measured.windowMs)
-				];
+			: [measuredNumber('Events in', METRIC_MEANINGS.in, flow.measured.in, flow.measured.windowMs), measuredNumber('Deliveries out', METRIC_MEANINGS.out, flow.measured.out, flow.measured.windowMs)];
 
 		// The snapshot's own age, from the server that read sampled_at, carries the
 		// schedule forward to now without the browser's clock entering into it.
@@ -812,20 +1003,11 @@ function absenceLines(replica: DataPlaneReplica, absence: EngineFlowAbsence): Ex
 // A dash and the reason for it. The reason is decided above rather than by the
 // cell, so a cell cannot invent an explanation the wire did not give.
 function absentNumber(label: string, about: Explained, lines: Explained): FlowNumber {
-	return { label, value: null, about: explainer(label, about), absent: explainer(label, lines), notes: [] };
+	return { label, value: null, about: explainer(label, about), absent: explainer(label, lines), notes: [], chart: null };
 }
 
-// The window is named on the number rather than assumed, and marked approximate
-// by intervalWindowLabel, because the plane reports the elapsed time it actually
-// measured rather than the period it was configured with.
-// zeroNote is for a number whose zero is worth reading as a reading. It is only
-// added when the plane measured the interval, so it can never appear beside a
-// dash and can never be mistaken for an explanation of an absent value.
-function measuredNumber(label: string, about: Explained, value: number, windowMs: number, zeroNote?: string): FlowNumber {
-	const notes = [`last ${intervalWindowLabel(windowMs)}`];
-	if (value === 0 && zeroNote) notes.push(zeroNote);
-
-	return { label, value: engineCount(value), about: explainer(label, about), absent: null, notes };
+function measuredNumber(label: string, about: Explained, value: number, windowMs: number): FlowNumber {
+	return { label, value: engineCount(value), about: explainer(label, about), absent: null, notes: [`last ${intervalWindowLabel(windowMs)}`], chart: null };
 }
 
 // The backlog as a level, with the schedule of its retries under it. The level
@@ -837,7 +1019,7 @@ function measuredNumber(label: string, about: Explained, value: number, windowMs
 // Two minutes old with something due in thirty seconds is a backlog draining on
 // time. An hour old with nothing due for a long time is the shape of one nothing
 // is draining. That is the distinction "Where it is stuck" claimed to make and
-// could not, and it lives here, beside the number it is about.
+// could not, and it lives here, on the number it is about.
 function outstandingNumber(outstanding: EngineCount, schedule: RetrySchedule, snapshotAgeMs: number): FlowNumber {
 	const about = explainer('Outstanding', METRIC_MEANINGS.outstanding);
 	// The schedule lines survive a total that could not be read, unlike the
@@ -848,9 +1030,9 @@ function outstandingNumber(outstanding: EngineCount, schedule: RetrySchedule, sn
 	// that was read would throw away the most useful thing on the card over an
 	// unread count somewhere else.
 	const notes = scheduleNotes(schedule, snapshotAgeMs);
-	if (!outstanding.known) return { label: 'Outstanding', value: null, about, absent: explainer('Outstanding', ABSENT_REASONS.unread), notes };
+	if (!outstanding.known) return { label: 'Outstanding', value: null, about, absent: explainer('Outstanding', ABSENT_REASONS.unread), notes, chart: null };
 
-	return { label: 'Outstanding', value: engineCount(outstanding.value), about, absent: null, notes };
+	return { label: 'Outstanding', value: engineCount(outstanding.value), about, absent: null, notes, chart: null };
 }
 
 // The schedule as two plain readings, and a third line only when one sample can

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring.component.spec.ts
@@ -440,8 +440,8 @@ describe('QueueMonitoringComponent segments', () => {
 
 		click('Queue');
 
-		expect(component.otherEngineLine).toContain('1 data plane replica reporting');
-		expect(component.otherEngineLine).toContain('1 accepting work');
+		expect(component.otherEngineLine).toContain('1 data plane replica');
+		expect(component.otherEngineLine).toContain('1 accepting');
 	});
 
 	// A blipped poll keeps the segment, because the plane is still there. What it
@@ -454,7 +454,7 @@ describe('QueueMonitoringComponent segments', () => {
 		fixture.changeDetectorRef.detectChanges();
 
 		expect(component.segment).toBe(QUEUE);
-		expect(component.otherEngineLine).toContain('how many replicas are up is unknown');
+		expect(component.otherEngineLine).toContain('last read failed');
 		expect(component.otherEngineLine).not.toContain('0 data plane');
 	});
 });

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring.component.ts
@@ -107,15 +107,15 @@ export class QueueMonitoringComponent implements OnInit {
 	// that the answer might be on the other side.
 	get otherEngineLine(): string {
 		if (this.segment === 'dataplane') {
-			return 'The queue still carries broadcast and dynamic events, broker sources, replays and batch retries, meta events, emails, retention and backups.';
+			return 'The queue still carries non-HTTP work.';
 		}
 
-		const tail = 'Events on their projects do not pass through this queue.';
-		if (!this.planeCountsKnown) return `A data plane is reporting on this instance, and its last read failed, so how many replicas are up is unknown. ${tail}`;
+		const tail = 'HTTP events on their projects do not use this queue.';
+		if (!this.planeCountsKnown) return `Data plane last read failed. ${tail}`;
 
-		const replicas = `${this.planeReplicas} data plane ${this.planeReplicas === 1 ? 'replica' : 'replicas'} reporting`;
+		const replicas = `${this.planeReplicas} data plane ${this.planeReplicas === 1 ? 'replica' : 'replicas'}`;
 
-		return `${replicas}, ${this.planeAccepting} accepting work. ${tail}`;
+		return `${replicas}, ${this.planeAccepting} accepting. ${tail}`;
 	}
 
 	// The default segment is whichever engine owns HTTP events on this instance,


### PR DESCRIPTION
## Summary
- Diagnostics columns now say what each number means for running the plane, including that `unbounded` is a mode rather than an empty pool or empty limit.
- Live replicas sort ahead of stale leftovers so a restart does not open on a ghost card.
- Events in, deliveries out, and outstanding each keep a short sparkline from this tab's polls.

## Test plan
- [ ] Open Admin → Queue monitoring → Data plane and expand diagnostics.
- [ ] Confirm each column info tooltip reads as operator copy (no goroutine or send jargon).
- [ ] Confirm Workers prints `unbounded` when the replica reports 0, and Fullest lane prints `N / unbounded` when capacity is 0.
- [ ] Confirm a stale leftover replica sorts below a live one with the same deployment.
- [ ] `go test ./internal/pkg/dataplanestats/`
- [ ] Dashboard dataplane panel specs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly dashboard presentation and read-path ordering; backend sort is additive after staleness is computed, with broad test coverage and no auth or schema changes.
> 
> **Overview**
> **Data plane monitoring** gets a round of operator-focused polish: replica lists now show **live reporters before stale leftovers** (server via `OrderReplicas` and matching client sort), so a restart does not open on a ghost card that sorts first by container id.
> 
> The **Data plane** panel adds **session sparklines** for Events in, Deliveries out, and Outstanding (from tab polls, with guards against plotting unknowns, duplicate samples, and all-zero series). Metric **notes** (window, retry schedule) move into **value tooltips** instead of captions under the numbers; **engine verdict** copy is shortened across states.
> 
> **Diagnostics** gain per-column tooltips for the stages table, **`unbounded`** labeling (and tooltips) when workers or lane capacity are 0, and layout fixes so tooltips are not clipped (stages table overflow removed; tooltip overlay classes consolidated so `absolute` is not dropped). Minor queue-monitoring cross-tab copy is tightened.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ee70acfe4d3a1a1ea664c366bd7e9817d3ac2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->