### PR TITLE
fix(dashboard): keep table tooltips visible without blocking row menus

### DIFF
--- a/web/ui/dashboard/src/app/components/overlay/overlay.directive.ts
+++ b/web/ui/dashboard/src/app/components/overlay/overlay.directive.ts
@@ -3,7 +3,7 @@ import { Directive, Input } from '@angular/core';
 @Directive({
 	selector: '[convoyOverlay]',
 	standalone: true,
-	// Above project subnav (z-12) and table tooltips (z-50); org header stays at z-50.
+	// Above project subnav (z-12) and default tooltips (z-50); table tooltips can opt into z-56.
 	host: { class: 'fixed h-screen w-screen top-0 right-0 bottom-0 z-[55]', '[class]': "overlayHasBackdrop ? 'bg-black bg-opacity-50':''" }
 })
 export class OverlayDirective {

--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.html
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.html
@@ -1,23 +1,25 @@
-<button type="button" class="relative inline-flex flex-col items-stretch w-full max-w-full group" [attr.aria-label]="ariaLabel || null">
-  @if (withIcon) {
-    <div>
-      @if (img) {
-        <img [src]="img" [attr.height]="size === 'sm' ? '13px' : '18px'" [attr.width]="size === 'sm' ? '13px' : '18px'" alt="info" />
-      }
-      @if (!img) {
-        <svg width="18" height="18" [attr.height]="size === 'sm' ? '13' : '18'" [attr.width]="size === 'sm' ? '13' : '18'" class="fill-new.text-secondary">
-          <use xlink:href="#info-icon"></use>
-        </svg>
-      }
-    </div>
-  }
-  <div class="empty:hidden">
-    <ng-content select="[tooltipToggle]"></ng-content>
-  </div>
-  <div data-tooltip-body [class]="classes">
-    @if (tooltipContent) {
-      <span>{{ tooltipContent }}</span>
+<div [class]="hostClasses">
+  <button type="button" class="inline-flex flex-col items-stretch w-full border-0 bg-transparent p-0 text-left" [attr.aria-label]="ariaLabel || null">
+    @if (withIcon) {
+      <div>
+        @if (img) {
+          <img [src]="img" [attr.height]="size === 'sm' ? '13px' : '18px'" [attr.width]="size === 'sm' ? '13px' : '18px'" alt="info" />
+        }
+        @if (!img) {
+          <svg width="18" height="18" [attr.height]="size === 'sm' ? '13' : '18'" [attr.width]="size === 'sm' ? '13' : '18'" class="fill-new.text-secondary">
+            <use xlink:href="#info-icon"></use>
+          </svg>
+        }
+      </div>
     }
-    <ng-content></ng-content>
-  </div>
-</button>
+    <div class="empty:hidden">
+      <ng-content select="[tooltipToggle]"></ng-content>
+    </div>
+    <div data-tooltip-body [class]="classes">
+      @if (tooltipContent) {
+        <span>{{ tooltipContent }}</span>
+      }
+      <ng-content></ng-content>
+    </div>
+  </button>
+</div>

--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.spec.ts
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.spec.ts
@@ -28,7 +28,19 @@ describe('TooltipComponent', () => {
   });
 
   it('lets full-width toggles fill their host', () => {
-    const root = fixture.nativeElement.querySelector('button') as HTMLElement;
-    expect(root.className.split(/\s+/)).toContain('w-full');
+    component.fillHost = true;
+    expect(component.hostClasses.split(/\s+/)).toContain('w-full');
+  });
+
+  it('keeps non-interactive tooltips click-through on hover', () => {
+    component.interactive = false;
+    const classes = component.classes.split(/\s+/);
+    expect(classes).toContain('pointer-events-none');
+    expect(classes).not.toContain('group-hover:pointer-events-auto');
+  });
+
+  it('can stack above dropdown overlays without blocking menus', () => {
+    component.stackAboveOverlay = true;
+    expect(component.classes.split(/\s+/)).toContain('z-[56]');
   });
 });

--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.ts
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.ts
@@ -25,6 +25,17 @@ export class TooltipComponent implements OnInit {
 	// callers are unchanged.
 	@Input('ariaLabel') ariaLabel = '';
 
+	// When false, the tooltip body stays pointer-events-none even on hover so
+	// read-only table tooltips do not intercept clicks on nearby row actions.
+	@Input('interactive') interactive = true;
+
+	// Stretch the hover target to the host width so read-only table tooltips stay
+	// open while the pointer is anywhere in the cell, not only on the toggle text.
+	@Input('fillHost') fillHost = false;
+
+	// Sit above dropdown dismiss overlays (z-55) but below open menus (z-60).
+	@Input('stackAboveOverlay') stackAboveOverlay = false;
+
 	constructor() {}
 
 	ngOnInit(): void {}
@@ -45,6 +56,15 @@ export class TooltipComponent implements OnInit {
 		// Overlay classes live on the same [class] binding as position/color.
 		// A static class= plus [class] string overwrites the static list, which
 		// dropped `absolute` and let min-w-[192px] bodies sit in layout.
-		return `absolute opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 group-focus:opacity-100 group-hover:pointer-events-auto group-focus-within:pointer-events-auto group-focus:pointer-events-auto pointer-events-none transition-all z-50 rounded-8px p-14px text-12 text-left after:content-[''] after:absolute font-light after:border-[10px] ${positions[this.position]} ${colors[this.color]} min-w-[192px] ${this.class}`;
+		const pointerEvents = this.interactive
+			? 'group-hover:pointer-events-auto group-focus-within:pointer-events-auto group-focus:pointer-events-auto pointer-events-none'
+			: 'pointer-events-none';
+		const zIndex = this.stackAboveOverlay ? 'z-[56]' : 'z-50';
+		return `absolute opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 group-focus:opacity-100 ${pointerEvents} transition-all ${zIndex} rounded-8px p-14px text-12 text-left after:content-[''] after:absolute font-light after:border-[10px] ${positions[this.position]} ${colors[this.color]} min-w-[192px] ${this.class}`;
+	}
+
+	get hostClasses(): string {
+		const width = this.fillHost ? 'w-full max-w-full' : 'w-fit max-w-full';
+		return `relative inline-flex flex-col items-stretch ${width} group`;
 	}
 }

