### PR TITLE
fix(controlplane): bound retention row counts so they cannot block drops

### DIFF
--- a/internal/pkg/partitions/partitions_test.go
+++ b/internal/pkg/partitions/partitions_test.go
@@ -62,6 +62,11 @@ func setupTestDB(t *testing.T) (database.Database, context.Context) {
 	conn, err := testEnv.CloneTestDatabase(t, "convoy")
 	require.NoError(t, err)
 
+	// List reads the whole table. A leftover row from the clone template (or
+	// another test that wrote the source) makes require.Len(runs, N) flake.
+	_, err = conn.Exec(context.Background(), `TRUNCATE convoy.partition_runs`)
+	require.NoError(t, err)
+
 	return postgres.NewFromConnection(conn), context.Background()
 }
 

--- a/internal/pkg/retention/retention.go
+++ b/internal/pkg/retention/retention.go
@@ -615,8 +615,11 @@ func (r *PartitionRetentionPolicy) dropAdoptedPartition(ctx context.Context, tab
 	}
 
 	var rowCount int64
-	if err = r.db.GetConn().QueryRow(ctx,
-		fmt.Sprintf(`SELECT count(*) FROM %s.%s`, retentionSchema, partition)).Scan(&rowCount); err != nil {
+	countCtx, cancelCount := rowCountContext(ctx)
+	err = r.db.GetConn().QueryRow(countCtx,
+		fmt.Sprintf(`SELECT count(*) FROM %s.%s`, retentionSchema, partition)).Scan(&rowCount)
+	cancelCount()
+	if err != nil {
 		r.logger.Warn("counting rows before dropping adopted history partition; proceeding without row count",
 			"partition", partition, "error", err)
 		rowCount = 0

--- a/internal/pkg/retention/retention_test.go
+++ b/internal/pkg/retention/retention_test.go
@@ -359,6 +359,24 @@ func TestDropAdoptedPartitionNoopsWhenDefaultIsMissing(t *testing.T) {
 	require.False(t, dropped)
 }
 
+func TestDropAdoptedPartitionStillDropsWhenCountBudgetIsGone(t *testing.T) {
+	db, ctx := setupTestDB(t)
+
+	seedExpiredRow(t, db, "event_deliveries", time.Now().AddDate(0, 0, -90))
+	partitionDeliveries(t, ctx, db)
+	policy := newDropPolicy(t, db, 24*time.Hour)
+	policy.registerParents(ctx)
+
+	// Remaining deadline is under the count cap, so COUNT(*) skips.
+	// DROP still uses this ctx and must succeed.
+	jobCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	dropped, _, err := policy.dropAdoptedPartition(jobCtx, "event_deliveries")
+	require.NoError(t, err)
+	require.True(t, dropped, "history partition survived because the row count consumed the job deadline")
+	require.False(t, relationExists(t, ctx, db, "event_deliveries_default"))
+}
+
 func TestDropAdoptedPartitionIsIdempotent(t *testing.T) {
 	db, ctx := setupTestDB(t)
 

--- a/internal/pkg/retention/runs.go
+++ b/internal/pkg/retention/runs.go
@@ -20,6 +20,12 @@ import (
 const (
 	runColumns       = `id, status, retention_period, details, error, started_at, completed_at`
 	retentionHistory = 90 * 24 * time.Hour
+
+	// rowCountTimeout caps the best-effort COUNT(*) pass so a large expired
+	// partition cannot exhaust the nightly job's 30-minute asynq lock before
+	// Maintain and DROP run. That lock cancels the job context at the bound
+	// (worker/task/retention_policies.go).
+	rowCountTimeout = 30 * time.Second
 )
 
 type RunStatus string
@@ -202,10 +208,38 @@ func snapshotManagedPartitions(ctx context.Context, db database.Database) (parti
 	return out, rows.Err()
 }
 
+// rowCountContext bounds observability counts so they cannot cancel or consume
+// the job deadline Maintain and DROP still use.
+//
+// Counts fail open: if the job is already cancelled, or remaining deadline is
+// at or under the cap, skip immediately. Otherwise the child is detached from
+// job cancellation and capped at rowCountTimeout.
+func rowCountContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	detached := context.WithoutCancel(ctx)
+	if ctx.Err() != nil {
+		c, cancel := context.WithCancel(detached)
+		cancel()
+		return c, cancel
+	}
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) <= rowCountTimeout {
+		c, cancel := context.WithCancel(detached)
+		cancel()
+		return c, cancel
+	}
+	return context.WithTimeout(detached, rowCountTimeout)
+}
+
 // countExpiredPartitionRowCounts counts rows only in partitions partman will
 // drop this run (same filter as gopartman ListExpiredPartitions). Best-effort:
-// a failed count on one partition must not block Maintain.
+// a failed or skipped count must not block Maintain. The job context is not
+// used for the scans; a slow COUNT(*) on it would cancel Maintain and DROP.
 func countExpiredPartitionRowCounts(ctx context.Context, db database.Database) map[string]map[string]int64 {
+	ctx, cancel := rowCountContext(ctx)
+	defer cancel()
+	if ctx.Err() != nil {
+		return nil
+	}
+
 	rows, err := db.GetDB().QueryxContext(ctx, `
         SELECT t.table_name, p.name
         FROM partman.partitions p

--- a/internal/pkg/retention/runs_test.go
+++ b/internal/pkg/retention/runs_test.go
@@ -1,11 +1,54 @@
 package retention
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestRowCountContextDetachesFromJobCancel(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
+	countCtx, stop := rowCountContext(ctx)
+	defer stop()
+
+	parentDL, ok := ctx.Deadline()
+	require.True(t, ok)
+	countDL, ok := countCtx.Deadline()
+	require.True(t, ok)
+	require.True(t, countDL.Before(parentDL), "count deadline must be earlier than the job so a slow COUNT cannot consume Maintain")
+
+	cancel()
+	require.NoError(t, countCtx.Err(), "count ctx inherited job cancellation")
+}
+
+func TestRowCountContextSkipsWhenJobHasNoBudget(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	countCtx, stop := rowCountContext(ctx)
+	defer stop()
+	require.Error(t, countCtx.Err(), "counts must skip when remaining deadline is at or under the cap")
+}
+
+func TestRowCountContextSkipsWhenJobAlreadyCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	countCtx, stop := rowCountContext(ctx)
+	defer stop()
+	require.Error(t, countCtx.Err())
+}
+
+func TestCountExpiredPartitionRowCountsSkipsCancelledJob(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// A cancelled job must not open a query. Passing a nil db would panic if
+	// the scan still used the job context.
+	require.Nil(t, countExpiredPartitionRowCounts(ctx, nil))
+}
 
 func TestRunDetailsValue(t *testing.T) {
 	d := RunDetails{{


### PR DESCRIPTION
## Summary
- Nightly retention `COUNT(*)` (expired partitions and adopted `_default`) now runs on a detached, 30s-capped context and is skipped when the job is already cancelled or remaining deadline is at or under that cap, so a slow scan cannot cancel Maintain or DROP.
- `setupTestDB` truncates `convoy.partition_runs` so boot-rebuild tests that assert `List` length cannot flake on leftover rows from the clone template.

## Test plan
- [x] `go test ./internal/pkg/retention/` (42 passed), including `TestCountExpiredPartitionRowCountsSkipsCancelledJob` (fails on unfixed code: cancelled job still queries) and `TestDropAdoptedPartitionStillDropsWhenCountBudgetIsGone`
- [x] `go test ./internal/pkg/partitions/ -run 'TestBootRebuildStartsEveryOwedIndexWhenTheSlotFrees|TestUserRebuildStartsTheNextOwedIndexWhenTheSlotFrees'`
- [ ] CI unit shard that previously failed `TestBootRebuildStartsEveryOwedIndexWhenTheSlotFrees` (expected 4 `partition_runs`, got 5)