### PR TITLE
fix(dashboard): widen fillHost tooltip hover target to component host

### DIFF
--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.html
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.html
@@ -1,5 +1,5 @@
 <div [class]="hostClasses">
-  <button type="button" class="inline-flex flex-col items-stretch w-full border-0 bg-transparent p-0 text-left" [attr.aria-label]="ariaLabel || null">
+  <button type="button" [class]="toggleClasses" [attr.aria-label]="ariaLabel || null">
     @if (withIcon) {
       <div>
         @if (img) {

--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.spec.ts
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.spec.ts
@@ -29,9 +29,8 @@ describe('TooltipComponent', () => {
 
   it('expands the inner wrapper when fillHost is enabled', () => {
     component.fillHost = true;
-    const classes = component.hostClasses.split(/\s+/);
-    expect(classes).toContain('w-full');
-    expect(classes).toContain('items-end');
+    expect(component.hostClasses.split(/\s+/)).toContain('w-full');
+    expect(component.toggleClasses.split(/\s+/)).toContain('text-right');
   });
 
   it('keeps non-interactive tooltips click-through on hover', () => {

--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.spec.ts
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.spec.ts
@@ -27,9 +27,11 @@ describe('TooltipComponent', () => {
     expect(body.className.split(/\s+/)).toContain('absolute');
   });
 
-  it('lets full-width toggles fill their host', () => {
+  it('expands the inner wrapper when fillHost is enabled', () => {
     component.fillHost = true;
-    expect(component.hostClasses.split(/\s+/)).toContain('w-full');
+    const classes = component.hostClasses.split(/\s+/);
+    expect(classes).toContain('w-full');
+    expect(classes).toContain('items-end');
   });
 
   it('keeps non-interactive tooltips click-through on hover', () => {

--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.ts
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.ts
@@ -5,7 +5,12 @@ import { Component, Input, OnInit } from '@angular/core';
     selector: 'convoy-tooltip',
     imports: [],
     templateUrl: './tooltip.component.html',
-    styleUrls: ['./tooltip.component.scss']
+    styleUrls: ['./tooltip.component.scss'],
+	host: {
+		'[class.block]': 'fillHost',
+		'[class.w-full]': 'fillHost',
+		'[class.min-w-0]': 'fillHost'
+	}
 })
 export class TooltipComponent implements OnInit {
 	@Input('size') size: 'sm' | 'md' = 'md';
@@ -65,6 +70,8 @@ export class TooltipComponent implements OnInit {
 
 	get hostClasses(): string {
 		const width = this.fillHost ? 'w-full max-w-full' : 'w-fit max-w-full';
-		return `relative inline-flex flex-col items-stretch ${width} group`;
+		const align = this.fillHost ? 'items-end' : 'items-stretch';
+		return `relative inline-flex flex-col ${align} ${width} group`;
 	}
+
 }

--- a/web/ui/dashboard/src/app/components/tooltip/tooltip.component.ts
+++ b/web/ui/dashboard/src/app/components/tooltip/tooltip.component.ts
@@ -70,8 +70,12 @@ export class TooltipComponent implements OnInit {
 
 	get hostClasses(): string {
 		const width = this.fillHost ? 'w-full max-w-full' : 'w-fit max-w-full';
-		const align = this.fillHost ? 'items-end' : 'items-stretch';
-		return `relative inline-flex flex-col ${align} ${width} group`;
+		return `relative inline-flex flex-col items-stretch ${width} group`;
+	}
+
+	get toggleClasses(): string {
+		const base = 'inline-flex flex-col w-full border-0 bg-transparent p-0';
+		return this.fillHost ? `${base} items-end text-right` : `${base} items-stretch text-left`;
 	}
 
 }


### PR DESCRIPTION
## Summary
- Applies `block w-full min-w-0` on the `convoy-tooltip` host when `fillHost` is enabled so the hover target spans the table cell, not just the toggle text.
- Right-aligns the inner wrapper (`items-end`) so failure-rate labels stay visually anchored while the hover area fills the cell.

Follow-up to #2857 (Bugbot: fillHost left the component host content-sized in flex cells).

## Test plan
- [ ] Endpoints → hover anywhere in the failure-rate cell (not only the percentage text) — tooltip stays open.
- [ ] Row ⋮ menu still opens when moving from failure-rate cell to actions.
- [ ] `npm test -- --include='**/tooltip.component.spec.ts' --browsers=ChromeHeadless --watch=false`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/layout change to the tooltip component when fillHost is true; default tooltip behavior is unchanged.
> 
> **Overview**
> When **`fillHost`** is enabled on `convoy-tooltip`, the component **host** now gets `block`, `w-full`, and `min-w-0` so the hover/focus group spans the full table cell instead of staying content-sized in flex layouts.
> 
> The toggle **button** styling moves into a new **`toggleClasses`** getter: with `fillHost`, it uses **`items-end`** and **`text-right`** so failure-rate labels stay right-aligned while the invisible hit area fills the cell; otherwise behavior matches the previous left-aligned toggle.
> 
> Specs were updated to assert **`text-right`** on the toggle when `fillHost` is on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78bf903e2959e59b8d03f7994cb857eb01c434da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->