--- a/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.html
+++ b/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.html
@@ -139,13 +139,13 @@
           <!-- Endpoint: status pill + name -->
           <div class="flex items-center gap-8px px-20px h-40px min-w-0">
             @if (circuitBreakerOpen(endpoint)) {
-              <convoy-tooltip class="shrink-0" [withIcon]="false" position="top" [className]="statusTooltipClass">
+              <convoy-tooltip class="shrink-0" [withIcon]="false" [interactive]="false" [stackAboveOverlay]="true" position="top" [className]="statusTooltipClass">
                 <p>{{ cbStatusTooltip(endpoint) }}</p>
                 <p class="mt-6px text-new.text-secondary">{{ cbStatusTooltipDetail(endpoint) }}</p>
                 <span tooltipToggle class="inline-flex items-center h-20px px-4px rounded-4px font-body font-medium text-[12px] leading-[14px] text-new.text-primary" [class]="statusPillClass(endpoint)">{{ statusPillLabel(endpoint) }}</span>
               </convoy-tooltip>
             } @else if (endpoint.status) {
-              <convoy-tooltip class="shrink-0" [withIcon]="false" position="top" [className]="statusTooltipClass">
+              <convoy-tooltip class="shrink-0" [withIcon]="false" [interactive]="false" [stackAboveOverlay]="true" position="top" [className]="statusTooltipClass">
                 <p>{{ statusTooltip(endpoint) }}</p>
                 @if (statusTooltipDetail(endpoint)) {
                   <p class="mt-6px text-new.text-secondary">{{ statusTooltipDetail(endpoint) }}</p>
@@ -187,7 +187,7 @@
 
           <!-- Failure rate -->
           <div class="flex items-center justify-end px-12px h-40px">
-            <convoy-tooltip [withIcon]="false" position="top" className="!min-w-[240px]">
+            <convoy-tooltip [withIcon]="false" [interactive]="false" [fillHost]="true" [stackAboveOverlay]="true" position="top-right" [className]="failureRateTooltipClass">
               <p>{{ periodFailureRateStats(endpoint) }}</p>
               <p class="mt-6px text-new.text-secondary">Deliveries still retrying count as failed until they succeed. Discarded and not-yet-attempted deliveries are excluded.</p>
               <span tooltipToggle class="font-body font-normal text-[14px] leading-normal" [class]="(endpoint.period_failure_rate || 0) > 0 ? 'text-new.error-500' : 'text-new.text-secondary'">{{ failureRateLabel(endpoint) }}</span>

--- a/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.ts
+++ b/web/ui/dashboard/src/app/private/pages/project/endpoints/endpoints.component.ts
@@ -58,6 +58,7 @@ export class EndpointsComponent implements OnInit, OnDestroy {
 	// panel grows to the right; a centered/right-anchored panel overflows this
 	// left-hugging column off the viewport.
 	readonly statusTooltipClass = '!min-w-[280px] !left-0 !translate-x-0 after:!left-[24px] after:!translate-x-0';
+	readonly failureRateTooltipClass = '!min-w-[240px] !right-0 !translate-x-0 after:!right-[12px] after:!translate-x-0';
 	endpoints?: { pagination?: PAGINATION; content?: ENDPOINT[] };
 	selectedEndpoint?: ENDPOINT;
 	isLoadingEndpoints = true;


### PR DESCRIPTION
## Summary
- Adds `interactive`, `fillHost`, and `stackAboveOverlay` options to `convoy-tooltip` so read-only table hints stay visible without intercepting row action clicks.
- Endpoints status and failure-rate tooltips use click-through bodies, stack at `z-[56]` above dropdown dismiss overlays, and failure-rate tooltips anchor right so panels grow left away from the row menu column.

## Test plan
- [ ] On Endpoints, hover status pill and failure-rate cell — tooltips appear and remain readable.
- [ ] With a row menu open, hover adjacent status/failure-rate cells — tooltips stay visible above the overlay.
- [ ] Hover failure-rate or status, then click the row ⋮ menu — menu opens; Delete and other actions are reachable.
- [ ] `npm test -- --include='**/tooltip.component.spec.ts' --browsers=ChromeHeadless --watch=false`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only tooltip and Endpoints table UX; defaults preserve existing tooltip behavior for other callers.
> 
> **Overview**
> **`convoy-tooltip`** gains optional **`interactive`**, **`fillHost`**, and **`stackAboveOverlay`** so read-only table hints can stay visible without stealing clicks from row actions. Non-interactive bodies stay **`pointer-events-none`** on hover; **`fillHost`** widens the hover target; **`stackAboveOverlay`** uses **`z-[56]`** (above dismiss overlays at **`z-[55]**, below menus at **`z-[60]`**). The template moves layout/`group` classes to a wrapper via **`hostClasses`** instead of a full-width root button.
> 
> On **Endpoints**, status and failure-rate tooltips use click-through + elevated stacking; failure-rate uses **`top-right`**, **`fillHost`**, and a new right-anchored **`failureRateTooltipClass`**. Overlay directive comment is updated to match the new stacking model. Unit tests cover the new inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86f24225161a832e5265a49da1e277e0120c04a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->