### PR TITLE
fix(dashboard): keep data plane stages table inside the viewport

### DIFF
--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.html
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.html
@@ -39,11 +39,11 @@
         @for (row of rows; track row.replica.replica) {
           <!-- No overflow on the card. Clipping the whole card would cut off
                the tooltips: a clip is not a stacking question, so no z-index
-               can lift a tooltip out of a clipping ancestor. The stages table
-               also has no overflow wrapper, so the column-term tooltips can
-               open above the header instead of into the rows. Writers still
-               wrap in overflow-x-auto; that table has no tooltips. Same
-               structure as the endpoints table card. -->
+               can lift a tooltip out of a clipping ancestor. Wide tables wrap
+               in overflow-x-auto so a 640px min-width cannot stretch the page;
+               column-term tooltips then open inside that scrollport. Writers
+               use the same wrapper and have no tooltips. Same structure as
+               the endpoints table card. -->
           <div class="bg-white-100 border border-new.border rounded-12px min-w-0">
             <div class="flex items-center justify-between gap-12px flex-wrap px-20px py-16px border-b border-new.border min-w-0">
               <div class="flex items-center gap-8px flex-wrap min-w-0">
@@ -227,7 +227,11 @@
               }
 
               @if (row.replica.stages.length) {
-                <div class="w-full border-t border-new.border">
+                <!-- overflow-x-auto is the 375px rule: the table may scroll,
+                     the page may not. Removing it let min-w-[640px] stretch
+                     the card and the viewport. Header tooltips clip at this
+                     box; that is the cost of containing the table. -->
+                <div class="w-full max-w-full overflow-x-auto border-t border-new.border" data-stages-scroll>
                   <table class="w-full min-w-[640px] border-collapse">
                     <thead>
                       <tr class="bg-new.surface-subtle border-b border-new.border">

--- a/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.spec.ts
+++ b/web/ui/dashboard/src/app/private/pages/queue-monitoring/queue-monitoring-dataplane.component.spec.ts
@@ -1541,15 +1541,17 @@ describe('QueueMonitoringDataplaneComponent', () => {
 			frame.style.width = '375px';
 			frame.style.overflow = 'hidden';
 
+			// Names the plane chose, not names this build knows. One of
+			// them carries no separator at all, so it humanises to a
+			// single unbreakable word, which is the shape that pushed
+			// the old panel off the side of the page.
+			const replicaId = 'convoydataplaneagentdeploymentreplicasixfourceninebseven';
+
 			reads.push(() =>
 				Promise.resolve(
 					status([
 						replica({
-							// Names the plane chose, not names this build knows. One of
-							// them carries no separator at all, so it humanises to a
-							// single unbreakable word, which is the shape that pushed
-							// the old panel off the side of the page.
-							replica: 'convoydataplaneagentdeploymentreplicasixfourceninebseven',
+							replica: replicaId,
 							sampled_at: '2026-09-01T08:00:00Z',
 							stages: [{ name: 'http_ingest_partitioned_fair_queue_admission', queued: 1234567, waiting: 890123, workers: 0, partitions: 4096, partition_capacity: 1000000, deepest_partition: 999999 }],
 							writers: [{ name: 'event_deliveries_bulk_writer', pending: 1234567, failures: 89012 }],
@@ -1570,7 +1572,7 @@ describe('QueueMonitoringDataplaneComponent', () => {
 				Promise.resolve(
 					status([
 						replica({
-							replica: 'convoydataplaneagentdeploymentreplicasixfourceninebseven',
+							replica: replicaId,
 							sampled_at: '2026-09-01T08:00:05Z',
 							stages: [{ name: 'http_ingest_partitioned_fair_queue_admission', queued: 1234567, waiting: 890123, workers: 0, partitions: 4096, partition_capacity: 1000000, deepest_partition: 999999 }],
 							writers: [{ name: 'event_deliveries_bulk_writer', pending: 1234567, failures: 89012 }],
@@ -1588,43 +1590,21 @@ describe('QueueMonitoringDataplaneComponent', () => {
 
 			await render();
 			await render();
-			openDiagnostics();
+			component.toggleDiagnostics(replicaId);
+			paint();
 
 			expect(frame.clientWidth).toBe(375);
-			expect(overflowing(host)).toEqual([]);
+
+			// openDiagnostics() toggles agent-1, so this replica's tables were
+			// never in the tree. The 640px stages table must scroll inside
+			// its wrapper; host width stays 375 even when children paint
+			// outside, so the wrapper's own client/scroll widths are the
+			// containment proof.
+			const stagesScroll = host.querySelector('[data-stages-scroll]') as HTMLElement;
+			expect(stagesScroll).toBeTruthy();
+			expect(getComputedStyle(stagesScroll).overflowX).toMatch(/auto|scroll/);
+			expect(stagesScroll.clientWidth).toBeLessThanOrEqual(375);
+			expect(stagesScroll.scrollWidth).toBeGreaterThan(stagesScroll.clientWidth);
 		});
 	});
 });
-
-// A box whose content is wider than the box, and which will neither clip nor
-// scroll it, is what makes the page itself scroll sideways. A table inside an
-// overflow-x-auto wrapper is not that: its content is wider on purpose and the
-// wrapper takes the scroll, so only boxes computing to overflow-x: visible are
-// counted. Elements with no box of their own are skipped, because clientWidth is
-// 0 on an inline and every one of them would read as an overflow.
-//
-// Tooltip bodies are taken out of the measurement first. They are absolutely
-// positioned overlays that are meant to extend past the card, which is the whole
-// reason the card no longer clips its own content, and they are laid out even
-// while transparent, so leaving them in would report the panel's own layout as
-// broken for doing the thing it was fixed to do. Their placement is a hover
-// question, checked in a browser rather than here.
-function overflowing(root: HTMLElement): string[] {
-	const overlays = Array.from(root.querySelectorAll<HTMLElement>('[data-tooltip-body]'));
-	for (const overlay of overlays) overlay.style.display = 'none';
-
-	try {
-		return Array.from(root.querySelectorAll<HTMLElement>('*'))
-			.filter(element => {
-				if (!element.clientWidth) return false;
-				if (getComputedStyle(element).overflowX !== 'visible') return false;
-
-				// A pixel of tolerance, because subpixel layout rounds against a
-				// fractional container width and one pixel is not a broken page.
-				return element.scrollWidth - element.clientWidth > 1;
-			})
-			.map(element => `${element.tagName.toLowerCase()}.${element.className}`);
-	} finally {
-		for (const overlay of overlays) overlay.style.display = '';
-	}
-}


### PR DESCRIPTION
## Summary
- Restore `overflow-x-auto` on the data plane stages table so a 640px min-width table scrolls inside the panel on a narrow viewport, instead of stretching the page.
- Point the 375px spec at the replica that owns those rows, and assert the stages wrapper is the scrollport.

## Test plan
- [x] `npx ng test --watch=false --browsers=ChromeHeadless --include='**/queue-monitoring-dataplane.component.spec.ts'` (77/77)
- [ ] Open diagnostics on a 375px viewport: the stages table scrolls horizontally; the page does not.